### PR TITLE
[Tree/C-06] Implement RLS hardening migration for schedule writes

### DIFF
--- a/docs/AUDIT-ISSUES-2026-02-21.md
+++ b/docs/AUDIT-ISSUES-2026-02-21.md
@@ -38,6 +38,8 @@ Scope: scheduler UI, persistence/Supabase, scripts/data pipeline, conflict engin
 - **Files:** `scripts/supabase-schema.sql:136`, `scripts/supabase-schema.sql:174`, `scripts/supabase-schema.sql:176`
 - **Impact:** anonymous clients can write/delete all scheduling data.
 - **DoD:** role-scoped policies; only authenticated/authorized writes.
+- **Migration:** `scripts/supabase-rls-hardening.sql` (Tree/C-06 idempotent hardening migration)
+- **Runbook:** `docs/supabase-rls-hardening-migration.md`
 
 ---
 

--- a/docs/supabase-rls-hardening-migration.md
+++ b/docs/supabase-rls-hardening-migration.md
@@ -1,0 +1,78 @@
+# Supabase RLS Hardening Migration (Tree/C-06)
+
+## Purpose
+
+Apply operation-scoped authenticated write policies for core scheduling tables and remove legacy broad `FOR ALL` write policies.
+
+## Migration Script
+
+- `scripts/supabase-rls-hardening.sql`
+
+This migration is idempotent and can be re-run safely.
+
+## What It Changes
+
+- Drops legacy policy name `"Authenticated write"` from scheduling tables.
+- Recreates explicit authenticated policies by operation (`INSERT`, `UPDATE`, `DELETE`) per table.
+- Leaves `departments` write operations service-role only.
+- Keeps anonymous write/delete blocked by not granting any `anon` write policy.
+
+## Target Behavior
+
+- Anonymous users cannot `INSERT`, `UPDATE`, or `DELETE` scheduling rows.
+- Authenticated users can write only where operation policies are explicitly defined.
+- Service role retains full access for automation/migrations.
+
+## Run Instructions
+
+In Supabase SQL editor (recommended), run:
+
+```sql
+-- copy/paste the full contents of scripts/supabase-rls-hardening.sql
+```
+
+Or from local tooling:
+
+```bash
+psql "$SUPABASE_DB_URL" -f scripts/supabase-rls-hardening.sql
+```
+
+## Verification Query
+
+Run after migration to verify active policies:
+
+```sql
+select
+  schemaname,
+  tablename,
+  policyname,
+  roles,
+  cmd
+from pg_policies
+where schemaname = 'public'
+  and tablename in (
+    'departments',
+    'academic_years',
+    'rooms',
+    'courses',
+    'faculty',
+    'scheduled_courses',
+    'faculty_preferences',
+    'scheduling_constraints',
+    'release_time',
+    'pathways',
+    'pathway_courses'
+  )
+order by tablename, policyname;
+```
+
+Expected:
+
+- No remaining `policyname = 'Authenticated write'`.
+- `scheduled_courses` has explicit authenticated `INSERT`, `UPDATE`, and `DELETE` policies.
+- No write policy with role `anon`.
+
+## Follow-on
+
+- C-07 adds automated smoke checks for these policy expectations.
+- C-08 captures live environment verification evidence.

--- a/scripts/supabase-rls-hardening.sql
+++ b/scripts/supabase-rls-hardening.sql
@@ -1,0 +1,158 @@
+-- Tree/C-06: Supabase RLS hardening migration for scheduling writes
+-- Idempotent: safe to run multiple times.
+
+BEGIN;
+
+-- Remove legacy broad write policies.
+DROP POLICY IF EXISTS "Authenticated write" ON public.departments;
+DROP POLICY IF EXISTS "Authenticated write" ON public.academic_years;
+DROP POLICY IF EXISTS "Authenticated write" ON public.rooms;
+DROP POLICY IF EXISTS "Authenticated write" ON public.courses;
+DROP POLICY IF EXISTS "Authenticated write" ON public.faculty;
+DROP POLICY IF EXISTS "Authenticated write" ON public.scheduled_courses;
+DROP POLICY IF EXISTS "Authenticated write" ON public.faculty_preferences;
+DROP POLICY IF EXISTS "Authenticated write" ON public.scheduling_constraints;
+DROP POLICY IF EXISTS "Authenticated write" ON public.release_time;
+DROP POLICY IF EXISTS "Authenticated write" ON public.pathways;
+DROP POLICY IF EXISTS "Authenticated write" ON public.pathway_courses;
+
+-- Remove previous operation-scoped policies if they exist.
+DROP POLICY IF EXISTS "auth_insert_academic_years" ON public.academic_years;
+DROP POLICY IF EXISTS "auth_update_academic_years" ON public.academic_years;
+DROP POLICY IF EXISTS "auth_insert_rooms" ON public.rooms;
+DROP POLICY IF EXISTS "auth_update_rooms" ON public.rooms;
+DROP POLICY IF EXISTS "auth_insert_courses" ON public.courses;
+DROP POLICY IF EXISTS "auth_update_courses" ON public.courses;
+DROP POLICY IF EXISTS "auth_insert_faculty" ON public.faculty;
+DROP POLICY IF EXISTS "auth_update_faculty" ON public.faculty;
+DROP POLICY IF EXISTS "auth_insert_scheduled_courses" ON public.scheduled_courses;
+DROP POLICY IF EXISTS "auth_update_scheduled_courses" ON public.scheduled_courses;
+DROP POLICY IF EXISTS "auth_delete_scheduled_courses" ON public.scheduled_courses;
+DROP POLICY IF EXISTS "auth_insert_faculty_preferences" ON public.faculty_preferences;
+DROP POLICY IF EXISTS "auth_update_faculty_preferences" ON public.faculty_preferences;
+DROP POLICY IF EXISTS "auth_delete_faculty_preferences" ON public.faculty_preferences;
+DROP POLICY IF EXISTS "auth_insert_scheduling_constraints" ON public.scheduling_constraints;
+DROP POLICY IF EXISTS "auth_update_scheduling_constraints" ON public.scheduling_constraints;
+DROP POLICY IF EXISTS "auth_delete_scheduling_constraints" ON public.scheduling_constraints;
+DROP POLICY IF EXISTS "auth_insert_release_time" ON public.release_time;
+DROP POLICY IF EXISTS "auth_update_release_time" ON public.release_time;
+DROP POLICY IF EXISTS "auth_delete_release_time" ON public.release_time;
+DROP POLICY IF EXISTS "auth_insert_pathways" ON public.pathways;
+DROP POLICY IF EXISTS "auth_update_pathways" ON public.pathways;
+DROP POLICY IF EXISTS "auth_delete_pathways" ON public.pathways;
+DROP POLICY IF EXISTS "auth_insert_pathway_courses" ON public.pathway_courses;
+DROP POLICY IF EXISTS "auth_update_pathway_courses" ON public.pathway_courses;
+DROP POLICY IF EXISTS "auth_delete_pathway_courses" ON public.pathway_courses;
+
+-- Departments remain read-only for authenticated clients.
+-- Writes for this table are expected to use service_role only.
+
+-- academic_years
+CREATE POLICY "auth_insert_academic_years" ON public.academic_years
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_academic_years" ON public.academic_years
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+
+-- rooms
+CREATE POLICY "auth_insert_rooms" ON public.rooms
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_rooms" ON public.rooms
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+
+-- courses
+CREATE POLICY "auth_insert_courses" ON public.courses
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_courses" ON public.courses
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+
+-- faculty
+CREATE POLICY "auth_insert_faculty" ON public.faculty
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_faculty" ON public.faculty
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+
+-- scheduled_courses
+CREATE POLICY "auth_insert_scheduled_courses" ON public.scheduled_courses
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_scheduled_courses" ON public.scheduled_courses
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_delete_scheduled_courses" ON public.scheduled_courses
+    FOR DELETE TO authenticated
+    USING (auth.uid() IS NOT NULL);
+
+-- faculty_preferences
+CREATE POLICY "auth_insert_faculty_preferences" ON public.faculty_preferences
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_faculty_preferences" ON public.faculty_preferences
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_delete_faculty_preferences" ON public.faculty_preferences
+    FOR DELETE TO authenticated
+    USING (auth.uid() IS NOT NULL);
+
+-- scheduling_constraints
+CREATE POLICY "auth_insert_scheduling_constraints" ON public.scheduling_constraints
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_scheduling_constraints" ON public.scheduling_constraints
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_delete_scheduling_constraints" ON public.scheduling_constraints
+    FOR DELETE TO authenticated
+    USING (auth.uid() IS NOT NULL);
+
+-- release_time
+CREATE POLICY "auth_insert_release_time" ON public.release_time
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_release_time" ON public.release_time
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_delete_release_time" ON public.release_time
+    FOR DELETE TO authenticated
+    USING (auth.uid() IS NOT NULL);
+
+-- pathways
+CREATE POLICY "auth_insert_pathways" ON public.pathways
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_pathways" ON public.pathways
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_delete_pathways" ON public.pathways
+    FOR DELETE TO authenticated
+    USING (auth.uid() IS NOT NULL);
+
+-- pathway_courses
+CREATE POLICY "auth_insert_pathway_courses" ON public.pathway_courses
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_update_pathway_courses" ON public.pathway_courses
+    FOR UPDATE TO authenticated
+    USING (auth.uid() IS NOT NULL)
+    WITH CHECK (auth.uid() IS NOT NULL);
+CREATE POLICY "auth_delete_pathway_courses" ON public.pathway_courses
+    FOR DELETE TO authenticated
+    USING (auth.uid() IS NOT NULL);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add `scripts/supabase-rls-hardening.sql` as an idempotent RLS migration for scheduling writes
- replace broad legacy `"Authenticated write"` policies with explicit operation-scoped authenticated policies
- keep anonymous write/delete blocked by defining no anon write policy
- add runbook/verification doc in `docs/supabase-rls-hardening-migration.md`
- link migration artifacts from the security blocker entry in `docs/AUDIT-ISSUES-2026-02-21.md`

## Validation
- npm test -- --runInBand

Closes #58
