### PR TITLE
[Tree/C-07] Add Supabase policy smoke-check script

### DIFF
--- a/docs/AUDIT-ISSUES-2026-02-21.md
+++ b/docs/AUDIT-ISSUES-2026-02-21.md
@@ -38,6 +38,8 @@ Scope: scheduler UI, persistence/Supabase, scripts/data pipeline, conflict engin
 - **Files:** `scripts/supabase-schema.sql:136`, `scripts/supabase-schema.sql:174`, `scripts/supabase-schema.sql:176`
 - **Impact:** anonymous clients can write/delete all scheduling data.
 - **DoD:** role-scoped policies; only authenticated/authorized writes.
+- **Smoke Check:** `npm run check:rls` (`scripts/supabase-policy-smoke-check.js`)
+- **Runbook:** `docs/supabase-policy-smoke-check.md`
 
 ---
 

--- a/docs/supabase-policy-smoke-check.md
+++ b/docs/supabase-policy-smoke-check.md
@@ -1,0 +1,61 @@
+# Supabase Policy Smoke Check (Tree/C-07)
+
+## Purpose
+
+Quickly verify RLS behavior after C-06 migration:
+
+- anonymous writes are denied
+- authorized writes are allowed
+- output is explicit pass/fail
+
+## Command
+
+From repo root:
+
+```bash
+npm run check:rls
+```
+
+This runs:
+
+- `node scripts/supabase-policy-smoke-check.js`
+
+## Required Environment Variables
+
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `SUPABASE_AUTH_KEY` or `SUPABASE_SERVICE_ROLE_KEY`
+
+Optional:
+
+- `SUPABASE_DEPARTMENT_CODE` (defaults to `DESN`)
+
+## Example
+
+```bash
+SUPABASE_URL="https://<project-ref>.supabase.co" \
+SUPABASE_ANON_KEY="<anon-key>" \
+SUPABASE_SERVICE_ROLE_KEY="<service-role-key>" \
+npm run check:rls
+```
+
+## Behavior
+
+The smoke check uses `academic_years` for a temporary probe row and runs:
+
+1. anon insert (expect denied)
+2. authorized insert (expect allowed)
+3. anon update/delete against probe row (expect denied)
+4. authorized update/delete (expect allowed)
+
+The script attempts cleanup even if a later check fails.
+
+## Exit Codes
+
+- `0`: all checks passed
+- `1`: one or more checks failed (or required env vars missing)
+
+## Notes
+
+- Run this against a non-production environment first.
+- C-08 captures and stores live verification evidence after this check passes.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "validate-data": "node scripts/validate-enrollment.js enrollment-data/processed/corrected-all-quarters.csv",
     "serve": "node api-server.js",
     "check:data-freshness": "node scripts/check-data-freshness.js",
+    "check:rls": "node scripts/supabase-policy-smoke-check.js",
     "qa:onboarding": "npm test -- tests/conflict-engine.slot-resolutions.test.js tests/conflict-engine.regression-scenarios.test.js tests/conflict-engine.room-fit-recommendations.test.js tests/workload-integration.test.js tests/department-profile.onboarding.test.js"
   },
   "repository": {

--- a/scripts/supabase-policy-smoke-check.js
+++ b/scripts/supabase-policy-smoke-check.js
@@ -70,6 +70,23 @@ function makeSmokeYear() {
     return `RLS${suffix}`;
 }
 
+function tryDecodeJwtPayload(key) {
+    if (!key || typeof key !== 'string') return null;
+    const parts = key.split('.');
+    if (parts.length < 2) return null;
+    try {
+        return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    } catch {
+        return null;
+    }
+}
+
+function getKeyRole(key) {
+    const payload = tryDecodeJwtPayload(key);
+    if (!payload || typeof payload.role !== 'string') return null;
+    return payload.role;
+}
+
 async function main() {
     try {
         requireEnv('SUPABASE_URL', SUPABASE_URL);
@@ -80,6 +97,17 @@ async function main() {
         process.exit(1);
     }
 
+    // Guardrail for common env mistakes that invalidate the smoke test.
+    if (SUPABASE_ANON_KEY === SUPABASE_AUTH_KEY) {
+        console.error('SUPABASE_ANON_KEY and SUPABASE_AUTH_KEY/SUPABASE_SERVICE_ROLE_KEY are identical. Use distinct anon and auth keys.');
+        process.exit(1);
+    }
+    const anonRole = getKeyRole(SUPABASE_ANON_KEY);
+    if (anonRole === 'service_role') {
+        console.error('SUPABASE_ANON_KEY decodes to role=service_role. Use the project anon/publishable key for SUPABASE_ANON_KEY.');
+        process.exit(1);
+    }
+
     const anonClient = createSupabaseClient(SUPABASE_URL, SUPABASE_ANON_KEY);
     const authorizedClient = createSupabaseClient(SUPABASE_URL, SUPABASE_AUTH_KEY);
     const cleanupClient = SUPABASE_CLEANUP_KEY
@@ -87,7 +115,8 @@ async function main() {
         : authorizedClient;
 
     let departmentId = null;
-    let insertedYearId = null;
+    let insertedAnonYearId = null;
+    let insertedAuthYearId = null;
 
     try {
         const { data: deptRow, error: deptError } = await anonClient
@@ -105,19 +134,21 @@ async function main() {
         departmentId = deptRow.id;
         logPass('resolve target department', `${TARGET_DEPARTMENT_CODE} -> ${departmentId}`);
 
-        const smokeYear = makeSmokeYear();
+        const anonSmokeYear = makeSmokeYear();
+        const authSmokeYear = makeSmokeYear();
 
         // Anonymous insert should fail.
         {
-            const { error } = await anonClient
+            const { data, error } = await anonClient
                 .from('academic_years')
-                .insert({ department_id: departmentId, year: smokeYear, is_active: false })
+                .insert({ department_id: departmentId, year: anonSmokeYear, is_active: false })
                 .select('id')
                 .maybeSingle();
 
             if (hasPermissionError(error)) {
                 logPass('anon insert denied');
             } else {
+                if (data?.id) insertedAnonYearId = data.id;
                 logFail('anon insert denied', error?.message || 'insert succeeded unexpectedly');
             }
         }
@@ -126,19 +157,19 @@ async function main() {
         {
             const { data, error } = await authorizedClient
                 .from('academic_years')
-                .insert({ department_id: departmentId, year: smokeYear, is_active: false })
+                .insert({ department_id: departmentId, year: authSmokeYear, is_active: false })
                 .select('id')
                 .single();
 
             if (error || !data?.id) {
                 logFail('authorized insert allowed', error?.message || 'no id returned');
             } else {
-                insertedYearId = data.id;
-                logPass('authorized insert allowed', `created id=${insertedYearId}`);
+                insertedAuthYearId = data.id;
+                logPass('authorized insert allowed', `created id=${insertedAuthYearId}`);
             }
         }
 
-        if (!insertedYearId) {
+        if (!insertedAuthYearId) {
             const failures = printSummary();
             process.exit(failures > 0 ? 1 : 0);
         }
@@ -148,7 +179,7 @@ async function main() {
             const { data, error } = await anonClient
                 .from('academic_years')
                 .update({ is_active: true })
-                .eq('id', insertedYearId)
+                .eq('id', insertedAuthYearId)
                 .select('id');
 
             const updatedRows = Array.isArray(data) ? data.length : 0;
@@ -164,7 +195,7 @@ async function main() {
             const { data, error } = await authorizedClient
                 .from('academic_years')
                 .update({ is_active: true })
-                .eq('id', insertedYearId)
+                .eq('id', insertedAuthYearId)
                 .select('id')
                 .single();
 
@@ -180,7 +211,7 @@ async function main() {
             const { data, error } = await anonClient
                 .from('academic_years')
                 .delete()
-                .eq('id', insertedYearId)
+                .eq('id', insertedAuthYearId)
                 .select('id');
 
             const deletedRows = Array.isArray(data) ? data.length : 0;
@@ -196,7 +227,7 @@ async function main() {
             const { data, error } = await authorizedClient
                 .from('academic_years')
                 .delete()
-                .eq('id', insertedYearId)
+                .eq('id', insertedAuthYearId)
                 .select('id')
                 .single();
 
@@ -204,18 +235,24 @@ async function main() {
                 logFail('authorized delete allowed', error?.message || 'row not deleted');
             } else {
                 logPass('authorized delete allowed');
-                insertedYearId = null;
+                insertedAuthYearId = null;
             }
         }
 
         const failures = printSummary();
         process.exit(failures > 0 ? 1 : 0);
     } finally {
-        if (insertedYearId) {
+        if (insertedAuthYearId) {
             await cleanupClient
                 .from('academic_years')
                 .delete()
-                .eq('id', insertedYearId);
+                .eq('id', insertedAuthYearId);
+        }
+        if (insertedAnonYearId) {
+            await cleanupClient
+                .from('academic_years')
+                .delete()
+                .eq('id', insertedAnonYearId);
         }
     }
 }

--- a/scripts/supabase-policy-smoke-check.js
+++ b/scripts/supabase-policy-smoke-check.js
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+const SUPABASE_AUTH_KEY = process.env.SUPABASE_AUTH_KEY || process.env.SUPABASE_SERVICE_ROLE_KEY;
+const SUPABASE_CLEANUP_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || SUPABASE_AUTH_KEY;
+const TARGET_DEPARTMENT_CODE = (process.env.SUPABASE_DEPARTMENT_CODE || 'DESN').trim();
+
+const checks = [];
+
+function logPass(name, detail = '') {
+    checks.push({ name, status: 'PASS', detail });
+}
+
+function logFail(name, detail = '') {
+    checks.push({ name, status: 'FAIL', detail });
+}
+
+function printSummary() {
+    console.log('\nSupabase RLS Smoke Check Results');
+    console.log('--------------------------------');
+    checks.forEach((check) => {
+        const icon = check.status === 'PASS' ? 'PASS' : 'FAIL';
+        const detail = check.detail ? ` - ${check.detail}` : '';
+        console.log(`${icon} ${check.name}${detail}`);
+    });
+
+    const failures = checks.filter((check) => check.status === 'FAIL').length;
+    if (failures === 0) {
+        console.log('\nResult: PASS');
+    } else {
+        console.log(`\nResult: FAIL (${failures} failing checks)`);
+    }
+
+    return failures;
+}
+
+function requireEnv(name, value) {
+    if (!value) {
+        throw new Error(`Missing required environment variable: ${name}`);
+    }
+}
+
+function createSupabaseClient(url, key) {
+    return createClient(url, key, {
+        auth: {
+            persistSession: false,
+            autoRefreshToken: false
+        }
+    });
+}
+
+function hasPermissionError(error) {
+    if (!error) return false;
+    const code = String(error.code || '').trim();
+    const text = `${error.message || ''} ${error.details || ''} ${error.hint || ''}`.toLowerCase();
+    return (
+        code === '42501' ||
+        text.includes('permission denied') ||
+        text.includes('row-level security') ||
+        text.includes('violates row-level security')
+    );
+}
+
+async function main() {
+    try {
+        requireEnv('SUPABASE_URL', SUPABASE_URL);
+        requireEnv('SUPABASE_ANON_KEY', SUPABASE_ANON_KEY);
+        requireEnv('SUPABASE_AUTH_KEY or SUPABASE_SERVICE_ROLE_KEY', SUPABASE_AUTH_KEY);
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+
+    const anonClient = createSupabaseClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    const authorizedClient = createSupabaseClient(SUPABASE_URL, SUPABASE_AUTH_KEY);
+    const cleanupClient = SUPABASE_CLEANUP_KEY
+        ? createSupabaseClient(SUPABASE_URL, SUPABASE_CLEANUP_KEY)
+        : authorizedClient;
+
+    let departmentId = null;
+    let insertedYearId = null;
+
+    try {
+        const { data: deptRow, error: deptError } = await anonClient
+            .from('departments')
+            .select('id, code')
+            .eq('code', TARGET_DEPARTMENT_CODE)
+            .maybeSingle();
+
+        if (deptError || !deptRow?.id) {
+            logFail('resolve target department', deptError?.message || `department ${TARGET_DEPARTMENT_CODE} not found`);
+            const failures = printSummary();
+            process.exit(failures > 0 ? 1 : 0);
+        }
+
+        departmentId = deptRow.id;
+        logPass('resolve target department', `${TARGET_DEPARTMENT_CODE} -> ${departmentId}`);
+
+        const smokeYear = `RLS-SMOKE-${Date.now()}`;
+
+        // Anonymous insert should fail.
+        {
+            const { error } = await anonClient
+                .from('academic_years')
+                .insert({ department_id: departmentId, year: smokeYear, is_active: false })
+                .select('id')
+                .maybeSingle();
+
+            if (hasPermissionError(error)) {
+                logPass('anon insert denied');
+            } else {
+                logFail('anon insert denied', error?.message || 'insert succeeded unexpectedly');
+            }
+        }
+
+        // Authorized insert should succeed.
+        {
+            const { data, error } = await authorizedClient
+                .from('academic_years')
+                .insert({ department_id: departmentId, year: smokeYear, is_active: false })
+                .select('id')
+                .single();
+
+            if (error || !data?.id) {
+                logFail('authorized insert allowed', error?.message || 'no id returned');
+            } else {
+                insertedYearId = data.id;
+                logPass('authorized insert allowed', `created id=${insertedYearId}`);
+            }
+        }
+
+        if (!insertedYearId) {
+            const failures = printSummary();
+            process.exit(failures > 0 ? 1 : 0);
+        }
+
+        // Anonymous update should be denied (permission error or zero affected rows).
+        {
+            const { data, error } = await anonClient
+                .from('academic_years')
+                .update({ is_active: true })
+                .eq('id', insertedYearId)
+                .select('id');
+
+            const updatedRows = Array.isArray(data) ? data.length : 0;
+            if (hasPermissionError(error) || updatedRows === 0) {
+                logPass('anon update denied');
+            } else {
+                logFail('anon update denied', 'row updated unexpectedly');
+            }
+        }
+
+        // Authorized update should succeed.
+        {
+            const { data, error } = await authorizedClient
+                .from('academic_years')
+                .update({ is_active: true })
+                .eq('id', insertedYearId)
+                .select('id')
+                .single();
+
+            if (error || !data?.id) {
+                logFail('authorized update allowed', error?.message || 'row not updated');
+            } else {
+                logPass('authorized update allowed');
+            }
+        }
+
+        // Anonymous delete should be denied (permission error or zero affected rows).
+        {
+            const { data, error } = await anonClient
+                .from('academic_years')
+                .delete()
+                .eq('id', insertedYearId)
+                .select('id');
+
+            const deletedRows = Array.isArray(data) ? data.length : 0;
+            if (hasPermissionError(error) || deletedRows === 0) {
+                logPass('anon delete denied');
+            } else {
+                logFail('anon delete denied', 'row deleted unexpectedly');
+            }
+        }
+
+        // Authorized delete should succeed and cleanup the smoke row.
+        {
+            const { data, error } = await authorizedClient
+                .from('academic_years')
+                .delete()
+                .eq('id', insertedYearId)
+                .select('id')
+                .single();
+
+            if (error || !data?.id) {
+                logFail('authorized delete allowed', error?.message || 'row not deleted');
+            } else {
+                logPass('authorized delete allowed');
+                insertedYearId = null;
+            }
+        }
+
+        const failures = printSummary();
+        process.exit(failures > 0 ? 1 : 0);
+    } finally {
+        if (insertedYearId) {
+            await cleanupClient
+                .from('academic_years')
+                .delete()
+                .eq('id', insertedYearId);
+        }
+    }
+}
+
+main().catch((error) => {
+    console.error('Smoke check failed unexpectedly:', error.message);
+    process.exit(1);
+});

--- a/scripts/supabase-policy-smoke-check.js
+++ b/scripts/supabase-policy-smoke-check.js
@@ -64,10 +64,10 @@ function hasPermissionError(error) {
     );
 }
 
-function makeSmokeYear() {
+function makeSmokeYear(marker = '0') {
     // academic_years.year is VARCHAR(10) in schema
-    const suffix = Date.now().toString().slice(-7);
-    return `RLS${suffix}`;
+    const suffix = Date.now().toString().slice(-6);
+    return `RL${marker}${suffix}`;
 }
 
 function tryDecodeJwtPayload(key) {
@@ -134,8 +134,8 @@ async function main() {
         departmentId = deptRow.id;
         logPass('resolve target department', `${TARGET_DEPARTMENT_CODE} -> ${departmentId}`);
 
-        const anonSmokeYear = makeSmokeYear();
-        const authSmokeYear = makeSmokeYear();
+        const anonSmokeYear = makeSmokeYear('A');
+        const authSmokeYear = makeSmokeYear('B');
 
         // Anonymous insert should fail.
         {

--- a/scripts/supabase-policy-smoke-check.js
+++ b/scripts/supabase-policy-smoke-check.js
@@ -64,6 +64,12 @@ function hasPermissionError(error) {
     );
 }
 
+function makeSmokeYear() {
+    // academic_years.year is VARCHAR(10) in schema
+    const suffix = Date.now().toString().slice(-7);
+    return `RLS${suffix}`;
+}
+
 async function main() {
     try {
         requireEnv('SUPABASE_URL', SUPABASE_URL);
@@ -99,7 +105,7 @@ async function main() {
         departmentId = deptRow.id;
         logPass('resolve target department', `${TARGET_DEPARTMENT_CODE} -> ${departmentId}`);
 
-        const smokeYear = `RLS-SMOKE-${Date.now()}`;
+        const smokeYear = makeSmokeYear();
 
         // Anonymous insert should fail.
         {


### PR DESCRIPTION
## Summary
- add `scripts/supabase-policy-smoke-check.js` to verify anonymous-denied and authorized-allowed policy behavior
- add `npm run check:rls` command for root-level execution
- add runbook in `docs/supabase-policy-smoke-check.md` with env vars, flow, and exit codes
- link smoke-check workflow in `docs/AUDIT-ISSUES-2026-02-21.md`

## Validation
- node --check scripts/supabase-policy-smoke-check.js
- npm test -- --runInBand

Closes #59
