### PR TITLE
[Tree/C-08] Capture live Supabase verification evidence for save safety + RLS

### DIFF
--- a/docs/examples/supabase-rls-smoke-check-2026-02-28.txt
+++ b/docs/examples/supabase-rls-smoke-check-2026-02-28.txt
@@ -1,0 +1,14 @@
+> ewu-design-schedule-analyzer@2.0.0 check:rls
+> node scripts/supabase-policy-smoke-check.js
+
+Supabase RLS Smoke Check Results
+--------------------------------
+PASS resolve target department - DESN -> 67b1449f-1338-419c-8e89-351d9fb7c370
+PASS anon insert denied
+PASS authorized insert allowed - created id=c2132cf3-1aaf-4438-ab92-bc1503f5be79
+PASS anon update denied
+PASS authorized update allowed
+PASS anon delete denied
+PASS authorized delete allowed
+
+Result: PASS

--- a/docs/supabase-live-verification-c08-2026-02-28.md
+++ b/docs/supabase-live-verification-c08-2026-02-28.md
@@ -1,0 +1,45 @@
+# C-08 Live Supabase Verification Evidence (2026-02-28)
+
+Issue: [#60](https://github.com/sicxz/program-command/issues/60)  
+Scope: Capture live verification evidence for save safety and RLS behavior after C-06/C-07.
+
+## Environment
+- Project ref: `ohnrhjxcjkrdtudpzjgn`
+- Verification date (UTC): `2026-02-28`
+- Operator: repository maintainer via terminal session
+
+## Commands Executed
+1. `npm run check:rls`
+2. Direct SQL verification with `psql` against Supabase pooler endpoint to validate policy state and anon-role denial behavior.
+
+## Smoke Check Result
+See raw transcript: [docs/examples/supabase-rls-smoke-check-2026-02-28.txt](./examples/supabase-rls-smoke-check-2026-02-28.txt)
+
+Result:
+- `PASS resolve target department`
+- `PASS anon insert denied`
+- `PASS authorized insert allowed`
+- `PASS anon update denied`
+- `PASS authorized update allowed`
+- `PASS anon delete denied`
+- `PASS authorized delete allowed`
+- Final status: `Result: PASS`
+
+## Policy Verification Notes
+During verification, a legacy broad policy was detected in live DB:
+- `academic_years | Public write | ALL | {public}`
+
+This was removed, and hardened authenticated-only write policies were validated.
+
+Final `academic_years` policy state:
+- `Public read` (`SELECT` to `public`)
+- `auth_insert_academic_years` (`INSERT` to `authenticated`)
+- `auth_update_academic_years` (`UPDATE` to `authenticated`)
+
+Anon role insert verification (SQL):
+- `ERROR: new row violates row-level security policy for table "academic_years"`
+
+## Save-Safety / RLS Outcome
+- RLS behavior is now aligned with C-06 intent and C-07 smoke-check expectations.
+- Live verification evidence captured for C-08 acceptance.
+- Credentials used during session were rotated after completion.

--- a/docs/supabase-policy-smoke-check.md
+++ b/docs/supabase-policy-smoke-check.md
@@ -59,3 +59,4 @@ The script attempts cleanup even if a later check fails.
 
 - Run this against a non-production environment first.
 - C-08 captures and stores live verification evidence after this check passes.
+- Example completed evidence artifact: `docs/supabase-live-verification-c08-2026-02-28.md`.


### PR DESCRIPTION
## Summary
- add C-08 live verification evidence doc with smoke-check and SQL policy verification notes
- add raw smoke-check transcript artifact under docs/examples
- link the evidence artifact from the C-07 smoke-check runbook

## Validation
- npm test -- --runInBand
  - 10/10 suites passed
  - 25/25 tests passed

## Issue
- Closes #60