### PR TITLE
[Tree/A-02] Implement Supabase Auth sign-up / sign-in flow

### DIFF
--- a/.github/workflows/codex-issue-writer.yml
+++ b/.github/workflows/codex-issue-writer.yml
@@ -1,0 +1,96 @@
+name: Codex Issue Writer
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 15 * * *" # daily 3pm UTC, adjust if you want
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  propose_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+
+      - name: Generate issue proposals with Codex
+        uses: openai/codex-action@v1
+        with:
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          # This runs codex-cli under the hood.
+          # Keep it simple: output JSON that we can parse.
+          command: >
+            codex exec "
+            You are the repo triage and planning agent.
+
+            Read the repository. Use AGENTS.md as constraints.
+            Look for:
+            - TODO/FIXME comments
+            - failing or flaky tests
+            - security footguns
+            - missing docs that block onboarding
+            - obvious tech debt that will slow features
+
+            Produce up to 5 GitHub issues as JSON array:
+            [
+              {\"title\":\"...\",\"body\":\"...\",\"labels\":[\"agent-created\",\"p2\"],\"priority\":2}
+            ]
+
+            Rules:
+            - Do not propose vague issues.
+            - Each issue must have acceptance criteria bullets.
+            - Prefer small, atomic issues (1 to 3 hours).
+            - If the issue already exists, do not propose it.
+            Output ONLY valid JSON.
+            " > /tmp/codex_issues.json
+
+      - name: Create issues in GitHub
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          python3 - << 'PY'
+          import json, os, subprocess, sys
+
+          path = "/tmp/codex_issues.json"
+          data = json.load(open(path, "r"))
+
+          # Hard safety limits
+          MAX_ISSUES = 5
+          created = 0
+
+          # Get existing issue titles to avoid dupes
+          existing = subprocess.check_output(
+              ["gh","issue","list","--limit","200","--json","title"],
+              text=True
+          )
+          existing_titles = {i["title"].strip().lower() for i in json.loads(existing)}
+
+          for item in data[:MAX_ISSUES]:
+              title = item["title"].strip()
+              if title.lower() in existing_titles:
+                  continue
+
+              body = item["body"].strip()
+              labels = item.get("labels", [])
+              # Ensure a consistent label is present
+              if "agent-created" not in labels:
+                  labels.append("agent-created")
+
+              cmd = ["gh","issue","create","--title",title,"--body",body]
+              for lab in labels:
+                  cmd += ["--label", lab]
+
+              subprocess.check_call(cmd)
+              created += 1
+
+          print(f"Created {created} issues.")
+          PY

--- a/CODEX_UPDATE_HANDOFF.md
+++ b/CODEX_UPDATE_HANDOFF.md
@@ -1,0 +1,36 @@
+# Codex Handoff Update
+
+Date: 2026-02-27
+Repo: /Users/tmasingale/Documents/GitHub/scheduler-v2-codex
+Branch pushed to main: codex/merge-main-clss-rollout
+Main push range: 829280b..ddaaec3
+
+## What was pushed to main in this autopilot pass
+
+- Merged and pushed the pending department-onboarding/program-shell workstream commits already on `codex/merge-main-clss-rollout` into `main`.
+- Included shipped work for:
+  - Profile-driven scheduler/workload/import wiring
+  - Profile-aware CLSS confidence/placement diagnostics
+  - Department onboarding shell (wizard + health checks)
+  - Department onboarding QA pack + pilot profile assets
+  - Profile text slots / branding guardrails
+  - EagleNet comparison UI/report + export support
+
+## Verification run
+
+- Command: `npm test -- --runInBand`
+- Result: PASS (`10` suites, `25` tests)
+
+## Open issues status
+
+- `#3` (`P0`) remains open as **external verification blocker**:
+  - Schema hardening exists in repo, but live Supabase credentialed validation is still required.
+- `#23` (`P2`) remains open as **external verification blocker**:
+  - Atomic save RPC implementation exists (`scripts/supabase-schedule-sync-rpc.sql`, app RPC bridge), but live DB-side verification is still required.
+- `#1` epic remains open because `#3` is still pending verification.
+
+## Notes for next operator
+
+1. Run live Supabase verification for `#3` and `#23` in the target project.
+2. If both pass, close `#3`, close `#23`, then close epic `#1`.
+3. Keep `AGENTS.md` local edits separate (currently stashed during this run).

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ Interactive analytics dashboards for analyzing enrollment trends, faculty worklo
    ```
 3. Open your browser to `http://localhost:8080`
 
+## 🔎 Dev Data Freshness Check
+
+Before merging or deploying, compare production vs dev Supabase data drift:
+
+```bash
+PROD_SUPABASE_URL="https://<prod-ref>.supabase.co" \
+PROD_SUPABASE_KEY="<prod-key>" \
+DEV_SUPABASE_URL="https://<dev-ref>.supabase.co" \
+DEV_SUPABASE_KEY="<dev-key>" \
+npm run check:data-freshness -- --department DESN --year 2026-27 --output output/data-freshness-report.json
+```
+
+If drift is detected, the command exits with code `2` and lists tables that need carry-over review.
+See `/docs/dev-data-freshness.md` for full usage.
+
 ## 🌐 GitHub Pages Deployment
 
 This repo now includes `/.github/workflows/deploy-pages.yml` to publish static dashboards to GitHub Pages on every push to `main`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # EWU Design Schedule Analyzer
-https://sicxz.github.io/program-com
+https://sicxz.github.io/program-command/
 
 Interactive analytics dashboards for analyzing enrollment trends, faculty workload, and capacity planning for the EWU Design program.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ npm run check:data-freshness -- --department DESN --year 2026-27 --output output
 If drift is detected, the command exits with code `2` and lists tables that need carry-over review.
 See `/docs/dev-data-freshness.md` for full usage.
 
+## ✅ Onboarding QA Gate
+
+Run the onboarding QA suite before rollout:
+
+```bash
+npm run qa:onboarding
+```
+
+Rollout checklist and SOP: `/docs/department-onboarding-qa-pack.md`.
+
 ## 🌐 GitHub Pages Deployment
 
 This repo now includes `/.github/workflows/deploy-pages.yml` to publish static dashboards to GitHub Pages on every push to `main`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # EWU Design Schedule Analyzer
+https://sicxz.github.io/program-com
 
 Interactive analytics dashboards for analyzing enrollment trends, faculty workload, and capacity planning for the EWU Design program.
 

--- a/department-profiles/design-v1.json
+++ b/department-profiles/design-v1.json
@@ -31,7 +31,25 @@
   },
   "scheduler": {
     "storageKeyPrefix": "designSchedulerData_",
-    "allowedRooms": ["206", "207", "209", "210", "212", "CEB 102", "CEB 104"]
+    "allowedRooms": ["206", "207", "209", "210", "212", "CEB 102", "CEB 104"],
+    "dayPatterns": [
+      { "id": "MW", "label": "Monday / Wednesday", "aliases": ["MW", "WM"] },
+      { "id": "TR", "label": "Tuesday / Thursday", "aliases": ["TR", "RT", "TH", "TTH"] }
+    ],
+    "timeSlots": [
+      { "id": "10:00-12:20", "label": "10:00-12:20", "aliases": ["10:00-12:00"], "startMinutes": 600, "endMinutes": 740 },
+      { "id": "13:00-15:20", "label": "13:00-15:20", "aliases": ["13:00-15:00"], "startMinutes": 780, "endMinutes": 920 },
+      { "id": "16:00-18:20", "label": "16:00-18:20", "aliases": ["16:00-18:00"], "startMinutes": 960, "endMinutes": 1100 }
+    ],
+    "roomLabels": {
+      "206": "206 UX Lab",
+      "207": "207 Media Lab",
+      "209": "209 Mac Lab",
+      "210": "210 Mac Lab",
+      "212": "212 Project Lab",
+      "CEB 102": "CEB 102",
+      "CEB 104": "CEB 104"
+    }
   },
   "workload": {
     "dashboardTitle": "Faculty Workload Dashboard",
@@ -54,7 +72,9 @@
         "course+section+instructor+quarter",
         "course+quarter+instructor",
         "course+quarter"
-      ]
+      ],
+      "facultyAliases": {},
+      "courseAliases": {}
     }
   }
 }

--- a/department-profiles/design-v1.json
+++ b/department-profiles/design-v1.json
@@ -11,6 +11,20 @@
     "appTitle": "Program Command - EWU Design",
     "headerEyebrow": "EWU DESIGN · PROGRAM COMMAND",
     "headerSubtitle": "Design Program Planning, Scheduling, and Scenario Control",
+    "textSlots": {
+      "navAnalyticsLabel": "Analytics",
+      "navPlanningLabel": "Planning",
+      "navToolsLabel": "Tools",
+      "onboardingTitle": "Department Onboarding Shell",
+      "onboardingSubtitle": "Create and activate a versioned department profile without code edits for standard setup",
+      "onboardingStep1Title": "Step 1: Entry + Base Profile",
+      "onboardingStep1Help": "Select an existing profile as your base, then define department identity.",
+      "onboardingStep2Title": "Step 2: Seed Mapping Wizard",
+      "onboardingStep2Help": "Enter room map and CLSS alias mappings. Use one item per line. Alias format: alias=canonical.",
+      "onboardingStep3Title": "Step 3: Health Checks + Activation",
+      "onboardingStep3Help": "Run checks before activation. Errors block activation. Warnings are advisory.",
+      "onboardingStatusTitle": "Current Status"
+    },
     "themeTokens": {
       "headerTop": "#3d444d",
       "headerBottom": "#24292f",

--- a/department-profiles/itds-pilot-v1.json
+++ b/department-profiles/itds-pilot-v1.json
@@ -1,0 +1,88 @@
+{
+  "version": 1,
+  "id": "itds-pilot-v1",
+  "identity": {
+    "name": "Interactive Technology + Design",
+    "code": "ITDS",
+    "displayName": "EWU ITDS",
+    "shortName": "ITDS"
+  },
+  "branding": {
+    "appTitle": "Program Command - EWU ITDS",
+    "headerEyebrow": "EWU ITDS · PROGRAM COMMAND",
+    "headerSubtitle": "ITDS Program Planning and Schedule Operations",
+    "themeTokens": {
+      "headerTop": "#1f3b4d",
+      "headerBottom": "#10212b",
+      "headerForeground": "#f8fafc",
+      "headerMuted": "#cbd5e1",
+      "headerActionBg": "#10212b",
+      "headerActionBorder": "#3b5568",
+      "headerActionHoverBg": "#1f3b4d",
+      "headerActionHoverBorder": "#5f7485"
+    }
+  },
+  "academic": {
+    "system": "quarter",
+    "quarters": ["fall", "winter", "spring"],
+    "defaultTargetYearMode": "current",
+    "defaultWorkloadImportYearMode": "next",
+    "defaultSchedulerYear": "2026-27"
+  },
+  "scheduler": {
+    "storageKeyPrefix": "itdsSchedulerData_",
+    "allowedRooms": ["IT 101", "IT 102", "LAB 201", "LAB 203", "ONLINE"],
+    "dayPatterns": [
+      { "id": "MW", "label": "Monday / Wednesday", "aliases": ["MW", "WM"] },
+      { "id": "TR", "label": "Tuesday / Thursday", "aliases": ["TR", "RT", "TH", "TTH"] }
+    ],
+    "timeSlots": [
+      { "id": "09:00-11:20", "label": "09:00-11:20", "aliases": ["09:00-11:00"], "startMinutes": 540, "endMinutes": 680 },
+      { "id": "12:00-14:20", "label": "12:00-14:20", "aliases": ["12:00-14:00"], "startMinutes": 720, "endMinutes": 860 },
+      { "id": "15:00-17:20", "label": "15:00-17:20", "aliases": ["15:00-17:00"], "startMinutes": 900, "endMinutes": 1040 }
+    ],
+    "roomLabels": {
+      "IT 101": "IT 101 Studio",
+      "IT 102": "IT 102 Studio",
+      "LAB 201": "LAB 201 Compute Lab",
+      "LAB 203": "LAB 203 XR Lab",
+      "ONLINE": "ONLINE"
+    }
+  },
+  "workload": {
+    "dashboardTitle": "Faculty Workload Dashboard",
+    "dashboardSubtitleBase": "EWU ITDS Department - Academic Workload Analysis",
+    "productionResetDefaultScheduleYear": "2027-28",
+    "defaultAnnualTargets": {
+      "Full Professor": 36,
+      "Associate Professor": 36,
+      "Assistant Professor": 36,
+      "Tenure/Tenure-track": 36,
+      "Senior Lecturer": 45,
+      "Lecturer": 45,
+      "Adjunct": 15
+    },
+    "appliedLearningCourses": {
+      "ITDS 495": { "title": "Internship", "rate": 0.1 },
+      "ITDS 499": { "title": "Independent Study", "rate": 0.2 }
+    }
+  },
+  "import": {
+    "clss": {
+      "roomMatchPriority": ["IT 101", "IT 102", "LAB 201", "LAB 203"],
+      "preferredMatchingOrder": [
+        "course+section+instructor+quarter",
+        "course+quarter+instructor",
+        "course+quarter"
+      ],
+      "facultyAliases": {
+        "J Smith": "J.Smith",
+        "L Perez": "L.Perez"
+      },
+      "courseAliases": {
+        "ITD 101": "ITDS 101",
+        "ITD 220": "ITDS 220"
+      }
+    }
+  }
+}

--- a/department-profiles/itds-pilot-v1.json
+++ b/department-profiles/itds-pilot-v1.json
@@ -11,6 +11,20 @@
     "appTitle": "Program Command - EWU ITDS",
     "headerEyebrow": "EWU ITDS · PROGRAM COMMAND",
     "headerSubtitle": "ITDS Program Planning and Schedule Operations",
+    "textSlots": {
+      "navAnalyticsLabel": "Insights",
+      "navPlanningLabel": "Planning Studio",
+      "navToolsLabel": "Operations",
+      "onboardingTitle": "ITDS Onboarding Shell",
+      "onboardingSubtitle": "Configure and activate an ITDS-ready profile with guided checks",
+      "onboardingStep1Title": "Step 1: Profile Base + ITDS Identity",
+      "onboardingStep1Help": "Select a baseline profile, then confirm ITDS naming/codes.",
+      "onboardingStep2Title": "Step 2: Room + Alias Mapping",
+      "onboardingStep2Help": "Map scheduler rooms and CLSS alias pairs using alias=canonical format.",
+      "onboardingStep3Title": "Step 3: Health Gate + Activation",
+      "onboardingStep3Help": "Run checks, resolve errors, then save a versioned profile and activate.",
+      "onboardingStatusTitle": "Onboarding Status"
+    },
     "themeTokens": {
       "headerTop": "#1f3b4d",
       "headerBottom": "#10212b",

--- a/department-profiles/manifest.json
+++ b/department-profiles/manifest.json
@@ -6,6 +6,11 @@
       "id": "design-v1",
       "label": "EWU Design",
       "file": "design-v1.json"
+    },
+    {
+      "id": "itds-pilot-v1",
+      "label": "EWU ITDS Pilot",
+      "file": "itds-pilot-v1.json"
     }
   ]
 }

--- a/docs/auth-contract.md
+++ b/docs/auth-contract.md
@@ -1,0 +1,114 @@
+# Auth Contract (A-01)
+
+Issue: [#87](https://github.com/sicxz/program-command/issues/87)  
+Parent epic: [#86](https://github.com/sicxz/program-command/issues/86)
+
+## 1) Provider Decision
+Decision: use **Supabase Auth (email + password)** as the primary provider.
+
+Rationale:
+- already aligned with current Supabase-backed data architecture
+- first-party JWT + RLS integration without additional auth proxy
+- supports immediate rollout for A-02/A-03/A-05 with minimal system churn
+
+Initial auth methods:
+- enabled: email/password
+- disabled for phase 1: social providers, anonymous auth
+
+## 2) Role Model
+Two application roles are in scope for phase 1:
+
+- `admin`
+  - platform/developer-level access
+  - full read/write across scheduler data and program configuration
+  - can invite/revoke users and assign roles
+
+- `chair`
+  - department/program operational editor
+  - can edit scheduling/workload data for assigned program
+  - no global platform administration
+
+Role source of truth:
+- role stored in auth claims (`app_metadata.role`) and enforced by RLS/policy layer
+- application UI can additionally gate controls for UX clarity, but DB policy is authoritative
+
+## 3) Session Lifecycle
+Session flow:
+1. user signs in (`/auth` flow)
+2. client restores existing session on app load
+3. active session continues with token refresh handled by Supabase client
+4. inactivity timeout warning is shown before local session expiration
+5. on timeout or invalid refresh token, user must re-authenticate
+
+Timeout contract:
+- UI idle warning threshold: 25 minutes inactivity
+- forced sign-out target: 30 minutes inactivity
+- absolute max session age before re-auth prompt: 8 hours
+
+Notes:
+- exact timers are enforced in A-10 implementation; values above are contract defaults
+
+## 4) Token Storage Strategy
+Decision: use Supabase JS managed session storage only.
+
+Rules:
+- do not manually persist JWTs in custom storage keys
+- do not copy service-role credentials to browser runtime
+- browser uses anon/publishable key + user session token
+- privileged operations remain server-side or service-role only
+
+## 5) Registration Model
+Decision: **invite-only** registration for phase 1.
+
+Contract:
+- self-signup is disabled
+- admins invite chair users
+- invited users set password via Supabase invite/reset flow
+
+Reasoning:
+- avoids uncontrolled account creation during early multi-tenant rollout
+- keeps role assignment and program scoping explicit
+
+## 6) Permission Matrix (Phase 1)
+Legend:
+- `R` = read
+- `W` = insert/update/delete
+- `-` = no direct access
+
+| Table | chair | admin |
+|---|---|---|
+| `departments` | R | R/W |
+| `academic_years` | R/W (scoped) | R/W |
+| `rooms` | R/W (scoped) | R/W |
+| `courses` | R/W (scoped) | R/W |
+| `faculty` | R/W (scoped) | R/W |
+| `scheduled_courses` | R/W (scoped) | R/W |
+| `faculty_preferences` | R/W (scoped) | R/W |
+| `scheduling_constraints` | R/W (scoped) | R/W |
+| `release_time` | R/W (scoped) | R/W |
+| `pathways` | R/W (scoped) | R/W |
+| `pathway_courses` | R/W (scoped) | R/W |
+
+Scoping contract:
+- all chair writes must be constrained to the current program/department context
+- all chair reads should be program-scoped once T-series multi-tenant schema lands
+
+## 7) Downstream Issue Contracts
+This spec is normative input for:
+- [#88](https://github.com/sicxz/program-command/issues/88) Supabase Auth sign-up/sign-in flow
+- [#89](https://github.com/sicxz/program-command/issues/89) login UI/session indicator/logout
+- [#90](https://github.com/sicxz/program-command/issues/90) role-based access control
+- [#91](https://github.com/sicxz/program-command/issues/91) user-scoped RLS writes
+- [#92](https://github.com/sicxz/program-command/issues/92) save attribution
+- [#93](https://github.com/sicxz/program-command/issues/93) presence tracking
+- [#94](https://github.com/sicxz/program-command/issues/94) edit-lock warnings
+- [#95](https://github.com/sicxz/program-command/issues/95) unsaved-change guards
+- [#96](https://github.com/sicxz/program-command/issues/96) timeout/auto-save/recovery
+- [#97](https://github.com/sicxz/program-command/issues/97) auth + edit-state integration tests
+
+## 8) Non-Goals (A-01)
+- implementing UI auth screens
+- implementing invite workflows
+- implementing program multi-tenancy claims (`program_id`) end-to-end
+
+Those are handled in subsequent A/T issues.

--- a/docs/department-onboarding-qa-pack.md
+++ b/docs/department-onboarding-qa-pack.md
@@ -1,0 +1,89 @@
+# Department Onboarding QA Pack (M4 Release Gate)
+
+This QA pack is the release gate for department onboarding rollout work.
+
+## 1) Regression Suite (Scheduler + Workload + CLSS)
+
+Run before each onboarding rollout:
+
+```bash
+npm test
+```
+
+Coverage alignment:
+
+- Scheduler/conflict critical path:
+  - `tests/conflict-engine.slot-resolutions.test.js`
+  - `tests/conflict-engine.regression-scenarios.test.js`
+  - `tests/conflict-engine.room-fit-recommendations.test.js`
+- Workload critical path:
+  - `tests/workload-integration.test.js`
+- Onboarding/profile management critical path:
+  - `tests/department-profile.onboarding.test.js`
+
+Manual CLSS import regression (required until CLSS parser is fully modularized for unit tests):
+
+1. Open `/pages/department-onboarding.html` and activate a non-default profile.
+2. Open CLSS import in scheduler and parse sample rows with:
+   - at least one faculty alias match
+   - at least one course alias match
+   - at least one low-confidence row
+3. Confirm review summary shows low-confidence count and per-row diagnostics.
+4. Apply import and confirm results panel includes placement diagnostics sample.
+
+## 2) Pilot Profile
+
+Pilot profile file:
+
+- `department-profiles/itds-pilot-v1.json`
+
+Manifest registration:
+
+- `department-profiles/manifest.json` includes `itds-pilot-v1`
+
+Expected pilot onboarding outcome:
+
+- Profile can be selected as onboarding base.
+- Wizard can save a versioned profile (`<base>-vNN`) locally.
+- Activated profile becomes the active runtime profile and survives reload.
+
+## 3) Rollout SOP (Chair/Admin)
+
+### Preflight
+
+1. Run `npm test` and verify all suites pass.
+2. Run data drift check before carrying configuration between environments:
+   - `npm run check:data-freshness -- --department <CODE> --year <YYYY-YY>`
+3. Confirm backup/export of current active profile decisions (if any).
+
+### Onboarding Execution
+
+1. Open `pages/department-onboarding.html`.
+2. Select base profile.
+3. Enter identity and mapping inputs (rooms, faculty aliases, course aliases).
+4. Run Health Checks.
+5. Resolve all Errors (Warnings can proceed with explicit sign-off).
+6. Click **Save Versioned Profile + Activate**.
+
+### Post-Activation Verification
+
+1. Reload app and confirm new profile remains active.
+2. Verify scheduler headers/slots/rooms match profile settings.
+3. Verify workload dashboard labels/targets align with profile.
+4. Run one CLSS import dry run and confirm diagnostics output.
+
+### Rollback
+
+1. Reopen onboarding shell.
+2. Select prior known-good profile version from base selector.
+3. Activate prior version.
+4. Re-run quick smoke (scheduler + workload + CLSS parse).
+
+## 4) Handoff Artifacts
+
+For each rollout, capture:
+
+- activated profile id and timestamp
+- health check output summary (errors/warnings/passes)
+- data freshness report output JSON (if environment compare was run)
+- smoke-test notes (scheduler/workload/CLSS)

--- a/docs/department-profile-schema-v1.md
+++ b/docs/department-profile-schema-v1.md
@@ -15,6 +15,7 @@ This schema defines the runtime configuration contract for department onboarding
   - `appTitle` (string)
   - `headerEyebrow` (string)
   - `headerSubtitle` (string)
+  - `textSlots` (object map, optional): profile-driven UI labels/help copy
   - `themeTokens` (object): key/value map applied to CSS vars using `--pc-<token-name>`
 - `academic` (object, required):
   - `system` (string, currently `quarter`)
@@ -65,4 +66,5 @@ If manifest/profile loading fails or validation fails, runtime falls back to the
 - Unsupported profile versions fail validation.
 - Missing required fields fail validation.
 - Runtime applies v1 defaults for optional fields.
+- Runtime emits contrast warnings when branding foreground/background header tokens fail a 4.5:1 ratio check.
 - Migration hook entry point exists in `js/department-profile.js` (`migrateProfile`) for future version upgrades.

--- a/docs/department-profile-schema-v1.md
+++ b/docs/department-profile-schema-v1.md
@@ -25,6 +25,17 @@ This schema defines the runtime configuration contract for department onboarding
 - `scheduler` (object, required):
   - `storageKeyPrefix` (string, required)
   - `allowedRooms` (array of strings, optional)
+  - `dayPatterns` (array, optional): each entry can define:
+    - `id` (string, required)
+    - `label` (string, optional)
+    - `aliases` (array of strings, optional)
+  - `timeSlots` (array, optional): each entry can define:
+    - `id` (string, required)
+    - `label` (string, optional)
+    - `aliases` (array of strings, optional)
+    - `startMinutes` (number, optional)
+    - `endMinutes` (number, optional)
+  - `roomLabels` (object map, optional): room code to display label
 - `workload` (object, required):
   - `dashboardTitle` (string, optional)
   - `dashboardSubtitleBase` (string, optional)
@@ -33,6 +44,8 @@ This schema defines the runtime configuration contract for department onboarding
 - `import` (object, optional):
   - `clss.roomMatchPriority` (array of strings, optional)
   - `clss.preferredMatchingOrder` (array of strings, optional)
+  - `clss.facultyAliases` (object map, optional): alias to canonical faculty name
+  - `clss.courseAliases` (object map, optional): alias code to canonical course code
 
 ## Runtime Loader
 

--- a/docs/dev-data-freshness.md
+++ b/docs/dev-data-freshness.md
@@ -1,0 +1,53 @@
+# Dev Data Freshness Check
+
+Use this when you need to verify whether dev data has drifted from production before merging or deploying.
+
+## What it checks
+
+For a department and academic year, the checker compares these tables between production and dev:
+
+- `academic_years`
+- `rooms`
+- `courses`
+- `faculty`
+- `scheduling_constraints`
+- `scheduled_courses`
+- `release_time`
+
+For each table it reports:
+
+- row count
+- latest change timestamp (`updated_at` or `created_at`)
+- freshness status (`in-sync`, `prod-newer`, `dev-newer`, `prod-has-more`, `dev-has-more`, etc.)
+
+## Run (live compare)
+
+```bash
+PROD_SUPABASE_URL="https://<prod-ref>.supabase.co" \
+PROD_SUPABASE_KEY="<prod-key>" \
+DEV_SUPABASE_URL="https://<dev-ref>.supabase.co" \
+DEV_SUPABASE_KEY="<dev-key>" \
+npm run check:data-freshness -- --department DESN --year 2026-27 --output output/data-freshness-report.json
+```
+
+Notes:
+
+- `--department` defaults to `DESN`.
+- `--year` is optional. If omitted, the checker uses each environment's active year.
+- Exit code is `2` when drift is detected.
+
+## Run (offline compare from saved snapshots)
+
+```bash
+npm run check:data-freshness -- \
+  --prod-snapshot output/prod-snapshot.json \
+  --dev-snapshot output/dev-snapshot.json
+```
+
+## Interpreting results
+
+- `in-sync`: no action needed for that table.
+- `prod-newer` or `prod-has-more`: production changed after dev snapshot; carry-over likely needed.
+- `dev-newer` or `dev-has-more`: dev contains changes not yet in production.
+
+If drift is reported, review the affected tables and plan a carry-over before merge/deploy.

--- a/index.html
+++ b/index.html
@@ -4415,6 +4415,8 @@
                         <a href="pages/schedule-builder.html" class="nav-link"><span class="icon">📅</span>Builder</a>
                         <a href="pages/academic-year-setup.html" class="nav-link"><span class="icon">🗂️</span>AY
                             Setup</a>
+                        <a href="pages/department-onboarding.html" class="nav-link"><span
+                                class="icon">🧭</span>Onboarding</a>
                         <a href="pages/course-management.html" class="nav-link"><span class="icon">📚</span>Courses</a>
                         <a href="pages/workload-dashboard.html" class="nav-link"><span
                                 class="icon">👥</span>Workload</a>

--- a/index.html
+++ b/index.html
@@ -4397,7 +4397,7 @@
             <div class="nav-accordion-content collapsed" id="navAccordionContent">
                 <!-- Analytics Row -->
                 <div class="nav-row">
-                    <span class="nav-row-header">Analytics</span>
+                    <span class="nav-row-header" id="navHeaderAnalytics">Analytics</span>
                     <div class="nav-row-items">
                         <a href="enrollment-dashboard.html" class="nav-link"><span class="icon">📊</span>Enrollment</a>
                         <a href="pages/workload-dashboard.html" class="nav-link"><span
@@ -4410,7 +4410,7 @@
                 </div>
                 <!-- Planning Row -->
                 <div class="nav-row">
-                    <span class="nav-row-header">Planning</span>
+                    <span class="nav-row-header" id="navHeaderPlanning">Planning</span>
                     <div class="nav-row-items">
                         <a href="pages/schedule-builder.html" class="nav-link"><span class="icon">📅</span>Builder</a>
                         <a href="pages/academic-year-setup.html" class="nav-link"><span class="icon">🗂️</span>AY
@@ -4428,7 +4428,7 @@
                 </div>
                 <!-- Tools Row -->
                 <div class="nav-row">
-                    <span class="nav-row-header">Tools</span>
+                    <span class="nav-row-header" id="navHeaderTools">Tools</span>
                     <div class="nav-row-items">
                         <button onclick="highlightConflicts()" class="nav-link"><span
                                 class="icon">🔍</span>Conflicts</button>
@@ -4884,6 +4884,28 @@
             }
         }
 
+        function applyDepartmentProfileTextSlots(profile) {
+            if (!profile || typeof profile !== 'object') return;
+            const textSlots = profile.branding && profile.branding.textSlots && typeof profile.branding.textSlots === 'object'
+                ? profile.branding.textSlots
+                : {};
+
+            const slotBindings = {
+                navHeaderAnalytics: textSlots.navAnalyticsLabel,
+                navHeaderPlanning: textSlots.navPlanningLabel,
+                navHeaderTools: textSlots.navToolsLabel
+            };
+
+            Object.entries(slotBindings).forEach(([elementId, value]) => {
+                const text = String(value || '').trim();
+                if (!text) return;
+                const element = document.getElementById(elementId);
+                if (element) {
+                    element.textContent = text;
+                }
+            });
+        }
+
         function applyDepartmentProfileSchedulerOverrides(profile) {
             if (!profile || typeof profile !== 'object') return;
             const scheduler = profile.scheduler || {};
@@ -4963,6 +4985,7 @@
                 }
 
                 applyDepartmentProfileToHeader(activeDepartmentProfile);
+                applyDepartmentProfileTextSlots(activeDepartmentProfile);
                 applyDepartmentProfileSchedulerOverrides(activeDepartmentProfile);
                 refreshFacultyAliasMap();
 

--- a/index.html
+++ b/index.html
@@ -4589,6 +4589,269 @@
         const AY_SETUP_STORAGE_KEY = 'programCommandAySetup';
         let activeDepartmentProfile = null;
         let scheduleStorageKeyPrefix = 'designSchedulerData_';
+        const DEFAULT_CLSS_IMPORT_MATCHING_ORDER = [
+            'course+section+instructor+quarter',
+            'course+quarter+instructor',
+            'course+quarter'
+        ];
+        const DEFAULT_SCHEDULER_DAY_PATTERNS = [
+            { id: 'MW', label: 'Monday / Wednesday', aliases: ['MW', 'WM'] },
+            { id: 'TR', label: 'Tuesday / Thursday', aliases: ['TR', 'RT', 'TH', 'TTH'] }
+        ];
+        const DEFAULT_SCHEDULER_TIME_SLOTS = [
+            { id: '10:00-12:20', label: '10:00-12:20', aliases: ['10:00-12:00'], startMinutes: 10 * 60, endMinutes: (12 * 60) + 20 },
+            { id: '13:00-15:20', label: '13:00-15:20', aliases: ['13:00-15:00'], startMinutes: 13 * 60, endMinutes: (15 * 60) + 20 },
+            { id: '16:00-18:20', label: '16:00-18:20', aliases: ['16:00-18:00'], startMinutes: 16 * 60, endMinutes: (18 * 60) + 20 }
+        ];
+        const DEFAULT_SCHEDULER_ROOM_LABELS = {
+            '206': '206 UX Lab',
+            '207': '207 Media Lab',
+            '209': '209 Mac Lab',
+            '210': '210 Mac Lab',
+            '212': '212 Project Lab',
+            'CEB 102': 'CEB 102',
+            'CEB 104': 'CEB 104'
+        };
+        let schedulerDayPatterns = DEFAULT_SCHEDULER_DAY_PATTERNS.map((pattern) => ({
+            ...pattern,
+            aliases: Array.isArray(pattern.aliases) ? pattern.aliases.slice() : []
+        }));
+        let schedulerTimeSlots = DEFAULT_SCHEDULER_TIME_SLOTS.map((slot) => ({
+            ...slot,
+            aliases: Array.isArray(slot.aliases) ? slot.aliases.slice() : []
+        }));
+        let schedulerRoomLabels = { ...DEFAULT_SCHEDULER_ROOM_LABELS };
+        let CLSS_IMPORT_PROFILE_FACULTY_ALIASES = {};
+        let CLSS_IMPORT_PROFILE_COURSE_ALIASES = {};
+        let CLSS_IMPORT_PROFILE_COURSE_ALIAS_LOOKUP = {};
+        let CLSS_IMPORT_MATCHING_ORDER = DEFAULT_CLSS_IMPORT_MATCHING_ORDER.slice();
+
+        function normalizeSchedulerLookupKey(value) {
+            return String(value || '')
+                .toUpperCase()
+                .replace(/\s+/g, '')
+                .replace(/[^A-Z0-9:-]/g, '');
+        }
+
+        function escapeRegex(text) {
+            return String(text || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        }
+
+        function parseSchedulerRangeToMinutes(rangeValue) {
+            const match = String(rangeValue || '').trim().match(/^(\d{1,2}):(\d{2})\s*-\s*(\d{1,2}):(\d{2})$/);
+            if (!match) return { startMinutes: null, endMinutes: null };
+
+            const startHours = Number(match[1]);
+            const startMinutes = Number(match[2]);
+            const endHours = Number(match[3]);
+            const endMinutes = Number(match[4]);
+            if ([startHours, startMinutes, endHours, endMinutes].some((value) => !Number.isFinite(value))) {
+                return { startMinutes: null, endMinutes: null };
+            }
+            return {
+                startMinutes: (startHours * 60) + startMinutes,
+                endMinutes: (endHours * 60) + endMinutes
+            };
+        }
+
+        function parseSchedulerDayPatterns(rawDayPatterns) {
+            const list = Array.isArray(rawDayPatterns) ? rawDayPatterns : [];
+            const parsed = list
+                .map((entry, index) => {
+                    if (typeof entry === 'string') {
+                        const id = entry.trim().toUpperCase();
+                        if (!id) return null;
+                        return { id, label: id, aliases: [id] };
+                    }
+                    if (!entry || typeof entry !== 'object') return null;
+                    const id = String(entry.id || entry.key || entry.value || '').trim().toUpperCase();
+                    if (!id) return null;
+                    const label = String(entry.label || entry.name || id).trim() || id;
+                    const aliases = Array.isArray(entry.aliases) ? entry.aliases : [];
+                    return {
+                        id,
+                        label,
+                        aliases: [...new Set([id, ...aliases.map((alias) => String(alias || '').trim().toUpperCase()).filter(Boolean)])]
+                    };
+                })
+                .filter(Boolean);
+            return parsed.length ? parsed : DEFAULT_SCHEDULER_DAY_PATTERNS.map((pattern) => ({
+                ...pattern,
+                aliases: Array.isArray(pattern.aliases) ? pattern.aliases.slice() : []
+            }));
+        }
+
+        function parseSchedulerTimeSlots(rawTimeSlots) {
+            const list = Array.isArray(rawTimeSlots) ? rawTimeSlots : [];
+            const parsed = list
+                .map((entry, index) => {
+                    if (typeof entry === 'string') {
+                        const id = entry.trim();
+                        if (!id) return null;
+                        const range = parseSchedulerRangeToMinutes(id);
+                        return {
+                            id,
+                            label: id,
+                            aliases: [id],
+                            startMinutes: range.startMinutes,
+                            endMinutes: range.endMinutes
+                        };
+                    }
+                    if (!entry || typeof entry !== 'object') return null;
+                    const id = String(entry.id || entry.value || entry.slot || '').trim();
+                    if (!id) return null;
+                    const label = String(entry.label || entry.name || id).trim() || id;
+                    const aliases = Array.isArray(entry.aliases) ? entry.aliases : [];
+                    const rangeFromId = parseSchedulerRangeToMinutes(id);
+                    const startMinutes = Number.isFinite(Number(entry.startMinutes))
+                        ? Number(entry.startMinutes)
+                        : rangeFromId.startMinutes;
+                    const endMinutes = Number.isFinite(Number(entry.endMinutes))
+                        ? Number(entry.endMinutes)
+                        : rangeFromId.endMinutes;
+                    return {
+                        id,
+                        label,
+                        aliases: [...new Set([id, ...aliases.map((alias) => String(alias || '').trim()).filter(Boolean)])],
+                        startMinutes: Number.isFinite(startMinutes) ? startMinutes : null,
+                        endMinutes: Number.isFinite(endMinutes) ? endMinutes : null
+                    };
+                })
+                .filter(Boolean);
+            return parsed.length ? parsed : DEFAULT_SCHEDULER_TIME_SLOTS.map((slot) => ({
+                ...slot,
+                aliases: Array.isArray(slot.aliases) ? slot.aliases.slice() : []
+            }));
+        }
+
+        function getSchedulerDayPatterns() {
+            return Array.isArray(schedulerDayPatterns) && schedulerDayPatterns.length
+                ? schedulerDayPatterns
+                : DEFAULT_SCHEDULER_DAY_PATTERNS;
+        }
+
+        function getSchedulerDayIds() {
+            return getSchedulerDayPatterns().map((pattern) => pattern.id);
+        }
+
+        function getSchedulerDayLabel(dayId) {
+            const normalized = String(dayId || '').trim().toUpperCase();
+            const match = getSchedulerDayPatterns().find((pattern) => pattern.id === normalized);
+            return match?.label || normalized;
+        }
+
+        function getSchedulerDayRegexTokens() {
+            const tokens = new Set(['M', 'T', 'W', 'R', 'F', 'TH', 'TTH']);
+            getSchedulerDayPatterns().forEach((pattern) => {
+                [pattern.id, ...(Array.isArray(pattern.aliases) ? pattern.aliases : [])]
+                    .map((value) => String(value || '').trim().toUpperCase())
+                    .filter(Boolean)
+                    .forEach((alias) => tokens.add(alias));
+            });
+            return [...tokens].sort((a, b) => b.length - a.length);
+        }
+
+        function getSchedulerTimeSlots() {
+            return Array.isArray(schedulerTimeSlots) && schedulerTimeSlots.length
+                ? schedulerTimeSlots
+                : DEFAULT_SCHEDULER_TIME_SLOTS;
+        }
+
+        function getSchedulerTimeSlotIds() {
+            return getSchedulerTimeSlots().map((slot) => slot.id);
+        }
+
+        function getSchedulerTimeSlotByAlias(value) {
+            const lookup = normalizeSchedulerLookupKey(value);
+            if (!lookup) return null;
+            return getSchedulerTimeSlots().find((slot) => {
+                const aliases = [slot.id, ...(Array.isArray(slot.aliases) ? slot.aliases : [])];
+                return aliases.some((alias) => normalizeSchedulerLookupKey(alias) === lookup);
+            }) || null;
+        }
+
+        function getSchedulerTimeSlotIdForClockRange(startMinutes, endMinutes) {
+            const exact = getSchedulerTimeSlots().find((slot) =>
+                Number.isFinite(slot.startMinutes)
+                && Number.isFinite(slot.endMinutes)
+                && slot.startMinutes === startMinutes
+                && slot.endMinutes === endMinutes
+            );
+            if (exact) return exact.id;
+
+            const startMatch = getSchedulerTimeSlots().find((slot) =>
+                Number.isFinite(slot.startMinutes)
+                && slot.startMinutes === startMinutes
+            );
+            return startMatch ? startMatch.id : '';
+        }
+
+        function getSchedulerRoomOptionList() {
+            const ordered = Array.isArray(CLSS_IMPORT_ROOM_PRIORITY) ? CLSS_IMPORT_ROOM_PRIORITY.slice() : [];
+            const allowed = Array.from(CLSS_IMPORT_ALLOWED_ROOMS || []);
+            const merged = [...new Set([...ordered, ...allowed])].filter(Boolean);
+            return merged.length ? merged : Object.keys(DEFAULT_SCHEDULER_ROOM_LABELS);
+        }
+
+        function normalizeRoomLookupKey(room) {
+            return String(room || '').toUpperCase().replace(/[^A-Z0-9]/g, '');
+        }
+
+        function findConfiguredRoomInText(text) {
+            const candidateText = String(text || '');
+            const compactCandidate = normalizeRoomLookupKey(candidateText);
+            const rooms = getSchedulerRoomOptionList().slice().sort((a, b) => b.length - a.length);
+
+            for (const room of rooms) {
+                const roomValue = String(room || '').trim();
+                if (!roomValue) continue;
+
+                const roomRegex = new RegExp(`\\b${escapeRegex(roomValue).replace(/\s+/g, '\\s*')}\\b`, 'i');
+                if (roomRegex.test(candidateText)) {
+                    return roomValue;
+                }
+
+                const compactRoom = normalizeRoomLookupKey(roomValue);
+                if (compactRoom && compactCandidate.includes(compactRoom)) {
+                    return roomValue;
+                }
+            }
+
+            return '';
+        }
+
+        function getSchedulerRoomHeaderLabel(roomCode) {
+            const code = String(roomCode || '').trim();
+            return schedulerRoomLabels[code] || code;
+        }
+
+        function normalizeCourseAliasLookupKey(code) {
+            return normalizeSchedulerLookupKey(normalizeCourseCode(code));
+        }
+
+        function buildClssImportCourseAliasLookup(aliasMap) {
+            const lookup = {};
+            Object.entries(aliasMap || {}).forEach(([alias, canonical]) => {
+                const aliasKey = normalizeCourseAliasLookupKey(alias);
+                const canonicalCode = normalizeCourseCode(canonical);
+                if (!aliasKey || !canonicalCode) return;
+                lookup[aliasKey] = canonicalCode;
+            });
+            return lookup;
+        }
+
+        function resolveClssImportCourseCode(code) {
+            const normalized = normalizeCourseCode(code);
+            const key = normalizeCourseAliasLookupKey(normalized);
+            return CLSS_IMPORT_PROFILE_COURSE_ALIAS_LOOKUP[key] || normalized;
+        }
+
+        function getClssImportMatchingOrder() {
+            const configured = Array.isArray(CLSS_IMPORT_MATCHING_ORDER)
+                ? CLSS_IMPORT_MATCHING_ORDER.map((value) => String(value || '').trim()).filter(Boolean)
+                : [];
+            return configured.length ? configured : DEFAULT_CLSS_IMPORT_MATCHING_ORDER.slice();
+        }
 
         function getActiveDepartmentIdentity() {
             const identity = activeDepartmentProfile?.identity || {};
@@ -4622,6 +4885,27 @@
         function applyDepartmentProfileSchedulerOverrides(profile) {
             if (!profile || typeof profile !== 'object') return;
             const scheduler = profile.scheduler || {};
+            const clssImport = profile.import && profile.import.clss && typeof profile.import.clss === 'object'
+                ? profile.import.clss
+                : {};
+
+            schedulerDayPatterns = parseSchedulerDayPatterns(scheduler.dayPatterns);
+            schedulerTimeSlots = parseSchedulerTimeSlots(scheduler.timeSlots);
+
+            const configuredRoomLabels = scheduler.roomLabels && typeof scheduler.roomLabels === 'object'
+                ? scheduler.roomLabels
+                : {};
+            const normalizedRoomLabels = {};
+            Object.entries(configuredRoomLabels).forEach(([code, label]) => {
+                const normalizedCode = String(code || '').trim();
+                const normalizedLabel = String(label || '').trim();
+                if (!normalizedCode || !normalizedLabel) return;
+                normalizedRoomLabels[normalizedCode] = normalizedLabel;
+            });
+            schedulerRoomLabels = {
+                ...DEFAULT_SCHEDULER_ROOM_LABELS,
+                ...normalizedRoomLabels
+            };
 
             if (typeof scheduler.storageKeyPrefix === 'string' && scheduler.storageKeyPrefix.trim()) {
                 scheduleStorageKeyPrefix = scheduler.storageKeyPrefix.trim();
@@ -4630,10 +4914,29 @@
             const allowedRooms = Array.isArray(scheduler.allowedRooms)
                 ? scheduler.allowedRooms.map((room) => String(room || '').trim()).filter(Boolean)
                 : [];
-            if (allowedRooms.length > 0) {
-                CLSS_IMPORT_ROOM_PRIORITY = allowedRooms.slice();
-                CLSS_IMPORT_ALLOWED_ROOMS = new Set(allowedRooms);
+            const roomPriority = Array.isArray(clssImport.roomMatchPriority)
+                ? clssImport.roomMatchPriority.map((room) => String(room || '').trim()).filter(Boolean)
+                : [];
+            const mergedRooms = [...new Set([
+                ...roomPriority,
+                ...allowedRooms
+            ])];
+
+            if (mergedRooms.length > 0) {
+                CLSS_IMPORT_ROOM_PRIORITY = roomPriority.length ? roomPriority.slice() : mergedRooms.slice();
+                CLSS_IMPORT_ALLOWED_ROOMS = new Set(mergedRooms);
             }
+
+            CLSS_IMPORT_PROFILE_FACULTY_ALIASES = clssImport.facultyAliases && typeof clssImport.facultyAliases === 'object'
+                ? { ...clssImport.facultyAliases }
+                : {};
+            CLSS_IMPORT_PROFILE_COURSE_ALIASES = clssImport.courseAliases && typeof clssImport.courseAliases === 'object'
+                ? { ...clssImport.courseAliases }
+                : {};
+            CLSS_IMPORT_PROFILE_COURSE_ALIAS_LOOKUP = buildClssImportCourseAliasLookup(CLSS_IMPORT_PROFILE_COURSE_ALIASES);
+            CLSS_IMPORT_MATCHING_ORDER = Array.isArray(clssImport.preferredMatchingOrder)
+                ? clssImport.preferredMatchingOrder.map((value) => String(value || '').trim()).filter(Boolean)
+                : DEFAULT_CLSS_IMPORT_MATCHING_ORDER.slice();
         }
 
         async function initializeDepartmentProfileContext() {
@@ -4659,6 +4962,7 @@
 
                 applyDepartmentProfileToHeader(activeDepartmentProfile);
                 applyDepartmentProfileSchedulerOverrides(activeDepartmentProfile);
+                refreshFacultyAliasMap();
 
                 if (Array.isArray(snapshot?.warnings) && snapshot.warnings.length) {
                     console.warn('Department profile warnings:', snapshot.warnings);
@@ -4671,24 +4975,135 @@
             }
         }
 
-        function buildFacultyAliasMap() {
-            const aliasMap = {};
-            for (const [alias, info] of Object.entries(facultyColors)) {
-                const canonical = info?.name || alias;
-                aliasMap[alias] = canonical;
-                aliasMap[canonical] = canonical;
-            }
-            aliasMap.Online = 'Barton/Pettigrew';
-            return aliasMap;
+        function normalizeFacultyAliasArtifacts(name) {
+            return String(name || '')
+                .replace(/\u00a0/g, ' ')
+                .trim()
+                .replace(/^([A-Za-z])\.\s*(PAS|IND)([A-Za-z]{2,})$/i, '$1.$3')
+                .replace(/^([A-Za-z])\s+(PAS|IND)\s+([A-Za-z]{2,})$/i, '$1.$3')
+                .replace(/^([A-Za-z])\s+(PAS|IND)([A-Za-z]{2,})$/i, '$1.$3')
+                .replace(/^([A-Za-z]+)\s+(PAS|IND)([A-Za-z]{2,})$/i, '$1 $3')
+                .split(/\s+/)
+                .map((token) => token.replace(/^(PAS|IND)([A-Za-z]{3,})$/i, '$2'))
+                .join(' ')
+                .trim();
         }
 
-        const facultyAliasMap = buildFacultyAliasMap();
+        function normalizeFacultyAliasLookupKey(name) {
+            const compact = normalizeFacultyAliasArtifacts(name)
+                .toLowerCase()
+                .replace(/[^a-z0-9]/g, '');
+            if (!compact) return '';
+            return compact
+                .replace(/^([a-z])(pas|ind)([a-z]{3,})$/, '$1$3')
+                .replace(/^(pas|ind)([a-z]{3,})$/, '$2');
+        }
+
+        function buildFacultyAliasVariants(name) {
+            const cleaned = normalizeFacultyAliasArtifacts(name);
+            if (!cleaned) return [];
+
+            const variants = new Set([cleaned]);
+            const commaMatch = cleaned.match(/^([^,]+),\s*(.+)$/);
+            if (commaMatch) {
+                const last = commaMatch[1].trim();
+                const first = commaMatch[2].trim();
+                if (first && last) {
+                    variants.add(`${first} ${last}`);
+                    variants.add(`${first.charAt(0).toUpperCase()}.${last.replace(/\s+/g, '')}`);
+                }
+            } else {
+                const parts = cleaned.split(/\s+/).filter(Boolean);
+                if (parts.length >= 2) {
+                    const first = parts[0];
+                    const last = parts[parts.length - 1];
+                    variants.add(`${first.charAt(0).toUpperCase()}.${last.replace(/\s+/g, '')}`);
+                    variants.add(`${last}, ${first}`);
+                }
+            }
+
+            return [...variants];
+        }
+
+        function readAllAySetupFacultyNames() {
+            try {
+                const raw = localStorage.getItem(AY_SETUP_STORAGE_KEY);
+                if (!raw) return [];
+                const parsed = JSON.parse(raw);
+                if (!parsed || typeof parsed !== 'object') return [];
+                const names = [];
+                Object.values(parsed).forEach((yearData) => {
+                    const faculty = Array.isArray(yearData?.faculty) ? yearData.faculty : [];
+                    faculty.forEach((entry) => {
+                        const name = String(entry?.name || '').trim();
+                        if (name) names.push(name);
+                    });
+                });
+                return names;
+            } catch (error) {
+                return [];
+            }
+        }
+
+        function buildFacultyAliasMap() {
+            const exactMap = {};
+            const lookupMap = {};
+
+            const addAlias = (alias, canonical) => {
+                const aliasText = String(alias || '').trim();
+                const canonicalText = normalizeFacultyAliasArtifacts(canonical) || String(canonical || '').trim();
+                if (!aliasText || !canonicalText) return;
+
+                exactMap[aliasText] = canonicalText;
+                exactMap[aliasText.toLowerCase()] = canonicalText;
+
+                const aliasKey = normalizeFacultyAliasLookupKey(aliasText);
+                if (aliasKey && !lookupMap[aliasKey]) {
+                    lookupMap[aliasKey] = canonicalText;
+                }
+            };
+
+            Object.entries(facultyColors).forEach(([alias, info]) => {
+                const canonical = info?.name || alias;
+                buildFacultyAliasVariants(alias).forEach((variant) => addAlias(variant, canonical));
+                buildFacultyAliasVariants(canonical).forEach((variant) => addAlias(variant, canonical));
+            });
+
+            readAllAySetupFacultyNames().forEach((name) => {
+                const canonical = normalizeFacultyAliasArtifacts(name);
+                buildFacultyAliasVariants(canonical).forEach((variant) => addAlias(variant, canonical));
+            });
+
+            const profileAliases = CLSS_IMPORT_PROFILE_FACULTY_ALIASES && typeof CLSS_IMPORT_PROFILE_FACULTY_ALIASES === 'object'
+                ? CLSS_IMPORT_PROFILE_FACULTY_ALIASES
+                : {};
+            Object.entries(profileAliases).forEach(([alias, canonical]) => {
+                const canonicalText = normalizeFacultyAliasArtifacts(canonical);
+                addAlias(alias, canonicalText);
+                buildFacultyAliasVariants(alias).forEach((variant) => addAlias(variant, canonicalText));
+                buildFacultyAliasVariants(canonicalText).forEach((variant) => addAlias(variant, canonicalText));
+            });
+
+            addAlias('Online', 'Barton/Pettigrew');
+            return { exactMap, lookupMap };
+        }
+
+        let facultyAliasMap = {};
+        let facultyAliasLookupMap = {};
+
+        function refreshFacultyAliasMap() {
+            const maps = buildFacultyAliasMap();
+            facultyAliasMap = maps.exactMap;
+            facultyAliasLookupMap = maps.lookupMap;
+        }
+
+        refreshFacultyAliasMap();
 
         function getCanonicalFacultyName(name) {
             const raw = typeof name === 'string' ? name.trim() : '';
             if (!raw) return 'TBD';
 
-            const directMatch = facultyAliasMap[raw];
+            const directMatch = facultyAliasMap[raw] || facultyAliasMap[raw.toLowerCase()];
             if (directMatch) return directMatch;
 
             const lower = raw.toLowerCase();
@@ -4697,22 +5112,18 @@
             if (lower.includes('tbd')) return 'TBD';
 
             // Alias fallback that ignores punctuation/spacing.
-            const compactRaw = lower.replace(/[^a-z0-9]/g, '');
+            const compactRaw = normalizeFacultyAliasLookupKey(raw);
             const compactVariants = new Set([compactRaw]);
             compactVariants.add(compactRaw.replace(/^([a-z])(pas|ind)([a-z]{3,})$/, '$1$3'));
             compactVariants.add(compactRaw.replace(/^(pas|ind)([a-z]{3,})$/, '$2'));
-            for (const [alias, canonical] of Object.entries(facultyAliasMap)) {
-                const compactAlias = alias.toLowerCase().replace(/[^a-z0-9]/g, '');
-                if (compactVariants.has(compactAlias)) return canonical;
+            for (const compactAlias of compactVariants) {
+                if (!compactAlias) continue;
+                const canonical = facultyAliasLookupMap[compactAlias];
+                if (canonical) return canonical;
             }
 
-            const cleanedRaw = raw
-                .replace(/^([A-Za-z])\.\s*(PAS|IND)([A-Za-z]{2,})$/i, '$1.$3')
-                .replace(/^([A-Za-z])\s+(PAS|IND)\s+([A-Za-z]{2,})$/i, '$1.$3')
-                .replace(/^([A-Za-z])\s+(PAS|IND)([A-Za-z]{2,})$/i, '$1.$3')
-                .replace(/^([A-Za-z]+)\s+(PAS|IND)([A-Za-z]{2,})$/i, '$1 $3')
-                .trim();
-            const cleanedMatch = facultyAliasMap[cleanedRaw];
+            const cleanedRaw = normalizeFacultyAliasArtifacts(raw);
+            const cleanedMatch = facultyAliasMap[cleanedRaw] || facultyAliasMap[cleanedRaw.toLowerCase()];
             if (cleanedMatch) return cleanedMatch;
 
             return cleanedRaw || raw;
@@ -5354,6 +5765,10 @@
         function renderSchedule(quarter) {
             const grid = document.getElementById('scheduleGrid');
             const data = scheduleData[quarter];
+            const days = getSchedulerDayIds();
+            const times = getSchedulerTimeSlotIds();
+            const rooms = getSchedulerRoomOptionList();
+            grid.style.gridTemplateColumns = `100px repeat(${rooms.length}, 1fr)`;
 
             // Clear grid safely
             while (grid.firstChild) {
@@ -5361,17 +5776,13 @@
             }
 
             // Header row - create elements safely
-            const headers = ['Time', '206 UX Lab', '207 Media Lab', '209 Mac Lab', '210 Mac Lab', '212 Project Lab', 'CEB 102', 'CEB 104'];
+            const headers = ['Time', ...rooms.map((room) => getSchedulerRoomHeaderLabel(room))];
             headers.forEach(text => {
                 const header = document.createElement('div');
                 header.className = 'grid-header';
                 header.textContent = text;
                 grid.appendChild(header);
             });
-
-            const times = ['10:00-12:20', '13:00-15:20', '16:00-18:20'];
-            const days = ['MW', 'TR'];
-            const rooms = ['206', '207', '209', '210', '212', 'CEB 102', 'CEB 104'];
 
             days.forEach((day, dayIndex) => {
                 // Add divider for each day section
@@ -5993,9 +6404,9 @@
 
             // Collect all courses from the quarter
             let allCourses = [];
-            ['MW', 'TR'].forEach(day => {
+            getSchedulerDayIds().forEach((day) => {
                 if (data[day]) {
-                    ['10:00-12:20', '13:00-15:20', '16:00-18:20'].forEach(time => {
+                    getSchedulerTimeSlotIds().forEach((time) => {
                         if (data[day][time]) {
                             allCourses = allCourses.concat(data[day][time]);
                         }
@@ -6259,7 +6670,8 @@
         }
 
         function isSchedulableDay(day) {
-            return day === 'MW' || day === 'TR';
+            const normalized = String(day || '').trim().toUpperCase();
+            return getSchedulerDayIds().includes(normalized);
         }
 
         function getQuarterCourses(quarter) {
@@ -6271,11 +6683,7 @@
         }
 
         function formatConflictSlot(day, time) {
-            const dayLabel = day === 'MW'
-                ? 'Monday & Wednesday'
-                : day === 'TR'
-                    ? 'Tuesday & Thursday'
-                    : day;
+            const dayLabel = getSchedulerDayLabel(day) || day;
             return `${dayLabel}, ${formatTime(time)}`;
         }
 
@@ -6789,9 +7197,9 @@
         function renderConflictSolver(quarter) {
             const solverList = document.getElementById('conflictSolverList');
             const data = scheduleData[quarter] || {};
-            const days = ['MW', 'TR'];
-            const times = ['10:00-12:20', '13:00-15:20', '16:00-18:20'];
-            const rooms = ['206', '209', '210', '212', 'CEB 102', 'CEB 104'];
+            const days = getSchedulerDayIds();
+            const times = getSchedulerTimeSlotIds();
+            const rooms = getSchedulerRoomOptionList().filter((room) => room !== '207');
 
             refreshConflictData();
 
@@ -7054,8 +7462,6 @@
         }
 
         const UTILIZATION_ROOMS = ['206', '209', '210', '212', 'CEB 102', 'CEB 104'];
-        const UTILIZATION_DAYS = ['MW', 'TR'];
-        const UTILIZATION_TIMES = ['10:00-12:20', '13:00-15:20', '16:00-18:20'];
         const CHENEY_ONLY_COURSES = new Set(['DESN 100', 'DESN 200', 'DESN 216']);
         const ROOM_212_ONLY_COURSES = new Set(['DESN 301', 'DESN 359', 'DESN 401']);
         const ROOM_212_OVERFLOW_COURSES = new Set(['DESN 100', 'DESN 200']);
@@ -7064,7 +7470,7 @@
             return flattenQuarterData(data || {})
                 .filter((course) =>
                     isSchedulableDay(course.day)
-                    && UTILIZATION_TIMES.includes(course.time)
+                    && getSchedulerTimeSlotIds().includes(course.time)
                     && UTILIZATION_ROOMS.includes(String(course.room || '').trim())
                 )
                 .map((course) => ({
@@ -7169,7 +7575,7 @@
             const usedRoomSlots = new Set(
                 schedulableCourses.map((course) => `${course.day}|${course.time}|${course.room}`)
             ).size;
-            const totalRoomSlots = UTILIZATION_ROOMS.length * UTILIZATION_DAYS.length * UTILIZATION_TIMES.length;
+            const totalRoomSlots = UTILIZATION_ROOMS.length * getSchedulerDayIds().length * getSchedulerTimeSlotIds().length;
             const roomUtilizationRate = totalRoomSlots > 0 ? usedRoomSlots / totalRoomSlots : 0;
 
             const adjunctCapacityCredits = Math.max(adjunctTarget, adjunctRosterCapacityCredits, assignedAdjunctCredits);
@@ -8137,7 +8543,7 @@
         // CLSS IMPORT (REVIEW-FIRST)
         // ============================================
 
-        let CLSS_IMPORT_ROOM_PRIORITY = ['206', '207', '209', '210', '212', 'CEB 102', 'CEB 104'];
+        let CLSS_IMPORT_ROOM_PRIORITY = Object.keys(DEFAULT_SCHEDULER_ROOM_LABELS);
         let CLSS_IMPORT_ALLOWED_ROOMS = new Set(CLSS_IMPORT_ROOM_PRIORITY);
         const CLSS_IMPORT_QUARTERS = ['fall', 'winter', 'spring'];
         const CLSS_IMPORT_QUARTER_LABELS = {
@@ -8160,6 +8566,10 @@
         let clssImportOcrLibraryPromise = null;
         let clssImportPriorYearPlacementIndexCache = new Map();
         let clssImportLastApplyReport = null;
+
+        function getClssImportRoomOptionList() {
+            return getSchedulerRoomOptionList();
+        }
 
         function openClssImportModal() {
             const modal = document.getElementById('clssImportModal');
@@ -8417,6 +8827,7 @@
                 showToast('OCR is already running for uploaded screenshots. Please wait...', 'error');
                 return;
             }
+            refreshFacultyAliasMap();
 
             const pngCount = (document.getElementById('clssImportPngInput')?.files || []).length;
             let parseSources = getClssImportParseSources();
@@ -8757,7 +9168,7 @@
             const quarter = row?.reviewQuarter || row?.targetQuarter;
             if (!CLSS_IMPORT_QUARTERS.includes(quarter)) return null;
 
-            const code = normalizeCourseCode(row?.code);
+            const code = resolveClssImportCourseCode(row?.code);
             if (!code) return null;
 
             const index = buildClssImportPriorYearPlacementIndexForTargetYear(targetYear);
@@ -8765,7 +9176,7 @@
             if (!candidates.length) return null;
 
             const canonicalInstructor = getCanonicalFacultyName(row?.instructor || 'TBD');
-            const section = String(row?.section || '').trim();
+            const section = String(row?.section || '').trim().toUpperCase();
             const desiredDay = String(row?.reviewDay || row?.schedulerDay || '').trim();
             const desiredTime = String(row?.reviewTime || row?.schedulerTime || '').trim();
 
@@ -8774,22 +9185,58 @@
                 .map((candidate) => {
                     let score = 0;
                     if (canonicalInstructor && canonicalInstructor !== 'TBD' && candidate.instructor === canonicalInstructor) score += 100;
-                    if (section && candidate.section && candidate.section === section) score += 60;
+                    if (section && candidate.section && String(candidate.section || '').trim().toUpperCase() === section) score += 60;
                     if (desiredDay && candidate.day === desiredDay) score += 30;
                     if (desiredTime && candidate.time === desiredTime) score += 30;
                     if (desiredDay && desiredTime && candidate.day === desiredDay && candidate.time === desiredTime) score += 25;
                     if (candidate.room && CLSS_IMPORT_ALLOWED_ROOMS.has(candidate.room)) score += 5;
                     return { candidate, score };
-                })
-                .sort((a, b) => b.score - a.score);
+                });
 
             if (!scored.length) return null;
 
-            const bestMatch = scored[0];
+            const strategyMatchers = {
+                'course+section+instructor+quarter': ({ candidate }) =>
+                    Boolean(
+                        section
+                        && candidate?.section
+                        && String(candidate.section || '').trim().toUpperCase() === section
+                        && canonicalInstructor
+                        && canonicalInstructor !== 'TBD'
+                        && candidate.instructor === canonicalInstructor
+                    ),
+                'course+quarter+instructor': ({ candidate }) =>
+                    Boolean(
+                        canonicalInstructor
+                        && canonicalInstructor !== 'TBD'
+                        && candidate.instructor === canonicalInstructor
+                    ),
+                'course+quarter': () => true
+            };
+
+            let strategyUsed = 'score-fallback';
+            let ranked = [];
+            const preferredOrder = getClssImportMatchingOrder();
+            preferredOrder.some((strategy) => {
+                const matcher = strategyMatchers[strategy];
+                if (typeof matcher !== 'function') return false;
+                const filtered = scored.filter((entry) => matcher(entry));
+                if (!filtered.length) return false;
+                ranked = filtered;
+                strategyUsed = strategy;
+                return true;
+            });
+
+            if (!ranked.length) {
+                ranked = scored.slice();
+            }
+
+            ranked.sort((a, b) => b.score - a.score);
+            const bestMatch = ranked[0];
             const best = bestMatch.candidate;
             const uniqueCodeMatch = scored.length === 1;
             const matchedInstructor = best.instructor === canonicalInstructor && canonicalInstructor !== 'TBD';
-            const matchedSection = Boolean(section && best.section && best.section === section);
+            const matchedSection = Boolean(section && best.section && String(best.section || '').trim().toUpperCase() === section);
             const strongMatch = matchedInstructor || matchedSection || uniqueCodeMatch;
             return {
                 sourceYear: index?.previousYear || '',
@@ -8800,7 +9247,8 @@
                 matchedInstructor,
                 matchedSection,
                 strongMatch,
-                score: bestMatch.score
+                score: bestMatch.score,
+                matchStrategy: strategyUsed
             };
         }
 
@@ -8843,7 +9291,8 @@
                     suggestion.sourceYear ? `from ${suggestion.sourceYear}` : 'from prior year',
                     suggestion.day && suggestion.time ? `${suggestion.day} ${suggestion.time}` : '',
                     suggestion.room ? suggestion.room : 'auto room',
-                    suggestion.strongMatch ? 'matched by prior-year roster' : ''
+                    suggestion.strongMatch ? 'matched by prior-year roster' : '',
+                    suggestion.matchStrategy ? `strategy ${suggestion.matchStrategy}` : ''
                 ].filter(Boolean).join(' • ');
 
                 row.notes = [...new Set([...(row.notes || []), `Auto-matched prior-year placement (${suggestionDetails})`])];
@@ -8929,8 +9378,9 @@
                 const autoRoom = reviewRoomValue === 'AUTO' || (!reviewRoomValue && reviewInPerson);
                 const effectiveRoom = autoRoom ? '' : reviewRoomValue;
                 const manualNotes = [];
+                const dayHint = getSchedulerDayPatterns().map((pattern) => pattern.id).join('/');
 
-                if (!effectiveDay) manualNotes.push('Select day pattern (MW/TR)');
+                if (!effectiveDay) manualNotes.push(`Select day pattern (${dayHint || 'scheduler'})`);
                 if (!effectiveTime) manualNotes.push('Select scheduler time slot');
                 if (autoRoom) manualNotes.push('Room will auto-assign at import');
 
@@ -9086,9 +9536,11 @@
             const daySelect = document.createElement('select');
             daySelect.title = 'Day pattern';
             [
-                { value: '', label: 'Day (MW/TR)' },
-                { value: 'MW', label: 'MW' },
-                { value: 'TR', label: 'TR' }
+                { value: '', label: 'Day pattern' },
+                ...getSchedulerDayPatterns().map((pattern) => ({
+                    value: pattern.id,
+                    label: `${pattern.id} · ${pattern.label || pattern.id}`
+                }))
             ].forEach(({ value, label: optionLabel }) => {
                 const option = document.createElement('option');
                 option.value = value;
@@ -9104,9 +9556,10 @@
             timeSelect.title = 'Scheduler time slot';
             [
                 { value: '', label: 'Time slot' },
-                { value: '10:00-12:20', label: '10:00-12:20' },
-                { value: '13:00-15:20', label: '13:00-15:20' },
-                { value: '16:00-18:20', label: '16:00-18:20' }
+                ...getSchedulerTimeSlots().map((slot) => ({
+                    value: slot.id,
+                    label: String(slot.label || slot.id)
+                }))
             ].forEach(({ value, label: optionLabel }) => {
                 const option = document.createElement('option');
                 option.value = value;
@@ -9124,17 +9577,12 @@
             roomRow.className = 'row';
             const roomSelect = document.createElement('select');
             roomSelect.title = 'Room';
-            [
+            const roomOptions = [
                 { value: '', label: 'Room (parser/none)' },
                 { value: 'AUTO', label: 'Auto-assign open room' },
-                { value: '206', label: '206' },
-                { value: '207', label: '207' },
-                { value: '209', label: '209' },
-                { value: '210', label: '210' },
-                { value: '212', label: '212' },
-                { value: 'CEB 102', label: 'CEB 102' },
-                { value: 'CEB 104', label: 'CEB 104' }
-            ].forEach(({ value, label: optionLabel }) => {
+                ...getClssImportRoomOptionList().map((room) => ({ value: room, label: room }))
+            ];
+            roomOptions.forEach(({ value, label: optionLabel }) => {
                 const option = document.createElement('option');
                 option.value = value;
                 option.textContent = optionLabel;
@@ -9175,7 +9623,8 @@
             } else if (effectiveRow.effectiveStatus === 'needs-review' && !disableSlotFields) {
                 const hintRow = document.createElement('div');
                 hintRow.className = 'clss-import-resolve-label';
-                hintRow.textContent = 'Tip: set placement to In-person, then choose MW/TR + time (room can be Auto).';
+                const dayHint = getSchedulerDayPatterns().map((pattern) => pattern.id).join('/');
+                hintRow.textContent = `Tip: set placement to In-person, then choose ${dayHint || 'a day pattern'} + time (room can be Auto).`;
                 wrapper.appendChild(hintRow);
             }
 
@@ -9409,7 +9858,7 @@
                 return null;
             }
 
-            const code = normalizeCourseCode(match[1]);
+            const code = resolveClssImportCourseCode(match[1]);
             let titleAndMaybeRow = match[2].replace(/\s+/g, ' ').trim();
             let inlineRowText = '';
 
@@ -9437,7 +9886,7 @@
         function parseClssDetailRow(course, rawRowText) {
             const rawText = String(rawRowText || '').replace(/\s+/g, ' ').trim();
             const notes = [];
-            const code = normalizeCourseCode(course?.code || '');
+            const code = resolveClssImportCourseCode(course?.code || '');
             const title = String(course?.title || '').trim();
 
             const sectionMatch = rawText.match(/\b(\d{3}[A-Z]?)(?:\s*\(([^)]+)\))?/i);
@@ -9590,7 +10039,14 @@
                 return { raw: '', classification: 'none', dayPattern: '', timeSlot: '', matchEndIndex: -1, singleDay: false };
             }
 
-            if (/\b(online|web|async|asynch|asynchronous)\b/i.test(text) && !/\b(MW|TR|WM|RT|M|T|W|R|F)\b\s*\d/i.test(text)) {
+            const dayTokenPattern = getSchedulerDayRegexTokens()
+                .map((token) => escapeRegex(token))
+                .join('|');
+            const hasDayTokenWithTime = dayTokenPattern
+                ? new RegExp(`\\b(${dayTokenPattern})\\b\\s*\\d`, 'i').test(text)
+                : false;
+
+            if (/\b(online|web|async|asynch|asynchronous)\b/i.test(text) && !hasDayTokenWithTime) {
                 return {
                     raw: 'Online / Async',
                     classification: 'online',
@@ -9612,7 +10068,11 @@
                 };
             }
 
-            const meetingMatch = text.match(/\b(MW|WM|TR|RT|TH|TTH|M|T|W|R|F)\b\s*([0-9]{1,2}(?::[0-9]{2})?\s*[APap]\.?\s*M?\.?)\s*[-–]\s*([0-9]{1,2}(?::[0-9]{2})?\s*[APap]\.?\s*M?\.?)/);
+            const clockPattern = '[0-9]{1,2}(?::[0-9]{2})?\\s*[APap]\\.?\\s*M?\\.?';
+            const meetingRegex = dayTokenPattern
+                ? new RegExp(`\\b(${dayTokenPattern})\\b\\s*(${clockPattern})\\s*[-–]\\s*(${clockPattern})`, 'i')
+                : null;
+            const meetingMatch = meetingRegex ? text.match(meetingRegex) : null;
             if (!meetingMatch) {
                 return { raw: '', classification: 'none', dayPattern: '', timeSlot: '', matchEndIndex: -1, singleDay: false };
             }
@@ -9642,12 +10102,15 @@
                 .replace(/\s+/g, '')
                 .replace(/TH/g, 'R');
 
-            if (normalized === 'MW' || normalized === 'WM') {
-                return { dayPattern: 'MW', singleDay: false, note: '' };
-            }
+            const matchedPattern = getSchedulerDayPatterns().find((pattern) => {
+                const aliases = [pattern.id, ...(Array.isArray(pattern.aliases) ? pattern.aliases : [])];
+                return aliases
+                    .map((alias) => String(alias || '').toUpperCase().replace(/\s+/g, '').replace(/TH/g, 'R'))
+                    .includes(normalized);
+            });
 
-            if (normalized === 'TR' || normalized === 'RT') {
-                return { dayPattern: 'TR', singleDay: false, note: '' };
+            if (matchedPattern) {
+                return { dayPattern: matchedPattern.id, singleDay: false, note: '' };
             }
 
             if (['M', 'T', 'W', 'R', 'F'].includes(normalized)) {
@@ -9665,11 +10128,8 @@
             }
 
             const timeKey = `${formatClssMinutes(startMinutes)}-${formatClssMinutes(endMinutes)}`;
-            const mapped = ({
-                '10:00-12:20': '10:00-12:20',
-                '13:00-15:20': '13:00-15:20',
-                '16:00-18:20': '16:00-18:20'
-            })[timeKey];
+            const aliasMatch = getSchedulerTimeSlotByAlias(timeKey);
+            const mapped = aliasMatch?.id || getSchedulerTimeSlotIdForClockRange(startMinutes, endMinutes);
 
             if (!mapped) {
                 return { timeSlot: '', note: `Unsupported time (${timeKey})` };
@@ -9730,21 +10190,9 @@
             searchCandidates.push(text);
 
             for (const candidate of searchCandidates) {
-                const roomMatch = candidate.match(/\bCEB\s*(102|104)\b|\b(?:CEB\s*)?(206|207|209|210|212)\b/i);
-                if (!roomMatch) {
-                    continue;
-                }
-
-                let mappedRoom = '';
-                if (roomMatch[1]) {
-                    mappedRoom = `CEB ${roomMatch[1]}`;
-                } else if (roomMatch[2]) {
-                    mappedRoom = roomMatch[2];
-                }
-
-                const rawRoom = roomMatch[0].replace(/\s+/g, ' ').trim().toUpperCase();
+                const mappedRoom = findConfiguredRoomInText(candidate);
                 if (mappedRoom && CLSS_IMPORT_ALLOWED_ROOMS.has(mappedRoom)) {
-                    return { raw: rawRoom, mappedRoom, isOnline: false, note: '' };
+                    return { raw: mappedRoom, mappedRoom, isOnline: false, note: '' };
                 }
             }
 
@@ -10644,12 +11092,14 @@
         }
 
         function createEmptyQuarterScheduleBucket() {
-            return {
-                MW: {},
-                TR: {},
+            const bucket = {
                 ONLINE: { async: [] },
                 ARRANGED: { arranged: [] }
             };
+            getSchedulerDayIds().forEach((dayPattern) => {
+                bucket[dayPattern] = {};
+            });
+            return bucket;
         }
 
         function createEmptyAcademicYearScheduleData() {
@@ -10701,8 +11151,11 @@
             }
 
             const bucket = scheduleStore[quarter];
-            if (!bucket.MW || typeof bucket.MW !== 'object') bucket.MW = {};
-            if (!bucket.TR || typeof bucket.TR !== 'object') bucket.TR = {};
+            getSchedulerDayIds().forEach((dayPattern) => {
+                if (!bucket[dayPattern] || typeof bucket[dayPattern] !== 'object') {
+                    bucket[dayPattern] = {};
+                }
+            });
             if (!bucket.ONLINE || typeof bucket.ONLINE !== 'object') bucket.ONLINE = {};
             if (!Array.isArray(bucket.ONLINE.async)) bucket.ONLINE.async = [];
             if (!bucket.ARRANGED || typeof bucket.ARRANGED !== 'object') bucket.ARRANGED = {};
@@ -10774,7 +11227,7 @@
             const preferred = String(preferredRoom || '').trim();
             const roomOrder = Array.isArray(CLSS_IMPORT_ROOM_PRIORITY) && CLSS_IMPORT_ROOM_PRIORITY.length
                 ? CLSS_IMPORT_ROOM_PRIORITY
-                : ['206', '207', '209', '210', '212', 'CEB 102', 'CEB 104'];
+                : getSchedulerRoomOptionList();
             const candidates = [];
             if (preferred && CLSS_IMPORT_ALLOWED_ROOMS.has(preferred)) {
                 candidates.push(preferred);
@@ -11038,30 +11491,33 @@
         }
 
         function migrateTimeSlots(data) {
-            const timeMapping = {
-                '10:00-12:00': '10:00-12:20',
-                '13:00-15:00': '13:00-15:20',
-                '16:00-18:00': '16:00-18:20'
-            };
             let migrated = false;
 
             for (const quarter of ['fall', 'winter', 'spring']) {
-                if (data[quarter]) {
-                    for (const day of ['MW', 'TR']) {
-                        if (data[quarter][day]) {
-                            for (const oldTime of Object.keys(timeMapping)) {
-                                if (data[quarter][day][oldTime]) {
-                                    const newTime = timeMapping[oldTime];
-                                    data[quarter][day][newTime] = data[quarter][day][oldTime];
-                                    delete data[quarter][day][oldTime];
-                                    migrated = true;
-                                }
+                const quarterData = data[quarter];
+                if (quarterData && typeof quarterData === 'object') {
+                    Object.entries(quarterData).forEach(([dayPattern, dayBucket]) => {
+                        if (!isSchedulableDay(dayPattern) || !dayBucket || typeof dayBucket !== 'object') return;
+
+                        Object.keys(dayBucket).forEach((timeKey) => {
+                            const slot = getSchedulerTimeSlotByAlias(timeKey);
+                            const canonicalTime = slot?.id || '';
+                            if (!canonicalTime || canonicalTime === timeKey) return;
+
+                            if (!Array.isArray(dayBucket[canonicalTime])) {
+                                dayBucket[canonicalTime] = [];
                             }
-                        }
-                    }
+                            if (Array.isArray(dayBucket[timeKey])) {
+                                dayBucket[canonicalTime].push(...dayBucket[timeKey]);
+                            }
+                            delete dayBucket[timeKey];
+                            migrated = true;
+                        });
+                    });
+
                     // Ensure ONLINE structure exists if not present
-                    if (!data[quarter]['ONLINE']) {
-                        data[quarter]['ONLINE'] = { 'async': [] };
+                    if (!quarterData['ONLINE']) {
+                        quarterData['ONLINE'] = { 'async': [] };
                     }
                 }
             }
@@ -11111,12 +11567,37 @@
 
         // Migrate old storage format to year-aware format
         function migrateOldScheduleData() {
-            const oldKey = 'designSchedulerData';
-            const oldData = localStorage.getItem(oldKey);
-            if (oldData && !localStorage.getItem(getStorageKey('2025-26'))) {
-                localStorage.setItem(getStorageKey('2025-26'), oldData);
-                localStorage.removeItem(oldKey);
-                console.log('Migrated schedule data to year-aware format');
+            const activePrefix = String(scheduleStorageKeyPrefix || 'designSchedulerData_').trim() || 'designSchedulerData_';
+            const legacyPrefixes = ['designSchedulerData_', activePrefix]
+                .filter(Boolean)
+                .filter((value, index, arr) => arr.indexOf(value) === index);
+
+            const oldUnscopedData = localStorage.getItem('designSchedulerData');
+            if (oldUnscopedData && !localStorage.getItem(`${activePrefix}2025-26`)) {
+                localStorage.setItem(`${activePrefix}2025-26`, oldUnscopedData);
+                localStorage.removeItem('designSchedulerData');
+                console.log('Migrated legacy unscoped schedule data to year-aware format');
+            }
+
+            legacyPrefixes.forEach((prefix) => {
+                if (prefix === activePrefix) return;
+
+                for (let i = 0; i < localStorage.length; i += 1) {
+                    const key = localStorage.key(i);
+                    if (!key || !key.startsWith(prefix)) continue;
+                    const year = key.slice(prefix.length);
+                    if (!/^\d{4}-\d{2}$/.test(year)) continue;
+
+                    const sourceValue = localStorage.getItem(key);
+                    const targetKey = `${activePrefix}${year}`;
+                    if (sourceValue && !localStorage.getItem(targetKey)) {
+                        localStorage.setItem(targetKey, sourceValue);
+                    }
+                }
+            });
+
+            if (legacyPrefixes.length > 1) {
+                console.log(`Checked legacy schedule storage prefixes for migration: ${legacyPrefixes.join(', ')}`);
             }
         }
 
@@ -11246,6 +11727,7 @@
                     if (data.facultyWorkload) {
                         facultyList = Object.keys(data.facultyWorkload).sort();
                         populateFacultyDropdowns();
+                        refreshFacultyAliasMap();
                     }
                 }
             } catch (error) {
@@ -13904,6 +14386,8 @@ RESPONSE FORMAT:
             const quarters = mode === 'all'
                 ? ['fall', 'winter', 'spring']
                 : [window.StateManager?.get('currentQuarter') || 'spring'];
+            const departmentIdentity = getActiveDepartmentIdentity();
+            const departmentLabel = departmentIdentity.displayName || departmentIdentity.name || 'Department';
 
             const quarterNames = {
                 fall: `Fall ${currentAcademicYear.split('-')[0]}`,
@@ -13911,9 +14395,10 @@ RESPONSE FORMAT:
                 spring: `Spring ${currentAcademicYear.split('-')[1]}`
             };
 
-            const rooms = ['206', '207', '209', '210', '212', 'CEB 102', 'CEB 104'];
-            const timeSlots = ['10:00-12:20', '13:00-15:20', '16:00-18:20'];
-            const timeLabels = ['10:00 AM - 12:20 PM', '1:00 PM - 3:20 PM', '4:00 PM - 6:20 PM'];
+            const rooms = getSchedulerRoomOptionList();
+            const timeSlots = getSchedulerTimeSlotIds();
+            const timeLabels = getSchedulerTimeSlots().map((slot) => String(slot.label || slot.id));
+            const dayPatterns = getSchedulerDayPatterns();
 
             let content = '';
             quarters.forEach((quarter, qIdx) => {
@@ -13921,17 +14406,22 @@ RESPONSE FORMAT:
                 content += `
                     <div style="page-break-after: ${qIdx < quarters.length - 1 ? 'always' : 'auto'}; padding: 20px;">
                         <div style="text-align: center; margin-bottom: 20px; border-bottom: 3px solid #a10022; padding-bottom: 15px;">
-                            <h1 style="font-size: 28px; color: #a10022; margin: 0;">EWU Design Department</h1>
+                            <h1 style="font-size: 28px; color: #a10022; margin: 0;">${escapeHtml(departmentLabel)}</h1>
                             <h2 style="font-size: 22px; color: #333; margin: 5px 0;">${quarterNames[quarter]}</h2>
                             <div style="font-size: 12px; color: #666;">Printed: ${new Date().toLocaleDateString()}</div>
                         </div>
                 `;
 
-                // MW Section
-                content += buildPrintSectionHTML('Monday / Wednesday', ['MW'], quarterData, rooms, timeSlots, timeLabels);
-
-                // TR Section  
-                content += buildPrintSectionHTML('Tuesday / Thursday', ['TR'], quarterData, rooms, timeSlots, timeLabels);
+                dayPatterns.forEach((pattern) => {
+                    content += buildPrintSectionHTML(
+                        String(pattern.label || pattern.id),
+                        [pattern.id],
+                        quarterData,
+                        rooms,
+                        timeSlots,
+                        timeLabels
+                    );
+                });
 
                 // Online Section
                 const onlineCourses = getOnlineCoursesForQuarter(quarterData);
@@ -13952,7 +14442,7 @@ RESPONSE FORMAT:
                 <!DOCTYPE html>
                 <html>
                 <head>
-                    <title>EWU Schedule - ${mode === 'all' ? 'All Quarters' : quarterNames[quarters[0]]}</title>
+                    <title>${escapeHtml(departmentLabel)} Schedule - ${mode === 'all' ? 'All Quarters' : quarterNames[quarters[0]]}</title>
                     <style>
                         body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; }
                         @media print { body { -webkit-print-color-adjust: exact; print-color-adjust: exact; } }

--- a/index.html
+++ b/index.html
@@ -4417,6 +4417,8 @@
                             Setup</a>
                         <a href="pages/department-onboarding.html" class="nav-link"><span
                                 class="icon">🧭</span>Onboarding</a>
+                        <a href="pages/eaglenet-compare.html" class="nav-link"><span
+                                class="icon">🧾</span>EagleNet Compare</a>
                         <a href="pages/course-management.html" class="nav-link"><span class="icon">📚</span>Courses</a>
                         <a href="pages/workload-dashboard.html" class="nav-link"><span
                                 class="icon">👥</span>Workload</a>

--- a/index.html
+++ b/index.html
@@ -9299,6 +9299,113 @@
             });
         }
 
+        function getClssImportDiagnostics(row, effectiveRow) {
+            const sourceRow = row || {};
+            const effective = effectiveRow || getClssImportRowEffectiveState(sourceRow);
+            const notes = [...new Set([...(sourceRow.notes || []), ...(effective.effectiveNotes || [])]
+                .map((note) => String(note || '').trim())
+                .filter(Boolean))];
+            const reviewPlacement = String(sourceRow.reviewPlacement || '').toLowerCase();
+            const hasManualOverrides = Boolean(
+                reviewPlacement
+                || sourceRow.reviewDay
+                || sourceRow.reviewTime
+                || sourceRow.reviewRoom
+            );
+
+            let placementSource = 'parser';
+            if (reviewPlacement === 'skip') {
+                placementSource = 'manual-skip';
+            } else if (reviewPlacement === 'online') {
+                placementSource = 'manual-online';
+            } else if (reviewPlacement === 'arranged') {
+                placementSource = 'manual-arranged';
+            } else if (reviewPlacement === 'inperson' || hasManualOverrides) {
+                placementSource = 'manual-inperson';
+            } else if (notes.some((note) => /Auto-matched prior-year placement/i.test(note))) {
+                placementSource = 'prior-year-auto';
+            } else if (effective.effectiveDisposition === 'online') {
+                placementSource = 'parser-online';
+            } else if (effective.effectiveDisposition === 'arranged') {
+                placementSource = 'parser-arranged';
+            } else if (effective.effectiveDisposition === 'ready') {
+                placementSource = effective.effectiveRoom
+                    ? 'parser-slot-room'
+                    : 'parser-slot-auto-room';
+            } else if (effective.effectiveDisposition === 'error') {
+                placementSource = 'parser-error';
+            } else {
+                placementSource = 'parser-needs-review';
+            }
+
+            let score = 0.5;
+            if (placementSource === 'manual-inperson') score = 0.93;
+            else if (placementSource === 'manual-online' || placementSource === 'manual-arranged') score = 0.9;
+            else if (placementSource === 'manual-skip') score = 0.75;
+            else if (placementSource === 'prior-year-auto') score = 0.78;
+            else if (placementSource === 'parser-slot-room') score = 0.86;
+            else if (placementSource === 'parser-slot-auto-room') score = 0.72;
+            else if (placementSource === 'parser-online' || placementSource === 'parser-arranged') score = 0.8;
+            else if (placementSource === 'parser-error') score = 0.1;
+            else if (placementSource === 'parser-needs-review') score = 0.35;
+
+            const diagnostics = [];
+            if (effective.effectiveStatus === 'error') {
+                score = Math.min(score, 0.1);
+                diagnostics.push('Parser could not resolve required course identity');
+            } else if (effective.effectiveStatus === 'needs-review') {
+                score = Math.min(score, 0.45);
+                diagnostics.push('Row still requires manual review before apply');
+            }
+
+            if (String(effective.instructor || sourceRow.instructor || '').trim().toUpperCase() === 'TBD') {
+                score -= 0.18;
+                diagnostics.push('Instructor is unresolved (TBD/Staff)');
+            }
+
+            if (!String(effective.section || sourceRow.section || '').trim()) {
+                score -= 0.05;
+                diagnostics.push('Section missing');
+            }
+
+            if (placementSource === 'prior-year-auto') {
+                if (notes.some((note) => /matched by prior-year roster/i.test(note))) {
+                    score += 0.1;
+                    diagnostics.push('Matched prior-year instructor/section pattern');
+                } else {
+                    diagnostics.push('Prior-year placement used as heuristic');
+                }
+            }
+
+            const parserUncertaintyCount = notes.filter((note) =>
+                /(not recognized|not detected|not found|unsupported|manual placement|auto-assign|requires manual)/i.test(note)
+            ).length;
+            if (parserUncertaintyCount > 0) {
+                score -= Math.min(0.25, parserUncertaintyCount * 0.08);
+                diagnostics.push('Parser emitted uncertainty notes');
+            }
+
+            if (effective.effectiveDay && effective.effectiveTime && effective.effectiveDisposition === 'ready') {
+                score += 0.03;
+            }
+
+            score = Math.max(0.05, Math.min(0.99, score));
+            const roundedScore = Math.round(score * 100) / 100;
+            const confidenceLevel = roundedScore >= 0.8
+                ? 'high'
+                : roundedScore >= 0.6
+                    ? 'medium'
+                    : 'low';
+
+            return {
+                placementSource,
+                confidenceScore: roundedScore,
+                confidenceLevel,
+                lowConfidence: confidenceLevel === 'low',
+                diagnostics
+            };
+        }
+
         function getClssImportRowEffectiveState(row) {
             const parsedQuarter = row?.targetQuarter || (document.getElementById('clssImportQuarter')?.value || 'spring');
             const reviewQuarter = CLSS_IMPORT_QUARTERS.includes(row?.reviewQuarter) ? row.reviewQuarter : parsedQuarter;
@@ -9654,11 +9761,13 @@
             }
 
             const effectiveRows = rows.map((row) => getClssImportRowEffectiveState(row));
+            const rowDiagnostics = rows.map((row, index) => getClssImportDiagnostics(row, effectiveRows[index]));
 
             const statusCounts = effectiveRows.reduce((acc, row) => {
                 acc[row.effectiveStatus] = (acc[row.effectiveStatus] || 0) + 1;
                 return acc;
             }, {});
+            const lowConfidenceCount = rowDiagnostics.filter((diagnostics) => diagnostics.lowConfidence).length;
 
             const scope = getClssImportScope();
             const buildMode = getClssImportBuildMode();
@@ -9694,6 +9803,9 @@
                     summaryPills.push(`${label}: ${statusCounts[status]}`);
                 }
             });
+            if (lowConfidenceCount > 0) {
+                summaryPills.push(`Low confidence: ${lowConfidenceCount}`);
+            }
 
             if (Array.isArray(meta.warnings)) {
                 meta.warnings.forEach((warning) => summaryPills.push(warning));
@@ -9708,6 +9820,7 @@
 
             rows.forEach((row, rowIndex) => {
                 const effectiveRow = effectiveRows[rowIndex];
+                const diagnostics = rowDiagnostics[rowIndex];
                 const tr = document.createElement('tr');
 
                 const quarterTd = document.createElement('td');
@@ -9719,6 +9832,13 @@
                 statusBadge.className = `clss-import-status ${effectiveRow.effectiveStatus}`;
                 statusBadge.textContent = CLSS_IMPORT_STATUS_LABELS[effectiveRow.effectiveStatus] || effectiveRow.effectiveStatus;
                 statusTd.appendChild(statusBadge);
+                if (diagnostics?.lowConfidence) {
+                    const confidenceBadge = document.createElement('span');
+                    confidenceBadge.className = 'clss-import-status needs-review';
+                    confidenceBadge.style.marginLeft = '6px';
+                    confidenceBadge.textContent = `Low confidence (${Math.round((diagnostics.confidenceScore || 0) * 100)}%)`;
+                    statusTd.appendChild(confidenceBadge);
+                }
                 tr.appendChild(statusTd);
 
                 const courseTd = document.createElement('td');
@@ -9752,6 +9872,16 @@
                 const notesTd = document.createElement('td');
                 const notesWrap = document.createElement('div');
                 notesWrap.className = 'clss-import-notes';
+                const diagnosticsLabel = document.createElement('div');
+                diagnosticsLabel.className = 'clss-import-note-item';
+                diagnosticsLabel.textContent = `• Placement source: ${diagnostics?.placementSource || 'unknown'} • Confidence: ${diagnostics?.confidenceLevel || 'unknown'} (${Math.round((diagnostics?.confidenceScore || 0) * 100)}%)`;
+                notesWrap.appendChild(diagnosticsLabel);
+                (diagnostics?.diagnostics || []).forEach((message) => {
+                    const noteDiv = document.createElement('div');
+                    noteDiv.className = 'clss-import-note-item';
+                    noteDiv.textContent = `• ${message}`;
+                    notesWrap.appendChild(noteDiv);
+                });
                 (effectiveRow.effectiveNotes || []).forEach((note) => {
                     const noteDiv = document.createElement('div');
                     noteDiv.className = 'clss-import-note-item';
@@ -10329,6 +10459,9 @@
                     ? `No in-grid rows were placed. Outcome: ${reasons.join(', ')}.`
                     : 'No in-grid rows were placed for this import.');
             }
+            if ((Number(totals.lowConfidence) || 0) > 0) {
+                lines.push(`${totals.lowConfidence} row${totals.lowConfidence === 1 ? '' : 's'} flagged low-confidence; review notes/diagnostics before finalizing.`);
+            }
 
             if (report.targetYear !== currentYearLabel || targetQuarter !== currentQuarterLabel) {
                 lines.push(`Current view is ${currentYearLabel} ${CLSS_IMPORT_QUARTER_LABELS[currentQuarterLabel] || currentQuarterLabel}. Use "Show Imported Rows Now" to jump to ${report.targetYear} ${CLSS_IMPORT_QUARTER_LABELS[targetQuarter] || targetQuarter}.`);
@@ -10407,8 +10540,14 @@
             if ((Number(totals.roomFallbackPlacements) || 0) > 0) {
                 summaryPills.push(`Room fallback: ${Number(totals.roomFallbackPlacements) || 0}`);
             }
+            if ((Number(totals.lowConfidence) || 0) > 0) {
+                summaryPills.push(`Low confidence: ${Number(totals.lowConfidence) || 0}`);
+            }
 
             const contextLine = buildClssImportResultContextMessage(report);
+            const diagnosticRows = (Array.isArray(report.sampleRows) ? report.sampleRows : [])
+                .filter((row) => row && (row.confidence != null || row.placementSource))
+                .slice(0, 8);
             const quarterTableHtml = quarterRows.length
                 ? `
                     <table class="clss-import-results-table" aria-label="CLSS import outcomes by quarter">
@@ -10439,12 +10578,40 @@
                     </table>
                 `
                 : '<div class="clss-import-results-message">No quarter-level outcomes were recorded for this import.</div>';
+            const diagnosticsTableHtml = diagnosticRows.length
+                ? `
+                    <details class="clss-import-results-details">
+                        <summary>Placement diagnostics sample</summary>
+                        <table class="clss-import-results-table" aria-label="CLSS placement diagnostics sample">
+                            <thead>
+                                <tr>
+                                    <th>Course</th>
+                                    <th>Destination</th>
+                                    <th>Source</th>
+                                    <th>Confidence</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                ${diagnosticRows.map((row) => `
+                                    <tr>
+                                        <td>${escapeHtml(String(row.code || ''))}${row.section ? `-${escapeHtml(String(row.section))}` : ''}</td>
+                                        <td>${escapeHtml(String(row.destination || ''))}</td>
+                                        <td>${escapeHtml(String(row.placementSource || ''))}</td>
+                                        <td>${row.confidence != null ? `${Math.round(Number(row.confidence) * 100)}% (${escapeHtml(String(row.confidenceLevel || 'unknown'))})` : '—'}</td>
+                                    </tr>
+                                `).join('')}
+                            </tbody>
+                        </table>
+                    </details>
+                `
+                : '';
 
             bodyEl.innerHTML = `
                 <div class="clss-import-results-summary">
                     ${summaryPills.map((text) => `<span class="clss-import-summary-pill">${escapeHtml(text)}</span>`).join('')}
                 </div>
                 ${quarterTableHtml}
+                ${diagnosticsTableHtml}
                 <div class="clss-import-results-message">${escapeHtml(contextLine)}</div>
             `;
 
@@ -10526,6 +10693,7 @@
             return clssImportPreviewRows
                 .map((sourceRow) => {
                     const effective = getClssImportRowEffectiveState(sourceRow);
+                    const diagnostics = getClssImportDiagnostics(sourceRow, effective);
                     if (!effective || effective.effectiveDisposition === 'skip' || effective.effectiveStatus === 'error') {
                         return null;
                     }
@@ -10556,7 +10724,10 @@
                         time: String(effective.effectiveTime || '').trim(),
                         room: String(effective.effectiveRoom || '').trim(),
                         rawMeeting: String(effective.meetingLabel || '').trim(),
-                        rawRoom: String(effective.roomLabel || '').trim()
+                        rawRoom: String(effective.roomLabel || '').trim(),
+                        placementSource: diagnostics.placementSource,
+                        confidence: diagnostics.confidenceScore,
+                        confidenceLevel: diagnostics.confidenceLevel
                     };
                 })
                 .filter(Boolean);
@@ -10568,7 +10739,8 @@
                 byQuarter: { fall: 0, winter: 0, spring: 0 },
                 byModality: { 'in-person': 0, online: 0, arranged: 0 },
                 assignedFaculty: 0,
-                unassignedFaculty: 0
+                unassignedFaculty: 0,
+                lowConfidence: 0
             };
 
             (Array.isArray(rows) ? rows : []).forEach((row) => {
@@ -10579,6 +10751,9 @@
                     stats.unassignedFaculty += 1;
                 } else {
                     stats.assignedFaculty += 1;
+                }
+                if (String(row.confidenceLevel || '').toLowerCase() === 'low') {
+                    stats.lowConfidence += 1;
                 }
             });
 
@@ -10602,6 +10777,7 @@
                 `In-person/Online/Arranged: ${stats.byModality['in-person']}/${stats.byModality.online}/${stats.byModality.arranged}`,
                 `Assigned faculty rows: ${stats.assignedFaculty}`,
                 `TBD/Staff rows: ${stats.unassignedFaculty}`,
+                `Low-confidence rows: ${stats.lowConfidence}`,
                 '',
                 'This mode creates a workload handoff dataset and opens the workload dashboard. It does not place courses into the scheduler grid.'
             ].join('\n');
@@ -10645,10 +10821,14 @@
             const quarter = document.getElementById('clssImportQuarter')?.value || 'spring';
             const replaceQuarter = Boolean(document.getElementById('clssImportReplaceQuarter')?.checked);
             const targetYear = getClssImportTargetAcademicYear();
-            const reviewRows = clssImportPreviewRows.map((sourceRow) => ({
-                sourceRow,
-                effectiveRow: getClssImportRowEffectiveState(sourceRow)
-            }));
+            const reviewRows = clssImportPreviewRows.map((sourceRow) => {
+                const effectiveRow = getClssImportRowEffectiveState(sourceRow);
+                return {
+                    sourceRow,
+                    effectiveRow,
+                    diagnostics: getClssImportDiagnostics(sourceRow, effectiveRow)
+                };
+            });
             const currentYearLabel = currentAcademicYear || (window.StateManager?.get('currentAcademicYear')) || '2025-26';
             const importingToCurrentYear = targetYear === currentYearLabel;
             const impactedQuarters = [...new Set(reviewRows
@@ -10678,7 +10858,8 @@
                 skippedInvalidQuarter: 0,
                 unresolved: 0,
                 leftoverToTray: 0,
-                roomFallbackPlacements: 0
+                roomFallbackPlacements: 0,
+                lowConfidence: 0
             };
             const byQuarter = {};
             const rowOutcomes = [];
@@ -10696,9 +10877,23 @@
             const remainingRows = [];
             const applyableRows = [];
 
-            reviewRows.forEach(({ sourceRow, effectiveRow }) => {
+            reviewRows.forEach(({ sourceRow, effectiveRow, diagnostics }) => {
                 const effectiveQuarter = effectiveRow?.effectiveQuarter || sourceRow?.targetQuarter || quarter;
                 const quarterOutcome = ensureOutcome(effectiveQuarter);
+                const outcomeBase = {
+                    quarter: effectiveQuarter,
+                    code: normalizeCourseCode(effectiveRow?.code),
+                    section: String(effectiveRow?.section || '').trim(),
+                    instructor: getCanonicalFacultyName(effectiveRow?.instructor || 'TBD'),
+                    placementSource: diagnostics?.placementSource || 'unknown',
+                    confidence: diagnostics?.confidenceScore ?? null,
+                    confidenceLevel: diagnostics?.confidenceLevel || 'unknown',
+                    lowConfidence: Boolean(diagnostics?.lowConfidence),
+                    diagnostics: Array.isArray(diagnostics?.diagnostics) ? diagnostics.diagnostics.slice(0, 4) : []
+                };
+                if (diagnostics?.lowConfidence) {
+                    counts.lowConfidence += 1;
+                }
 
                 if (!sourceRow || !effectiveRow) {
                     counts.skipped += 1;
@@ -10714,10 +10909,7 @@
                         quarterOutcome.skippedMarkedSkip += 1;
                     }
                     rowOutcomes.push({
-                        quarter: effectiveQuarter,
-                        code: normalizeCourseCode(effectiveRow.code),
-                        section: String(effectiveRow.section || '').trim(),
-                        instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
+                        ...outcomeBase,
                         destination: 'skipped-marked-skip'
                     });
                     return;
@@ -10728,16 +10920,13 @@
                     counts.unresolved += 1;
                     if (quarterOutcome) quarterOutcome.unresolved += 1;
                     rowOutcomes.push({
-                        quarter: effectiveQuarter,
-                        code: normalizeCourseCode(effectiveRow.code),
-                        section: String(effectiveRow.section || '').trim(),
-                        instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
+                        ...outcomeBase,
                         destination: effectiveRow.effectiveStatus === 'error' ? 'skipped-error' : 'needs-review'
                     });
                     return;
                 }
 
-                applyableRows.push({ sourceRow, effectiveRow });
+                applyableRows.push({ sourceRow, effectiveRow, diagnostics });
             });
 
             if (!applyableRows.length && remainingRows.length) {
@@ -10766,9 +10955,20 @@
                 }
             }
 
-            applyableRows.forEach(({ sourceRow, effectiveRow }) => {
+            applyableRows.forEach(({ sourceRow, effectiveRow, diagnostics }) => {
                 const rowQuarter = effectiveRow.effectiveQuarter || quarter;
                 const quarterOutcome = ensureOutcome(rowQuarter);
+                const outcomeBase = {
+                    quarter: rowQuarter,
+                    code: normalizeCourseCode(effectiveRow.code),
+                    section: String(effectiveRow.section || '').trim(),
+                    instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
+                    placementSource: diagnostics?.placementSource || 'unknown',
+                    confidence: diagnostics?.confidenceScore ?? null,
+                    confidenceLevel: diagnostics?.confidenceLevel || 'unknown',
+                    lowConfidence: Boolean(diagnostics?.lowConfidence),
+                    diagnostics: Array.isArray(diagnostics?.diagnostics) ? diagnostics.diagnostics.slice(0, 4) : []
+                };
 
                 if (!CLSS_IMPORT_QUARTERS.includes(rowQuarter)) {
                     counts.skipped += 1;
@@ -10779,10 +10979,8 @@
                     }
                     remainingRows.push(sourceRow);
                     rowOutcomes.push({
+                        ...outcomeBase,
                         quarter: sourceRow?.targetQuarter || quarter,
-                        code: normalizeCourseCode(effectiveRow.code),
-                        section: String(effectiveRow.section || '').trim(),
-                        instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
                         destination: 'skipped-invalid-quarter'
                     });
                     return;
@@ -10812,10 +11010,7 @@
                             if (quarterOutcome) quarterOutcome.roomFallbackPlacements += 1;
                         }
                         rowOutcomes.push({
-                            quarter: rowQuarter,
-                            code: normalizeCourseCode(effectiveRow.code),
-                            section: String(effectiveRow.section || '').trim(),
-                            instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
+                            ...outcomeBase,
                             destination: 'grid',
                             day: rowForApply.schedulerDay || '',
                             time: rowForApply.schedulerTime || '',
@@ -10832,10 +11027,7 @@
                             quarterOutcome.skippedDuplicate += 1;
                         }
                         rowOutcomes.push({
-                            quarter: rowQuarter,
-                            code: normalizeCourseCode(effectiveRow.code),
-                            section: String(effectiveRow.section || '').trim(),
-                            instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
+                            ...outcomeBase,
                             destination: 'skipped-duplicate',
                             day: rowForApply.schedulerDay || '',
                             time: rowForApply.schedulerTime || ''
@@ -10850,10 +11042,7 @@
                     counts.leftoverToTray += 1;
                     if (quarterOutcome) quarterOutcome.displaced += 1;
                     rowOutcomes.push({
-                        quarter: rowQuarter,
-                        code: normalizeCourseCode(effectiveRow.code),
-                        section: String(effectiveRow.section || '').trim(),
-                        instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
+                        ...outcomeBase,
                         destination: 'displaced',
                         day: rowForApply.schedulerDay || '',
                         time: rowForApply.schedulerTime || '',
@@ -10868,10 +11057,7 @@
                     counts.onlinePlaced += 1;
                     if (quarterOutcome) quarterOutcome.onlinePlaced += 1;
                     rowOutcomes.push({
-                        quarter: rowQuarter,
-                        code: normalizeCourseCode(effectiveRow.code),
-                        section: String(effectiveRow.section || '').trim(),
-                        instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
+                        ...outcomeBase,
                         destination: 'online'
                     });
                     return;
@@ -10882,10 +11068,7 @@
                     counts.arrangedPlaced += 1;
                     if (quarterOutcome) quarterOutcome.arrangedPlaced += 1;
                     rowOutcomes.push({
-                        quarter: rowQuarter,
-                        code: normalizeCourseCode(effectiveRow.code),
-                        section: String(effectiveRow.section || '').trim(),
-                        instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
+                        ...outcomeBase,
                         destination: 'arranged'
                     });
                     return;
@@ -10895,10 +11078,7 @@
                 counts.unresolved += 1;
                 if (quarterOutcome) quarterOutcome.unresolved += 1;
                 rowOutcomes.push({
-                    quarter: rowQuarter,
-                    code: normalizeCourseCode(effectiveRow.code),
-                    section: String(effectiveRow.section || '').trim(),
-                    instructor: getCanonicalFacultyName(effectiveRow.instructor || 'TBD'),
+                    ...outcomeBase,
                     destination: 'needs-review'
                 });
             });
@@ -10991,7 +11171,8 @@
                     skippedDuplicate: Number(counts?.skippedDuplicate) || 0,
                     skippedMarkedSkip: Number(counts?.skippedMarkedSkip) || 0,
                     skippedInvalidQuarter: Number(counts?.skippedInvalidQuarter) || 0,
-                    roomFallbackPlacements: Number(counts?.roomFallbackPlacements) || 0
+                    roomFallbackPlacements: Number(counts?.roomFallbackPlacements) || 0,
+                    lowConfidence: Number(counts?.lowConfidence) || 0
                 },
                 byQuarter: normalizedByQuarter,
                 sampleRows: (Array.isArray(rowOutcomes) ? rowOutcomes : []).slice(0, 20)
@@ -11005,6 +11186,12 @@
                 acc[key] = (acc[key] || 0) + 1;
                 return acc;
             }, {});
+            const lowConfidenceCount = rows.reduce((acc, row) => {
+                const diagnostics = row?.diagnostics
+                    ? row.diagnostics
+                    : getClssImportDiagnostics(row?.sourceRow || row, row?.effectiveRow);
+                return acc + (diagnostics?.lowConfidence ? 1 : 0);
+            }, 0);
 
             const quartersLabel = (impactedQuarters.length
                 ? impactedQuarters
@@ -11023,7 +11210,8 @@
                 `Online: ${counts.online || 0}`,
                 `Arranged: ${counts.arranged || 0}`,
                 `Needs review (stays in review table): ${counts['needs-review'] || 0}`,
-                `Errors (skipped): ${counts.error || 0}`
+                `Errors (skipped): ${counts.error || 0}`,
+                `Low confidence (review recommended): ${lowConfidenceCount}`
             ];
 
             if (replaceQuarter) {

--- a/js/auth-service.js
+++ b/js/auth-service.js
@@ -1,0 +1,187 @@
+/**
+ * Auth Service Layer
+ * Wraps Supabase Auth operations behind a stable singleton API.
+ */
+const AuthService = (function() {
+    'use strict';
+
+    let cachedClient = null;
+
+    function isConfigured() {
+        if (typeof isSupabaseConfigured === 'function') {
+            return isSupabaseConfigured();
+        }
+        if (typeof window !== 'undefined' && typeof window.isSupabaseConfigured === 'function') {
+            return window.isSupabaseConfigured();
+        }
+        return true;
+    }
+
+    function resolveClient() {
+        if (cachedClient) {
+            return cachedClient;
+        }
+
+        if (typeof getSupabaseClient === 'function') {
+            cachedClient = getSupabaseClient();
+        } else if (typeof window !== 'undefined' && typeof window.getSupabaseClient === 'function') {
+            cachedClient = window.getSupabaseClient();
+        }
+
+        return cachedClient;
+    }
+
+    function getClientOrThrow() {
+        const client = resolveClient();
+        if (!client || !client.auth) {
+            throw new Error('Supabase Auth client is not available.');
+        }
+        return client;
+    }
+
+    function extractRole(user) {
+        if (!user) return null;
+        return (
+            user.app_metadata?.role ||
+            user.user_metadata?.role ||
+            user.raw_user_meta_data?.role ||
+            null
+        );
+    }
+
+    function normalizeUser(user, fallbackRole = null) {
+        if (!user) return null;
+        return {
+            ...user,
+            role: extractRole(user) || fallbackRole || null
+        };
+    }
+
+    function init() {
+        if (!isConfigured()) {
+            return null;
+        }
+        return resolveClient();
+    }
+
+    async function signUp(email, password, role = 'chair') {
+        if (!isConfigured()) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const client = getClientOrThrow();
+        const { data, error } = await client.auth.signUp({
+            email,
+            password,
+            options: {
+                data: { role }
+            }
+        });
+
+        if (error) throw error;
+
+        const user = normalizeUser(data?.user || null, role);
+        return {
+            user,
+            session: data?.session || null,
+            role: user?.role || role
+        };
+    }
+
+    async function signIn(email, password) {
+        if (!isConfigured()) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const client = getClientOrThrow();
+        const { data, error } = await client.auth.signInWithPassword({ email, password });
+
+        if (error) throw error;
+
+        const user = normalizeUser(data?.user || data?.session?.user || null);
+        return {
+            user,
+            session: data?.session || null
+        };
+    }
+
+    async function signOut() {
+        if (!isConfigured()) {
+            return true;
+        }
+
+        const client = getClientOrThrow();
+        const { error } = await client.auth.signOut();
+        if (error) throw error;
+        return true;
+    }
+
+    async function getSession() {
+        if (!isConfigured()) {
+            return null;
+        }
+
+        const client = getClientOrThrow();
+        const { data, error } = await client.auth.getSession();
+        if (error) throw error;
+        return data?.session || null;
+    }
+
+    async function getUser() {
+        if (!isConfigured()) {
+            return null;
+        }
+
+        const client = getClientOrThrow();
+        const { data, error } = await client.auth.getUser();
+        if (error) throw error;
+        return normalizeUser(data?.user || null);
+    }
+
+    function onAuthStateChange(callback) {
+        if (typeof callback !== 'function') {
+            throw new Error('Auth state callback must be a function.');
+        }
+
+        const client = getClientOrThrow();
+        const { data, error } = client.auth.onAuthStateChange((event, session) => {
+            const normalizedUser = normalizeUser(session?.user || null);
+            const normalizedSession = session
+                ? { ...session, user: normalizedUser }
+                : null;
+            callback(event, normalizedSession, normalizedUser);
+        });
+
+        if (error) throw error;
+        return data?.subscription || data || null;
+    }
+
+    function resetForTests() {
+        cachedClient = null;
+    }
+
+    return {
+        init,
+        signUp,
+        signIn,
+        signOut,
+        getSession,
+        getUser,
+        onAuthStateChange,
+        _resetForTests: resetForTests
+    };
+})();
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        AuthService.init();
+    });
+}
+
+if (typeof window !== 'undefined') {
+    window.AuthService = AuthService;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = AuthService;
+}

--- a/js/department-profile.js
+++ b/js/department-profile.js
@@ -24,6 +24,20 @@
             appTitle: 'Program Command - EWU Design',
             headerEyebrow: 'EWU DESIGN · PROGRAM COMMAND',
             headerSubtitle: 'Design Program Planning, Scheduling, and Scenario Control',
+            textSlots: {
+                navAnalyticsLabel: 'Analytics',
+                navPlanningLabel: 'Planning',
+                navToolsLabel: 'Tools',
+                onboardingTitle: 'Department Onboarding Shell',
+                onboardingSubtitle: 'Create and activate a versioned department profile without code edits for standard setup',
+                onboardingStep1Title: 'Step 1: Entry + Base Profile',
+                onboardingStep1Help: 'Select an existing profile as your base, then define department identity.',
+                onboardingStep2Title: 'Step 2: Seed Mapping Wizard',
+                onboardingStep2Help: 'Enter room map and CLSS alias mappings. Use one item per line. Alias format: alias=canonical.',
+                onboardingStep3Title: 'Step 3: Health Checks + Activation',
+                onboardingStep3Help: 'Run checks before activation. Errors block activation. Warnings are advisory.',
+                onboardingStatusTitle: 'Current Status'
+            },
             themeTokens: {
                 headerTop: '#3d444d',
                 headerBottom: '#24292f',
@@ -276,6 +290,10 @@
             .map((quarter) => String(quarter || '').toLowerCase())
             .filter(Boolean);
 
+        if (!isObject(merged.branding.textSlots)) {
+            merged.branding.textSlots = { ...DEFAULT_PROFILE.branding.textSlots };
+        }
+
         if (!Array.isArray(merged.scheduler.allowedRooms)) {
             merged.scheduler.allowedRooms = DEFAULT_PROFILE.scheduler.allowedRooms.slice();
         }
@@ -443,6 +461,74 @@
         });
     }
 
+    function parseHexColorToRgb(value) {
+        const input = String(value || '').trim();
+        if (!input.startsWith('#')) return null;
+        const hex = input.slice(1);
+        if (hex.length === 3 && /^[0-9a-fA-F]{3}$/.test(hex)) {
+            return {
+                r: parseInt(hex[0] + hex[0], 16),
+                g: parseInt(hex[1] + hex[1], 16),
+                b: parseInt(hex[2] + hex[2], 16)
+            };
+        }
+        if (hex.length === 6 && /^[0-9a-fA-F]{6}$/.test(hex)) {
+            return {
+                r: parseInt(hex.slice(0, 2), 16),
+                g: parseInt(hex.slice(2, 4), 16),
+                b: parseInt(hex.slice(4, 6), 16)
+            };
+        }
+        return null;
+    }
+
+    function toRelativeLuminance(rgb) {
+        const convert = (channel) => {
+            const normalized = channel / 255;
+            return normalized <= 0.03928
+                ? normalized / 12.92
+                : Math.pow((normalized + 0.055) / 1.055, 2.4);
+        };
+        const r = convert(rgb.r);
+        const g = convert(rgb.g);
+        const b = convert(rgb.b);
+        return (0.2126 * r) + (0.7152 * g) + (0.0722 * b);
+    }
+
+    function contrastRatio(foregroundHex, backgroundHex) {
+        const fg = parseHexColorToRgb(foregroundHex);
+        const bg = parseHexColorToRgb(backgroundHex);
+        if (!fg || !bg) return null;
+        const fgL = toRelativeLuminance(fg);
+        const bgL = toRelativeLuminance(bg);
+        const lighter = Math.max(fgL, bgL);
+        const darker = Math.min(fgL, bgL);
+        return (lighter + 0.05) / (darker + 0.05);
+    }
+
+    function evaluateBrandingAccessibility(profile) {
+        const warnings = [];
+        const tokens = profile && profile.branding && profile.branding.themeTokens;
+        if (!isObject(tokens)) return warnings;
+
+        const foreground = tokens.headerForeground;
+        const top = tokens.headerTop;
+        const bottom = tokens.headerBottom;
+        const minContrast = 4.5;
+
+        const topContrast = contrastRatio(foreground, top);
+        if (Number.isFinite(topContrast) && topContrast < minContrast) {
+            warnings.push(`branding.themeTokens contrast warning: headerForeground vs headerTop is ${topContrast.toFixed(2)} (< ${minContrast}).`);
+        }
+
+        const bottomContrast = contrastRatio(foreground, bottom);
+        if (Number.isFinite(bottomContrast) && bottomContrast < minContrast) {
+            warnings.push(`branding.themeTokens contrast warning: headerForeground vs headerBottom is ${bottomContrast.toFixed(2)} (< ${minContrast}).`);
+        }
+
+        return warnings;
+    }
+
     function publishActiveProfile(snapshot) {
         global.__PROGRAM_COMMAND_ACTIVE_PROFILE__ = deepClone(snapshot.profile);
         applyThemeTokens(snapshot.profile);
@@ -525,12 +611,14 @@
                 const fallback = normalizeProfile(deepClone(DEFAULT_PROFILE));
                 const fallbackValidation = validateProfile(fallback);
                 warnings.push(...fallbackValidation.warnings);
+                warnings.push(...evaluateBrandingAccessibility(fallback));
                 state.profile = fallback;
                 state.activeProfileId = fallback.id;
                 state.source = 'embedded-default';
                 state.errors = errors;
                 state.warnings = warnings;
             } else {
+                warnings.push(...evaluateBrandingAccessibility(normalizedProfile));
                 state.profile = normalizedProfile;
                 state.activeProfileId = normalizedProfile.id;
                 state.source = source || 'json-file';
@@ -602,6 +690,7 @@
         const normalizedProfile = normalizeProfile(migratedProfile);
         const validation = validateProfile(normalizedProfile);
         warnings.push(...validation.warnings);
+        warnings.push(...evaluateBrandingAccessibility(normalizedProfile));
         errors.push(...validation.errors);
 
         return {

--- a/js/department-profile.js
+++ b/js/department-profile.js
@@ -6,6 +6,7 @@
     'use strict';
 
     const ACTIVE_PROFILE_STORAGE_KEY = 'programCommandActiveDepartmentProfileId';
+    const CUSTOM_PROFILES_STORAGE_KEY = 'programCommandCustomDepartmentProfilesV1';
     const PROFILE_MANIFEST_FILE = 'manifest.json';
     const DEFAULT_PROFILE_ID = 'design-v1';
     const CURRENT_SCHEMA_VERSION = 1;
@@ -152,6 +153,85 @@
         } catch (error) {
             console.warn('Could not persist active department profile id:', error);
         }
+    }
+
+    function readCustomProfilesStore() {
+        try {
+            const raw = global.localStorage.getItem(CUSTOM_PROFILES_STORAGE_KEY);
+            if (!raw) return {};
+            const parsed = JSON.parse(raw);
+            return isObject(parsed) ? parsed : {};
+        } catch (error) {
+            console.warn('Could not read custom profile store:', error);
+            return {};
+        }
+    }
+
+    function writeCustomProfilesStore(store) {
+        try {
+            const safeStore = isObject(store) ? store : {};
+            global.localStorage.setItem(CUSTOM_PROFILES_STORAGE_KEY, JSON.stringify(safeStore));
+        } catch (error) {
+            console.warn('Could not persist custom profile store:', error);
+        }
+    }
+
+    function sanitizeProfileBaseId(rawValue) {
+        const normalized = String(rawValue || '')
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+/, '')
+            .replace(/-+$/, '');
+        return normalized || 'department';
+    }
+
+    function escapeRegExp(text) {
+        return String(text || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+
+    function getNextVersionedProfileId(baseId, existingIds) {
+        const prefix = sanitizeProfileBaseId(baseId);
+        const pattern = new RegExp(`^${escapeRegExp(prefix)}-v(\\d+)$`, 'i');
+        let maxVersion = 0;
+        (Array.isArray(existingIds) ? existingIds : []).forEach((candidateId) => {
+            const match = String(candidateId || '').match(pattern);
+            if (!match) return;
+            const version = Number(match[1]);
+            if (Number.isFinite(version) && version > maxVersion) {
+                maxVersion = version;
+            }
+        });
+        return `${prefix}-v${String(maxVersion + 1).padStart(2, '0')}`;
+    }
+
+    function readCustomProfile(profileId) {
+        const normalizedId = String(profileId || '').trim();
+        if (!normalizedId) return null;
+        const store = readCustomProfilesStore();
+        const entry = store[normalizedId];
+        if (!entry) return null;
+        if (isObject(entry.profile)) return deepClone(entry.profile);
+        if (isObject(entry)) return deepClone(entry);
+        return null;
+    }
+
+    function listCustomProfileEntries() {
+        const store = readCustomProfilesStore();
+        return Object.entries(store)
+            .map(([id, entry]) => {
+                const profile = isObject(entry?.profile) ? entry.profile : (isObject(entry) ? entry : null);
+                if (!profile) return null;
+                return {
+                    id,
+                    source: 'custom-local',
+                    savedAt: String(entry?.savedAt || entry?.updatedAt || '').trim() || null,
+                    baseId: String(entry?.baseId || '').trim() || null,
+                    profile: deepClone(profile)
+                };
+            })
+            .filter(Boolean)
+            .sort((a, b) => String(a.id).localeCompare(String(b.id)));
     }
 
     async function fetchJson(url) {
@@ -394,7 +474,18 @@
             const storedId = readStoredProfileId();
             const nextProfileId = requestedId || storedId || manifestDefaultId || DEFAULT_PROFILE_ID;
 
-            let loadedResult = await loadProfileDocument(nextProfileId, manifest);
+            const customProfile = readCustomProfile(nextProfileId);
+            let loadedResult = null;
+            if (customProfile && isObject(customProfile)) {
+                loadedResult = {
+                    ok: true,
+                    profile: customProfile,
+                    warnings: [`Loaded custom local profile ${nextProfileId}.`],
+                    source: 'custom-local'
+                };
+            } else {
+                loadedResult = await loadProfileDocument(nextProfileId, manifest);
+            }
             warnings.push(...loadedResult.warnings);
 
             let rawProfile = loadedResult.profile;
@@ -468,6 +559,137 @@
         return initialize({ profileId: normalized, forceReload: true });
     }
 
+    async function loadProfile(profileId) {
+        const normalizedId = String(profileId || '').trim();
+        if (!normalizedId) {
+            throw new Error('Profile id is required.');
+        }
+
+        const warnings = [];
+        const errors = [];
+        const manifestResult = await loadManifest();
+        warnings.push(...(manifestResult.warnings || []));
+        const manifest = manifestResult.manifest;
+
+        const customProfile = readCustomProfile(normalizedId);
+        let source = 'json-file';
+        let rawProfile = null;
+        if (customProfile) {
+            rawProfile = customProfile;
+            source = 'custom-local';
+        } else {
+            const loaded = await loadProfileDocument(normalizedId, manifest);
+            warnings.push(...(loaded.warnings || []));
+            rawProfile = loaded.profile;
+            source = loaded.source;
+        }
+
+        if (!isObject(rawProfile)) {
+            rawProfile = deepClone(DEFAULT_PROFILE);
+            source = 'embedded-default';
+            warnings.push(`Could not resolve ${normalizedId}; using default profile.`);
+        }
+
+        let migratedProfile = null;
+        try {
+            migratedProfile = migrateProfile(rawProfile, warnings);
+        } catch (error) {
+            errors.push(error && error.message ? error.message : 'Profile migration failed.');
+            migratedProfile = deepClone(DEFAULT_PROFILE);
+            source = 'embedded-default';
+        }
+
+        const normalizedProfile = normalizeProfile(migratedProfile);
+        const validation = validateProfile(normalizedProfile);
+        warnings.push(...validation.warnings);
+        errors.push(...validation.errors);
+
+        return {
+            profile: normalizedProfile,
+            source,
+            warnings,
+            errors,
+            valid: validation.valid
+        };
+    }
+
+    async function listProfiles() {
+        const manifestResult = await loadManifest();
+        const manifest = manifestResult.manifest || {};
+        const manifestProfiles = Array.isArray(manifest.profiles) ? manifest.profiles : [];
+        const discovered = [];
+
+        manifestProfiles.forEach((entry) => {
+            const id = String(entry?.id || '').trim();
+            if (!id) return;
+            discovered.push({
+                id,
+                file: entry.file ? String(entry.file) : `${id}.json`,
+                source: 'manifest'
+            });
+        });
+
+        const custom = listCustomProfileEntries().map((entry) => ({
+            id: entry.id,
+            file: null,
+            source: entry.source,
+            savedAt: entry.savedAt,
+            baseId: entry.baseId
+        }));
+
+        const mergedMap = new Map();
+        [...discovered, ...custom].forEach((entry) => {
+            if (!entry || !entry.id) return;
+            mergedMap.set(entry.id, entry);
+        });
+
+        return {
+            profiles: [...mergedMap.values()].sort((a, b) => String(a.id).localeCompare(String(b.id))),
+            warnings: manifestResult.warnings || []
+        };
+    }
+
+    async function saveCustomProfile(rawProfile, options) {
+        const config = isObject(options) ? options : {};
+        if (!isObject(rawProfile)) {
+            throw new Error('Profile payload must be an object.');
+        }
+
+        const store = readCustomProfilesStore();
+        const baseId = sanitizeProfileBaseId(config.baseId || rawProfile.id || rawProfile.identity?.code || 'department');
+        const nextProfileId = getNextVersionedProfileId(baseId, Object.keys(store));
+
+        const normalizedCandidate = normalizeProfile(rawProfile);
+        normalizedCandidate.id = nextProfileId;
+        normalizedCandidate.version = CURRENT_SCHEMA_VERSION;
+
+        const validation = validateProfile(normalizedCandidate);
+        if (!validation.valid) {
+            throw new Error(`Profile validation failed: ${validation.errors.join(' | ')}`);
+        }
+
+        const entry = {
+            profile: normalizedCandidate,
+            baseId,
+            savedAt: new Date().toISOString()
+        };
+        store[nextProfileId] = entry;
+        writeCustomProfilesStore(store);
+
+        let snapshot = null;
+        if (config.activate !== false) {
+            snapshot = await setActiveProfile(nextProfileId);
+        }
+
+        return {
+            profileId: nextProfileId,
+            profile: deepClone(normalizedCandidate),
+            validation,
+            entry: deepClone(entry),
+            snapshot
+        };
+    }
+
     function getValidationReport(profile) {
         const candidate = profile ? normalizeProfile(profile) : deepClone(state.profile);
         const validation = validateProfile(candidate);
@@ -482,6 +704,7 @@
     global.DepartmentProfileManager = {
         CURRENT_SCHEMA_VERSION,
         ACTIVE_PROFILE_STORAGE_KEY,
+        CUSTOM_PROFILES_STORAGE_KEY,
         DEFAULT_PROFILE_ID,
         getProfileBasePath,
         getDefaultProfile: function getDefaultProfile() {
@@ -495,7 +718,10 @@
             return state.activeProfileId;
         },
         getStoredProfileId: readStoredProfileId,
+        listProfiles,
+        loadProfile,
         setActiveProfile,
+        saveCustomProfile,
         initialize,
         validateProfile: getValidationReport,
         resetCache: function resetCache() {

--- a/js/department-profile.js
+++ b/js/department-profile.js
@@ -43,7 +43,25 @@
         },
         scheduler: {
             storageKeyPrefix: 'designSchedulerData_',
-            allowedRooms: ['206', '207', '209', '210', '212', 'CEB 102', 'CEB 104']
+            allowedRooms: ['206', '207', '209', '210', '212', 'CEB 102', 'CEB 104'],
+            dayPatterns: [
+                { id: 'MW', label: 'Monday / Wednesday', aliases: ['MW', 'WM'] },
+                { id: 'TR', label: 'Tuesday / Thursday', aliases: ['TR', 'RT', 'TH', 'TTH'] }
+            ],
+            timeSlots: [
+                { id: '10:00-12:20', label: '10:00-12:20', aliases: ['10:00-12:00'], startMinutes: 600, endMinutes: 740 },
+                { id: '13:00-15:20', label: '13:00-15:20', aliases: ['13:00-15:00'], startMinutes: 780, endMinutes: 920 },
+                { id: '16:00-18:20', label: '16:00-18:20', aliases: ['16:00-18:00'], startMinutes: 960, endMinutes: 1100 }
+            ],
+            roomLabels: {
+                '206': '206 UX Lab',
+                '207': '207 Media Lab',
+                '209': '209 Mac Lab',
+                '210': '210 Mac Lab',
+                '212': '212 Project Lab',
+                'CEB 102': 'CEB 102',
+                'CEB 104': 'CEB 104'
+            }
         },
         workload: {
             dashboardTitle: 'Faculty Workload Dashboard',
@@ -66,7 +84,9 @@
                     'course+section+instructor+quarter',
                     'course+quarter+instructor',
                     'course+quarter'
-                ]
+                ],
+                facultyAliases: {},
+                courseAliases: {}
             }
         }
     });
@@ -183,8 +203,28 @@
             .map((room) => String(room || '').trim())
             .filter(Boolean);
 
+        if (!Array.isArray(merged.scheduler.dayPatterns) || merged.scheduler.dayPatterns.length === 0) {
+            merged.scheduler.dayPatterns = DEFAULT_PROFILE.scheduler.dayPatterns.slice();
+        }
+
+        if (!Array.isArray(merged.scheduler.timeSlots) || merged.scheduler.timeSlots.length === 0) {
+            merged.scheduler.timeSlots = DEFAULT_PROFILE.scheduler.timeSlots.slice();
+        }
+
+        if (!isObject(merged.scheduler.roomLabels)) {
+            merged.scheduler.roomLabels = { ...DEFAULT_PROFILE.scheduler.roomLabels };
+        }
+
         if (!Array.isArray(merged.import.clss.roomMatchPriority)) {
             merged.import.clss.roomMatchPriority = merged.scheduler.allowedRooms.slice();
+        }
+
+        if (!isObject(merged.import.clss.facultyAliases)) {
+            merged.import.clss.facultyAliases = {};
+        }
+
+        if (!isObject(merged.import.clss.courseAliases)) {
+            merged.import.clss.courseAliases = {};
         }
 
         return merged;

--- a/js/workload-integration.js
+++ b/js/workload-integration.js
@@ -7,18 +7,18 @@ const WorkloadIntegration = (function() {
     'use strict';
 
     const AY_SETUP_STORAGE_KEY = 'programCommandAySetup';
-    const SCHEDULE_STORAGE_PREFIX = 'designSchedulerData_';
+    const DEFAULT_SCHEDULE_STORAGE_PREFIX = 'designSchedulerData_';
     const DETAIL_STORAGE_KEY = 'programCommandFacultyWorkloadDetails';
     const CLSS_WORKLOAD_IMPORT_STORAGE_KEY = 'programCommandClssWorkloadImport';
 
-    const APPLIED_LEARNING_COURSES = {
+    const DEFAULT_APPLIED_LEARNING_COURSES = {
         'DESN 399': { title: 'Independent Study', rate: 0.2 },
         'DESN 491': { title: 'Senior Project', rate: 0.2 },
         'DESN 495': { title: 'Internship', rate: 0.1 },
         'DESN 499': { title: 'Independent Study', rate: 0.2 }
     };
 
-    const ROLE_TARGET_DEFAULTS = {
+    const DEFAULT_ROLE_TARGET_DEFAULTS = {
         'Tenure/Tenure-track': 36,
         'Full Professor': 36,
         'Associate Professor': 36,
@@ -29,7 +29,7 @@ const WorkloadIntegration = (function() {
 
     // Chair-provided preliminary planning defaults used when AY Setup is missing.
     // These are name/alias matched and only applied as fallbacks.
-    const PRELIMINARY_ROSTER_TARGET_RULES = [
+    const DEFAULT_PRELIMINARY_ROSTER_TARGET_RULES = [
         {
             id: 'travis-tenure',
             aliases: ['travis', 'travis masingale', 'tmasingale', 'masingale', 't masingale'],
@@ -102,6 +102,117 @@ const WorkloadIntegration = (function() {
         Spring: 'spring',
         Summer: 'summer'
     };
+
+    function getActiveDepartmentProfile() {
+        const profileFromGlobal = (typeof globalThis !== 'undefined' && globalThis.__PROGRAM_COMMAND_ACTIVE_PROFILE__)
+            ? globalThis.__PROGRAM_COMMAND_ACTIVE_PROFILE__
+            : null;
+        if (profileFromGlobal && typeof profileFromGlobal === 'object') {
+            return profileFromGlobal;
+        }
+        const profileFromWindow = (typeof window !== 'undefined' && window.activeDepartmentProfile)
+            ? window.activeDepartmentProfile
+            : null;
+        if (profileFromWindow && typeof profileFromWindow === 'object') {
+            return profileFromWindow;
+        }
+        return null;
+    }
+
+    function getScheduleStoragePrefixes() {
+        const profile = getActiveDepartmentProfile();
+        const profileScheduler = profile && profile.scheduler && typeof profile.scheduler === 'object'
+            ? profile.scheduler
+            : {};
+        const activePrefix = String(profileScheduler.storageKeyPrefix || DEFAULT_SCHEDULE_STORAGE_PREFIX).trim()
+            || DEFAULT_SCHEDULE_STORAGE_PREFIX;
+        const legacy = Array.isArray(profileScheduler.legacyStoragePrefixes)
+            ? profileScheduler.legacyStoragePrefixes
+            : [];
+        const normalizedLegacy = legacy
+            .map((value) => String(value || '').trim())
+            .filter(Boolean);
+        const all = [activePrefix, ...normalizedLegacy, DEFAULT_SCHEDULE_STORAGE_PREFIX];
+        return [...new Set(all)];
+    }
+
+    function normalizeAppliedLearningCourseMap(rawMap) {
+        if (!rawMap || typeof rawMap !== 'object' || Array.isArray(rawMap)) {
+            return { ...DEFAULT_APPLIED_LEARNING_COURSES };
+        }
+
+        const merged = {};
+        const sourceEntries = Object.entries(rawMap);
+        sourceEntries.forEach(([code, details]) => {
+            const normalizedCode = normalizeCourseCode(code);
+            if (!normalizedCode) return;
+
+            if (Number.isFinite(Number(details))) {
+                const numericRate = Number(details);
+                if (numericRate > 0) {
+                    merged[normalizedCode] = { title: normalizedCode, rate: numericRate };
+                }
+                return;
+            }
+
+            if (!details || typeof details !== 'object' || Array.isArray(details)) {
+                return;
+            }
+
+            const rate = Number(details.rate);
+            if (!Number.isFinite(rate) || rate <= 0) return;
+            const title = String(details.title || normalizedCode).trim() || normalizedCode;
+            merged[normalizedCode] = { title, rate };
+        });
+
+        return Object.keys(merged).length
+            ? merged
+            : { ...DEFAULT_APPLIED_LEARNING_COURSES };
+    }
+
+    function getAppliedLearningCourseConfig() {
+        const profile = getActiveDepartmentProfile();
+        const profileWorkload = profile && profile.workload && typeof profile.workload === 'object'
+            ? profile.workload
+            : {};
+        return normalizeAppliedLearningCourseMap(profileWorkload.appliedLearningCourses);
+    }
+
+    function getRoleTargetDefaults() {
+        const profile = getActiveDepartmentProfile();
+        const profileWorkload = profile && profile.workload && typeof profile.workload === 'object'
+            ? profile.workload
+            : {};
+        const fromProfile = profileWorkload.defaultAnnualTargets
+            && typeof profileWorkload.defaultAnnualTargets === 'object'
+            && !Array.isArray(profileWorkload.defaultAnnualTargets)
+            ? profileWorkload.defaultAnnualTargets
+            : {};
+        return {
+            ...DEFAULT_ROLE_TARGET_DEFAULTS,
+            ...fromProfile
+        };
+    }
+
+    function getPreliminaryRosterTargetRules() {
+        const profile = getActiveDepartmentProfile();
+        const profileWorkload = profile && profile.workload && typeof profile.workload === 'object'
+            ? profile.workload
+            : {};
+        const customRules = Array.isArray(profileWorkload.preliminaryRosterTargetRules)
+            ? profileWorkload.preliminaryRosterTargetRules
+            : [];
+        return customRules.length ? customRules : DEFAULT_PRELIMINARY_ROSTER_TARGET_RULES;
+    }
+
+    function createAppliedLearningSummaryBuckets(appliedLearningMap = null) {
+        const map = appliedLearningMap || getAppliedLearningCourseConfig();
+        const buckets = {};
+        Object.keys(map).forEach((code) => {
+            buckets[code] = { credits: 0, workload: 0, students: 0, sections: 0 };
+        });
+        return buckets;
+    }
 
     function parseStorageJSON(key, fallback) {
         try {
@@ -176,7 +287,7 @@ const WorkloadIntegration = (function() {
         const normalized = normalizeNameKey(name);
         if (!normalized) return null;
 
-        return PRELIMINARY_ROSTER_TARGET_RULES.find((rule) => {
+        return getPreliminaryRosterTargetRules().find((rule) => {
             return (rule.aliases || []).some((alias) => {
                 const aliasKey = normalizeNameKey(alias);
                 if (!aliasKey) return false;
@@ -248,11 +359,11 @@ const WorkloadIntegration = (function() {
 
     function getAppliedLearningRate(courseCode) {
         const code = normalizeCourseCode(courseCode);
-        return APPLIED_LEARNING_COURSES[code]?.rate || 1;
+        return getAppliedLearningCourseConfig()[code]?.rate || 1;
     }
 
     function getAppliedLearningCourses() {
-        return Object.entries(APPLIED_LEARNING_COURSES).map(([code, details]) => ({
+        return Object.entries(getAppliedLearningCourseConfig()).map(([code, details]) => ({
             code,
             title: details.title,
             rate: details.rate
@@ -269,12 +380,21 @@ const WorkloadIntegration = (function() {
     }
 
     function getScheduleStorageKey(year) {
-        return `${SCHEDULE_STORAGE_PREFIX}${year}`;
+        const prefixes = getScheduleStoragePrefixes();
+        const activePrefix = prefixes[0] || DEFAULT_SCHEDULE_STORAGE_PREFIX;
+        return `${activePrefix}${year}`;
     }
 
     function readProgramCommandSchedule(year) {
         if (!year) return null;
-        return parseStorageJSON(getScheduleStorageKey(year), null);
+        const prefixes = getScheduleStoragePrefixes();
+        for (const prefix of prefixes) {
+            const parsed = parseStorageJSON(`${prefix}${year}`, null);
+            if (parsed && typeof parsed === 'object') {
+                return parsed;
+            }
+        }
+        return null;
     }
 
     function readClssWorkloadImportPayload() {
@@ -458,11 +578,22 @@ const WorkloadIntegration = (function() {
 
     function collectScheduleYearsFromLocalStorage() {
         const years = [];
+        const prefixes = getScheduleStoragePrefixes();
         try {
             for (let i = 0; i < localStorage.length; i += 1) {
                 const key = localStorage.key(i);
-                if (!key || !key.startsWith(SCHEDULE_STORAGE_PREFIX)) continue;
-                const year = key.slice(SCHEDULE_STORAGE_PREFIX.length);
+                if (!key) continue;
+
+                let matchedPrefix = '';
+                for (const prefix of prefixes) {
+                    if (key.startsWith(prefix)) {
+                        matchedPrefix = prefix;
+                        break;
+                    }
+                }
+                if (!matchedPrefix) continue;
+
+                const year = key.slice(matchedPrefix.length);
                 if (/^\d{4}-\d{2}$/.test(year)) {
                     years.push(year);
                 }
@@ -512,6 +643,7 @@ const WorkloadIntegration = (function() {
     }
 
     function createEmptyFacultyRecord(name) {
+        const appliedLearningBuckets = createAppliedLearningSummaryBuckets();
         return {
             facultyName: String(name || '').trim(),
             originalName: String(name || '').trim(),
@@ -523,12 +655,7 @@ const WorkloadIntegration = (function() {
             totalStudents: 0,
             sections: 0,
             courses: [],
-            appliedLearning: {
-                'DESN 399': { credits: 0, workload: 0, students: 0, sections: 0 },
-                'DESN 491': { credits: 0, workload: 0, students: 0, sections: 0 },
-                'DESN 495': { credits: 0, workload: 0, students: 0, sections: 0 },
-                'DESN 499': { credits: 0, workload: 0, students: 0, sections: 0 }
-            },
+            appliedLearning: appliedLearningBuckets,
             category: 'fullTime',
             status: 'underutilized',
             rank: 'Lecturer',
@@ -610,6 +737,7 @@ const WorkloadIntegration = (function() {
     }
 
     function recalcFacultyRecord(record) {
+        const appliedLearningConfig = getAppliedLearningCourseConfig();
         const summary = {
             totalCredits: 0,
             totalWorkloadCredits: 0,
@@ -619,12 +747,7 @@ const WorkloadIntegration = (function() {
             totalStudents: 0,
             sections: 0,
             byQuarter: createQuarterSummary(),
-            appliedLearning: {
-                'DESN 399': { credits: 0, workload: 0, students: 0, sections: 0 },
-                'DESN 491': { credits: 0, workload: 0, students: 0, sections: 0 },
-                'DESN 495': { credits: 0, workload: 0, students: 0, sections: 0 },
-                'DESN 499': { credits: 0, workload: 0, students: 0, sections: 0 }
-            }
+            appliedLearning: createAppliedLearningSummaryBuckets(appliedLearningConfig)
         };
 
         const normalizedCourses = (Array.isArray(record.courses) ? record.courses : []).map((course, index) => {
@@ -732,6 +855,8 @@ const WorkloadIntegration = (function() {
         const ayFaculty = Array.isArray(ayYearData.faculty) ? ayYearData.faculty : [];
         const scheduleCourses = getProgramCommandScheduleCourses(year);
         const detailFacultyMap = getDetailEntriesForYear(year);
+        const appliedLearningConfig = getAppliedLearningCourseConfig();
+        const roleTargetDefaults = getRoleTargetDefaults();
 
         const baseAll = baseYearData.all || {};
         const baseNames = Object.keys(baseAll);
@@ -825,7 +950,7 @@ const WorkloadIntegration = (function() {
 
             entries.forEach((entry, index) => {
                 const code = normalizeCourseCode(entry.courseCode);
-                if (!APPLIED_LEARNING_COURSES[code]) return;
+                if (!appliedLearningConfig[code]) return;
 
                 const studentCredits = Number(entry.studentCredits);
                 if (!Number.isFinite(studentCredits) || studentCredits <= 0) return;
@@ -869,7 +994,7 @@ const WorkloadIntegration = (function() {
 
             if (ayRecord) {
                 const role = String(ayRecord.role || record.rank || '').trim();
-                const targetFromRole = ROLE_TARGET_DEFAULTS[role] || null;
+                const targetFromRole = roleTargetDefaults[role] || null;
                 const annualTargetCredits = Number(ayRecord.annualTargetCredits);
                 const target = Number.isFinite(annualTargetCredits) && annualTargetCredits > 0
                     ? annualTargetCredits
@@ -989,15 +1114,20 @@ const WorkloadIntegration = (function() {
         });
 
         const unresolvedSummary = summarizeUnassignedScheduleCourses(unassignedScheduleCourses);
+        const appliedLearningAssumptionText = Object.entries(appliedLearningConfig)
+            .map(([code, details]) => `${code} (${Number(details.rate)})`)
+            .join(', ');
         const preliminaryAssumptions = [
             'Teaching workload is derived from the Program Command scheduler draft for the selected academic year.',
-            'DESN 399/491/499 use 0.2 workload rate and DESN 495 uses 0.1 workload rate.',
+            appliedLearningAssumptionText
+                ? `Applied-learning workload multipliers: ${appliedLearningAssumptionText}.`
+                : 'Applied-learning workload multipliers are profile-driven.',
             'TBD/Staff/blank instructor assignments are excluded from faculty totals and listed as unresolved sections.',
             'Non-teaching workload (service/research/PTOL/other assigned time) is not derived from the schedule and should be reviewed manually unless AY setup release credits are entered.'
         ];
 
         if (fallbackRulesApplied.length > 0) {
-            preliminaryAssumptions.push('Fallback chair planning targets were applied for matched faculty (tenure/tenure-track 36, lecturers 45, Mindy chair teaching target 18 via 18-credit release).');
+            preliminaryAssumptions.push('Fallback planning targets were applied for matched faculty based on the active department profile roster rules.');
         }
         if (adjunctAssignedDefaultsApplied.length > 0) {
             preliminaryAssumptions.push('Unlisted instructors are treated as adjuncts by default; adjunct target credits default to their currently assigned AY workload unless edited in AY Setup / workload planning.');
@@ -1025,7 +1155,7 @@ const WorkloadIntegration = (function() {
     }
 
     return {
-        APPLIED_LEARNING_COURSES,
+        APPLIED_LEARNING_COURSES: DEFAULT_APPLIED_LEARNING_COURSES,
         QUARTER_KEY_TO_NAME,
         QUARTER_NAME_TO_KEY,
         normalizeNameKey,
@@ -1033,6 +1163,7 @@ const WorkloadIntegration = (function() {
         normalizeQuarterName,
         getAppliedLearningRate,
         getAppliedLearningCourses,
+        getAppliedLearningCourseConfig,
         readAySetupDataForYear,
         readProgramCommandSchedule,
         getProgramCommandScheduleCourses,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "process-data": "node scripts/process-enrollment-data.js",
     "calculate-workload": "node scripts/workload-calculator.js enrollment-data/processed",
     "validate-data": "node scripts/validate-enrollment.js enrollment-data/processed/corrected-all-quarters.csv",
-    "serve": "node api-server.js"
+    "serve": "node api-server.js",
+    "check:data-freshness": "node scripts/check-data-freshness.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "calculate-workload": "node scripts/workload-calculator.js enrollment-data/processed",
     "validate-data": "node scripts/validate-enrollment.js enrollment-data/processed/corrected-all-quarters.csv",
     "serve": "node api-server.js",
-    "check:data-freshness": "node scripts/check-data-freshness.js"
+    "check:data-freshness": "node scripts/check-data-freshness.js",
+    "qa:onboarding": "npm test -- tests/conflict-engine.slot-resolutions.test.js tests/conflict-engine.regression-scenarios.test.js tests/conflict-engine.room-fit-recommendations.test.js tests/workload-integration.test.js tests/department-profile.onboarding.test.js"
   },
   "repository": {
     "type": "git",

--- a/pages/course-management.html
+++ b/pages/course-management.html
@@ -613,6 +613,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="../js/supabase-config.js"></script>
     <script src="../js/db-service.js"></script>
+    <script src="../js/auth-service.js"></script>
     <script src="course-management.js"></script>
 </body>
 </html>

--- a/pages/department-onboarding.html
+++ b/pages/department-onboarding.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Department Onboarding Shell</title>
+    <link rel="stylesheet" href="../css/design-system.css">
+    <link rel="stylesheet" href="../css/shared.css">
+    <link rel="stylesheet" href="../css/dashboard.css">
+    <style>
+        body {
+            margin: 0;
+            background: #f6f8fb;
+            color: #0f172a;
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        }
+
+        .onboarding-shell {
+            max-width: 1080px;
+            margin: 0 auto;
+            padding: 24px;
+            display: grid;
+            gap: 16px;
+        }
+
+        .shell-card {
+            background: #ffffff;
+            border: 1px solid #d9e2ec;
+            border-radius: 12px;
+            padding: 16px;
+            box-shadow: 0 4px 14px rgba(15, 23, 42, 0.06);
+        }
+
+        .shell-card h2 {
+            margin: 0 0 10px;
+            font-size: 1.1rem;
+        }
+
+        .shell-card p {
+            margin: 0 0 12px;
+            color: #475569;
+        }
+
+        .field-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 10px;
+        }
+
+        label {
+            display: grid;
+            gap: 6px;
+            font-size: 0.9rem;
+            color: #1e293b;
+        }
+
+        input,
+        textarea,
+        select,
+        button {
+            border: 1px solid #cbd5e1;
+            border-radius: 8px;
+            padding: 10px;
+            font-size: 0.92rem;
+            font-family: inherit;
+        }
+
+        textarea {
+            min-height: 120px;
+            resize: vertical;
+        }
+
+        .shell-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            align-items: center;
+        }
+
+        .shell-actions button {
+            cursor: pointer;
+            background: #0f172a;
+            color: #ffffff;
+            border-color: #0f172a;
+        }
+
+        .shell-actions button.secondary {
+            background: #ffffff;
+            color: #0f172a;
+        }
+
+        .onboarding-status {
+            border-radius: 8px;
+            padding: 10px;
+            border: 1px solid #cbd5e1;
+            background: #f8fafc;
+            color: #0f172a;
+            min-height: 20px;
+        }
+
+        .onboarding-status.ok {
+            border-color: #16a34a;
+            background: #f0fdf4;
+            color: #14532d;
+        }
+
+        .onboarding-status.warn {
+            border-color: #d97706;
+            background: #fffbeb;
+            color: #92400e;
+        }
+
+        .onboarding-status.error {
+            border-color: #dc2626;
+            background: #fef2f2;
+            color: #991b1b;
+        }
+
+        .onboarding-status.info {
+            border-color: #2563eb;
+            background: #eff6ff;
+            color: #1e3a8a;
+        }
+
+        #healthCheckOutput {
+            display: grid;
+            gap: 10px;
+        }
+
+        .check-group {
+            border: 1px solid #cbd5e1;
+            border-radius: 8px;
+            padding: 10px;
+            background: #ffffff;
+        }
+
+        .check-group h4 {
+            margin: 0 0 8px;
+            font-size: 0.95rem;
+        }
+
+        .check-group ul {
+            margin: 0;
+            padding-left: 18px;
+            display: grid;
+            gap: 4px;
+        }
+
+        .check-group.error {
+            border-color: #dc2626;
+            background: #fef2f2;
+        }
+
+        .check-group.warning {
+            border-color: #d97706;
+            background: #fffbeb;
+        }
+
+        .check-group.pass {
+            border-color: #16a34a;
+            background: #f0fdf4;
+        }
+    </style>
+</head>
+<body>
+    <app-header
+        eyebrow="PROGRAM COMMAND"
+        title-text="Department Onboarding Shell"
+        subtitle="Create and activate a versioned department profile without code edits for standard setup"
+    ></app-header>
+
+    <main class="onboarding-shell">
+        <section class="shell-card">
+            <h2>Step 1: Entry + Base Profile</h2>
+            <p>Select an existing profile as your base, then define department identity.</p>
+            <div class="field-grid">
+                <label>
+                    Base Profile
+                    <select id="baseProfileSelect"></select>
+                </label>
+                <label>
+                    Department Name
+                    <input id="departmentName" type="text" placeholder="Design">
+                </label>
+                <label>
+                    Department Code
+                    <input id="departmentCode" type="text" placeholder="DESN">
+                </label>
+                <label>
+                    Display Name
+                    <input id="departmentDisplayName" type="text" placeholder="EWU Design">
+                </label>
+                <label>
+                    Short Name
+                    <input id="departmentShortName" type="text" placeholder="Design">
+                </label>
+            </div>
+            <p id="baseProfileState"></p>
+        </section>
+
+        <section class="shell-card">
+            <h2>Step 2: Seed Mapping Wizard</h2>
+            <p>Enter room map and CLSS alias mappings. Use one item per line. Alias format: <code>alias=canonical</code>.</p>
+            <div class="field-grid">
+                <label>
+                    Rooms (one per line)
+                    <textarea id="roomListInput" placeholder="206\n207\nCEB 102"></textarea>
+                </label>
+                <label>
+                    Faculty Aliases
+                    <textarea id="facultyAliasInput" placeholder="T Masingale=T.Masingale\nMindy Breen=M.Breen"></textarea>
+                </label>
+                <label>
+                    Course Aliases
+                    <textarea id="courseAliasInput" placeholder="DES 101=DESN 101\nDESN101=DESN 101"></textarea>
+                </label>
+            </div>
+        </section>
+
+        <section class="shell-card">
+            <h2>Step 3: Health Checks + Activation</h2>
+            <p>Run checks before activation. Errors block activation. Warnings are advisory.</p>
+            <div class="shell-actions">
+                <button id="runHealthChecksButton" class="secondary" type="button">Run Health Checks</button>
+                <button id="saveActivateButton" type="button">Save Versioned Profile + Activate</button>
+                <span id="activationResult"></span>
+            </div>
+            <div id="healthCheckOutput"></div>
+        </section>
+
+        <section class="shell-card">
+            <h2>Current Status</h2>
+            <div id="onboardingStatus" class="onboarding-status">Initializing onboarding shell...</div>
+        </section>
+    </main>
+
+    <script type="module" src="../js/components/app-header.js"></script>
+    <script src="../js/department-profile.js"></script>
+    <script src="department-onboarding.js"></script>
+</body>
+</html>

--- a/pages/department-onboarding.html
+++ b/pages/department-onboarding.html
@@ -171,8 +171,8 @@
 
     <main class="onboarding-shell">
         <section class="shell-card">
-            <h2>Step 1: Entry + Base Profile</h2>
-            <p>Select an existing profile as your base, then define department identity.</p>
+            <h2 id="step1Title">Step 1: Entry + Base Profile</h2>
+            <p id="step1Help">Select an existing profile as your base, then define department identity.</p>
             <div class="field-grid">
                 <label>
                     Base Profile
@@ -199,8 +199,8 @@
         </section>
 
         <section class="shell-card">
-            <h2>Step 2: Seed Mapping Wizard</h2>
-            <p>Enter room map and CLSS alias mappings. Use one item per line. Alias format: <code>alias=canonical</code>.</p>
+            <h2 id="step2Title">Step 2: Seed Mapping Wizard</h2>
+            <p id="step2Help">Enter room map and CLSS alias mappings. Use one item per line. Alias format: <code>alias=canonical</code>.</p>
             <div class="field-grid">
                 <label>
                     Rooms (one per line)
@@ -218,8 +218,8 @@
         </section>
 
         <section class="shell-card">
-            <h2>Step 3: Health Checks + Activation</h2>
-            <p>Run checks before activation. Errors block activation. Warnings are advisory.</p>
+            <h2 id="step3Title">Step 3: Health Checks + Activation</h2>
+            <p id="step3Help">Run checks before activation. Errors block activation. Warnings are advisory.</p>
             <div class="shell-actions">
                 <button id="runHealthChecksButton" class="secondary" type="button">Run Health Checks</button>
                 <button id="saveActivateButton" type="button">Save Versioned Profile + Activate</button>
@@ -229,7 +229,7 @@
         </section>
 
         <section class="shell-card">
-            <h2>Current Status</h2>
+            <h2 id="statusTitle">Current Status</h2>
             <div id="onboardingStatus" class="onboarding-status">Initializing onboarding shell...</div>
         </section>
     </main>

--- a/pages/department-onboarding.js
+++ b/pages/department-onboarding.js
@@ -1,0 +1,382 @@
+(function departmentOnboardingPage() {
+    'use strict';
+
+    const state = {
+        manager: null,
+        baseProfile: null,
+        baseProfileSource: 'embedded-default',
+        lastChecks: null
+    };
+
+    function qs(id) {
+        return document.getElementById(id);
+    }
+
+    function clone(value) {
+        return JSON.parse(JSON.stringify(value));
+    }
+
+    function sanitizeCode(rawValue) {
+        return String(rawValue || '').trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
+    }
+
+    function sanitizeBaseId(rawValue) {
+        return String(rawValue || '')
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+/, '')
+            .replace(/-+$/, '')
+            || 'department';
+    }
+
+    function parseListLines(rawText) {
+        return String(rawText || '')
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+    }
+
+    function parseAliasLines(rawText) {
+        const aliases = {};
+        const errors = [];
+        parseListLines(rawText).forEach((line, index) => {
+            const splitIndex = line.indexOf('=');
+            if (splitIndex <= 0 || splitIndex === line.length - 1) {
+                errors.push(`Line ${index + 1}: use format alias=canonical`);
+                return;
+            }
+            const alias = line.slice(0, splitIndex).trim();
+            const canonical = line.slice(splitIndex + 1).trim();
+            if (!alias || !canonical) {
+                errors.push(`Line ${index + 1}: alias/canonical cannot be empty`);
+                return;
+            }
+            aliases[alias] = canonical;
+        });
+
+        return { aliases, errors };
+    }
+
+    function setStatus(kind, message) {
+        const statusEl = qs('onboardingStatus');
+        if (!statusEl) return;
+        statusEl.className = `onboarding-status ${kind}`;
+        statusEl.textContent = message;
+    }
+
+    function renderHealthChecks(checks) {
+        const wrap = qs('healthCheckOutput');
+        if (!wrap) return;
+        wrap.innerHTML = '';
+
+        const renderGroup = (title, items, cssClass) => {
+            if (!items.length) return;
+            const section = document.createElement('div');
+            section.className = `check-group ${cssClass}`;
+
+            const h4 = document.createElement('h4');
+            h4.textContent = title;
+            section.appendChild(h4);
+
+            const ul = document.createElement('ul');
+            items.forEach((item) => {
+                const li = document.createElement('li');
+                li.textContent = item;
+                ul.appendChild(li);
+            });
+            section.appendChild(ul);
+            wrap.appendChild(section);
+        };
+
+        renderGroup('Errors', checks.errors, 'error');
+        renderGroup('Warnings', checks.warnings, 'warning');
+        renderGroup('Passes', checks.passes, 'pass');
+
+        if (!checks.errors.length && !checks.warnings.length && !checks.passes.length) {
+            wrap.textContent = 'No checks run yet.';
+        }
+    }
+
+    function readIdentityInputs() {
+        const name = String(qs('departmentName')?.value || '').trim();
+        const code = sanitizeCode(qs('departmentCode')?.value || '');
+        const displayName = String(qs('departmentDisplayName')?.value || '').trim();
+        const shortName = String(qs('departmentShortName')?.value || '').trim();
+        return { name, code, displayName, shortName };
+    }
+
+    function buildDraftProfile() {
+        if (!state.baseProfile) {
+            throw new Error('Base profile is not loaded yet.');
+        }
+
+        const identity = readIdentityInputs();
+        const rooms = parseListLines(qs('roomListInput')?.value || '');
+        const facultyAliasParse = parseAliasLines(qs('facultyAliasInput')?.value || '');
+        const courseAliasParse = parseAliasLines(qs('courseAliasInput')?.value || '');
+
+        const profile = clone(state.baseProfile);
+        profile.id = sanitizeBaseId(identity.code || identity.name || profile.id || 'department');
+        profile.identity = {
+            ...profile.identity,
+            name: identity.name,
+            code: identity.code,
+            displayName: identity.displayName || identity.name,
+            shortName: identity.shortName || identity.name
+        };
+
+        profile.scheduler = profile.scheduler || {};
+        profile.scheduler.allowedRooms = rooms;
+
+        const existingRoomLabels = profile.scheduler.roomLabels && typeof profile.scheduler.roomLabels === 'object'
+            ? profile.scheduler.roomLabels
+            : {};
+        const nextRoomLabels = {};
+        rooms.forEach((room) => {
+            nextRoomLabels[room] = existingRoomLabels[room] || room;
+        });
+        profile.scheduler.roomLabels = nextRoomLabels;
+
+        profile.import = profile.import || {};
+        profile.import.clss = profile.import.clss || {};
+        profile.import.clss.roomMatchPriority = rooms.slice();
+        profile.import.clss.facultyAliases = facultyAliasParse.aliases;
+        profile.import.clss.courseAliases = courseAliasParse.aliases;
+
+        profile.onboardingMeta = {
+            basedOn: String(qs('baseProfileSelect')?.value || ''),
+            generatedAt: new Date().toISOString(),
+            generatedBy: 'department-onboarding-shell-v1'
+        };
+
+        return {
+            profile,
+            parseErrors: [...facultyAliasParse.errors, ...courseAliasParse.errors]
+        };
+    }
+
+    function runHealthChecks() {
+        const checks = {
+            errors: [],
+            warnings: [],
+            passes: []
+        };
+
+        let draft = null;
+        try {
+            draft = buildDraftProfile();
+        } catch (error) {
+            checks.errors.push(error?.message || String(error));
+            return { checks, draft: null };
+        }
+
+        const profile = draft.profile;
+        const identity = profile.identity || {};
+
+        if (!identity.name) checks.errors.push('Department name is required.');
+        if (!identity.code) checks.errors.push('Department code is required.');
+        if (identity.code && !/^[A-Z0-9]{2,8}$/.test(identity.code)) {
+            checks.errors.push('Department code must be 2-8 uppercase letters/numbers.');
+        }
+        if (!identity.displayName) checks.errors.push('Department display name is required.');
+
+        const rooms = Array.isArray(profile.scheduler?.allowedRooms) ? profile.scheduler.allowedRooms : [];
+        if (!rooms.length) {
+            checks.errors.push('At least one room is required for scheduler activation.');
+        } else {
+            checks.passes.push(`${rooms.length} rooms mapped.`);
+        }
+
+        if (!Array.isArray(profile.scheduler?.dayPatterns) || profile.scheduler.dayPatterns.length === 0) {
+            checks.errors.push('Scheduler day patterns are missing.');
+        } else {
+            checks.passes.push(`Day patterns available: ${profile.scheduler.dayPatterns.length}.`);
+        }
+
+        if (!Array.isArray(profile.scheduler?.timeSlots) || profile.scheduler.timeSlots.length === 0) {
+            checks.errors.push('Scheduler time slots are missing.');
+        } else {
+            checks.passes.push(`Time slots available: ${profile.scheduler.timeSlots.length}.`);
+        }
+
+        const facultyAliases = profile.import?.clss?.facultyAliases || {};
+        const courseAliases = profile.import?.clss?.courseAliases || {};
+
+        if (Object.keys(facultyAliases).length === 0) {
+            checks.warnings.push('No faculty aliases entered (recommended for CLSS imports).');
+        } else {
+            checks.passes.push(`${Object.keys(facultyAliases).length} faculty aliases mapped.`);
+        }
+
+        if (Object.keys(courseAliases).length === 0) {
+            checks.warnings.push('No course aliases entered (recommended for CLSS imports).');
+        } else {
+            checks.passes.push(`${Object.keys(courseAliases).length} course aliases mapped.`);
+        }
+
+        if (draft.parseErrors.length > 0) {
+            draft.parseErrors.forEach((err) => checks.errors.push(err));
+        }
+
+        const validation = state.manager.validateProfile(profile);
+        if (!validation.valid) {
+            validation.errors.forEach((err) => checks.errors.push(`Profile validation: ${err}`));
+        }
+        validation.warnings.forEach((warn) => checks.warnings.push(`Profile validation: ${warn}`));
+
+        return {
+            checks,
+            draft: {
+                profile,
+                baseId: sanitizeBaseId(identity.code || identity.name || 'department')
+            }
+        };
+    }
+
+    async function loadBaseProfile(profileId) {
+        const loadingState = qs('baseProfileState');
+        if (loadingState) {
+            loadingState.textContent = 'Loading base profile...';
+        }
+
+        const loaded = await state.manager.loadProfile(profileId);
+        state.baseProfile = loaded.profile;
+        state.baseProfileSource = loaded.source;
+
+        const identity = loaded.profile.identity || {};
+        qs('departmentName').value = identity.name || '';
+        qs('departmentCode').value = identity.code || '';
+        qs('departmentDisplayName').value = identity.displayName || '';
+        qs('departmentShortName').value = identity.shortName || '';
+
+        const rooms = Array.isArray(loaded.profile.scheduler?.allowedRooms)
+            ? loaded.profile.scheduler.allowedRooms
+            : [];
+        qs('roomListInput').value = rooms.join('\n');
+
+        const facultyAliases = loaded.profile.import?.clss?.facultyAliases || {};
+        const courseAliases = loaded.profile.import?.clss?.courseAliases || {};
+
+        qs('facultyAliasInput').value = Object.entries(facultyAliases)
+            .map(([alias, canonical]) => `${alias}=${canonical}`)
+            .join('\n');
+        qs('courseAliasInput').value = Object.entries(courseAliases)
+            .map(([alias, canonical]) => `${alias}=${canonical}`)
+            .join('\n');
+
+        if (loadingState) {
+            const sourceLabel = loaded.source === 'custom-local' ? 'custom local profile' : 'manifest profile';
+            loadingState.textContent = `Loaded ${profileId} (${sourceLabel}).`;
+        }
+
+        if (loaded.warnings.length) {
+            setStatus('warn', loaded.warnings.join(' | '));
+        } else {
+            setStatus('ok', `Base profile ${profileId} loaded.`);
+        }
+    }
+
+    async function populateProfileSelect() {
+        const select = qs('baseProfileSelect');
+        if (!select) return;
+
+        const profileList = await state.manager.listProfiles();
+        select.innerHTML = '';
+
+        profileList.profiles.forEach((profileEntry) => {
+            const option = document.createElement('option');
+            option.value = profileEntry.id;
+            const sourceTag = profileEntry.source === 'custom-local' ? 'local' : 'manifest';
+            option.textContent = `${profileEntry.id} (${sourceTag})`;
+            select.appendChild(option);
+        });
+
+        const stored = state.manager.getStoredProfileId();
+        if (stored && profileList.profiles.some((entry) => entry.id === stored)) {
+            select.value = stored;
+        }
+
+        if (!select.value && profileList.profiles.length > 0) {
+            select.value = profileList.profiles[0].id;
+        }
+
+        if (select.value) {
+            await loadBaseProfile(select.value);
+        }
+    }
+
+    function bindEvents() {
+        qs('baseProfileSelect')?.addEventListener('change', async (event) => {
+            const profileId = String(event.target.value || '').trim();
+            if (!profileId) return;
+            await loadBaseProfile(profileId);
+        });
+
+        qs('runHealthChecksButton')?.addEventListener('click', () => {
+            const result = runHealthChecks();
+            state.lastChecks = result;
+            renderHealthChecks(result.checks);
+            if (result.checks.errors.length > 0) {
+                setStatus('error', `Health checks failed (${result.checks.errors.length} error${result.checks.errors.length === 1 ? '' : 's'}).`);
+            } else if (result.checks.warnings.length > 0) {
+                setStatus('warn', `Health checks passed with ${result.checks.warnings.length} warning${result.checks.warnings.length === 1 ? '' : 's'}.`);
+            } else {
+                setStatus('ok', 'Health checks passed. Ready to activate.');
+            }
+        });
+
+        qs('saveActivateButton')?.addEventListener('click', async () => {
+            const result = runHealthChecks();
+            state.lastChecks = result;
+            renderHealthChecks(result.checks);
+
+            if (result.checks.errors.length > 0 || !result.draft) {
+                setStatus('error', 'Fix health check errors before activation.');
+                return;
+            }
+
+            try {
+                qs('saveActivateButton').disabled = true;
+                setStatus('info', 'Saving versioned profile and activating...');
+
+                const saved = await state.manager.saveCustomProfile(result.draft.profile, {
+                    baseId: result.draft.baseId,
+                    activate: true
+                });
+
+                qs('activationResult').textContent = `Activated profile ${saved.profileId}.`;
+                setStatus('ok', `Profile ${saved.profileId} saved and activated.`);
+                await populateProfileSelect();
+                qs('baseProfileSelect').value = saved.profileId;
+            } catch (error) {
+                setStatus('error', error?.message || 'Could not save profile.');
+            } finally {
+                qs('saveActivateButton').disabled = false;
+            }
+        });
+    }
+
+    async function init() {
+        const manager = window.DepartmentProfileManager;
+        if (!manager || typeof manager.initialize !== 'function') {
+            setStatus('error', 'Department profile manager is not available on this page.');
+            return;
+        }
+
+        state.manager = manager;
+        await manager.initialize();
+        bindEvents();
+        await populateProfileSelect();
+
+        const result = runHealthChecks();
+        state.lastChecks = result;
+        renderHealthChecks(result.checks);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        init().catch((error) => {
+            setStatus('error', error?.message || String(error));
+        });
+    });
+})();

--- a/pages/department-onboarding.js
+++ b/pages/department-onboarding.js
@@ -98,6 +98,40 @@
         }
     }
 
+    function applyOnboardingTextSlots(profile) {
+        const textSlots = profile && profile.branding && profile.branding.textSlots && typeof profile.branding.textSlots === 'object'
+            ? profile.branding.textSlots
+            : {};
+        const appHeader = document.querySelector('app-header');
+        if (appHeader) {
+            const eyebrow = String(textSlots.onboardingEyebrow || profile?.branding?.headerEyebrow || '').trim();
+            const title = String(textSlots.onboardingTitle || '').trim();
+            const subtitle = String(textSlots.onboardingSubtitle || '').trim();
+            if (eyebrow) appHeader.setAttribute('eyebrow', eyebrow);
+            if (title) appHeader.setAttribute('title-text', title);
+            if (subtitle) appHeader.setAttribute('subtitle', subtitle);
+        }
+
+        const bindings = {
+            step1Title: textSlots.onboardingStep1Title,
+            step1Help: textSlots.onboardingStep1Help,
+            step2Title: textSlots.onboardingStep2Title,
+            step2Help: textSlots.onboardingStep2Help,
+            step3Title: textSlots.onboardingStep3Title,
+            step3Help: textSlots.onboardingStep3Help,
+            statusTitle: textSlots.onboardingStatusTitle
+        };
+
+        Object.entries(bindings).forEach(([elementId, value]) => {
+            const text = String(value || '').trim();
+            if (!text) return;
+            const element = qs(elementId);
+            if (element) {
+                element.textContent = text;
+            }
+        });
+    }
+
     function readIdentityInputs() {
         const name = String(qs('departmentName')?.value || '').trim();
         const code = sanitizeCode(qs('departmentCode')?.value || '');
@@ -243,6 +277,7 @@
         const loaded = await state.manager.loadProfile(profileId);
         state.baseProfile = loaded.profile;
         state.baseProfileSource = loaded.source;
+        applyOnboardingTextSlots(loaded.profile);
 
         const identity = loaded.profile.identity || {};
         qs('departmentName').value = identity.name || '';

--- a/pages/eaglenet-compare.html
+++ b/pages/eaglenet-compare.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EagleNet Comparison</title>
+    <link rel="stylesheet" href="../css/design-system.css">
+    <link rel="stylesheet" href="../css/shared.css">
+    <link rel="stylesheet" href="../css/dashboard.css">
+    <style>
+        body {
+            margin: 0;
+            background: #f8fafc;
+            color: #0f172a;
+            font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+        }
+
+        .compare-shell {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 24px;
+            display: grid;
+            gap: 16px;
+        }
+
+        .panel {
+            background: #fff;
+            border: 1px solid #dbe3eb;
+            border-radius: 12px;
+            padding: 16px;
+            box-shadow: 0 4px 14px rgba(15, 23, 42, 0.05);
+        }
+
+        .panel h2 {
+            margin: 0 0 10px;
+            font-size: 1.05rem;
+        }
+
+        .panel p {
+            margin: 0 0 12px;
+            color: #475569;
+        }
+
+        .controls {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 10px;
+            align-items: end;
+        }
+
+        label {
+            display: grid;
+            gap: 6px;
+            font-size: 0.9rem;
+        }
+
+        input,
+        select,
+        textarea,
+        button {
+            border: 1px solid #cbd5e1;
+            border-radius: 8px;
+            padding: 10px;
+            font: inherit;
+        }
+
+        textarea {
+            min-height: 180px;
+            resize: vertical;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-size: 0.85rem;
+        }
+
+        .button-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        button {
+            cursor: pointer;
+            background: #0f172a;
+            color: #fff;
+            border-color: #0f172a;
+        }
+
+        button.secondary {
+            background: #fff;
+            color: #0f172a;
+        }
+
+        .status {
+            padding: 10px;
+            border-radius: 8px;
+            border: 1px solid #cbd5e1;
+            background: #f8fafc;
+            color: #0f172a;
+        }
+
+        .status.error {
+            border-color: #dc2626;
+            background: #fef2f2;
+            color: #991b1b;
+        }
+
+        .status.ok {
+            border-color: #16a34a;
+            background: #f0fdf4;
+            color: #14532d;
+        }
+
+        .summary-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 10px;
+        }
+
+        .metric {
+            border: 1px solid #dbe3eb;
+            border-radius: 8px;
+            padding: 10px;
+            background: #f8fafc;
+        }
+
+        .metric strong {
+            display: block;
+            font-size: 1.2rem;
+            color: #0f172a;
+        }
+
+        .report-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 10px;
+            font-size: 0.9rem;
+        }
+
+        .report-table th,
+        .report-table td {
+            border: 1px solid #dbe3eb;
+            padding: 8px;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        .report-table thead th {
+            background: #f1f5f9;
+        }
+
+        details {
+            border: 1px solid #dbe3eb;
+            border-radius: 8px;
+            padding: 8px;
+            background: #fff;
+        }
+
+        details + details {
+            margin-top: 10px;
+        }
+
+        summary {
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        .empty {
+            color: #64748b;
+            font-style: italic;
+        }
+    </style>
+</head>
+<body>
+    <app-header
+        eyebrow="PROGRAM COMMAND"
+        title-text="EagleNet Comparison"
+        subtitle="Compare scheduler draft vs EagleNet schedule data by year and export discrepancies"
+    ></app-header>
+
+    <main class="compare-shell">
+        <section class="panel">
+            <h2>Inputs</h2>
+            <p>Select a year, then provide EagleNet rows as JSON array or CSV.</p>
+            <div class="controls">
+                <label>
+                    Academic Year
+                    <select id="compareYear"></select>
+                </label>
+                <label>
+                    EagleNet Data File (optional)
+                    <input id="eaglenetFile" type="file" accept=".json,.csv,text/csv,application/json">
+                </label>
+            </div>
+            <label style="margin-top:10px; display:grid; gap:6px;">
+                EagleNet Data (paste JSON array or CSV with header row)
+                <textarea id="eaglenetDataInput" placeholder='[{"academicYear":"2026-27","quarter":"Fall","courseCode":"DESN 100",...}]'></textarea>
+            </label>
+            <div class="button-row" style="margin-top:10px;">
+                <button id="runCompareButton" type="button">Run Comparison</button>
+                <button id="exportDiscrepanciesButton" type="button" class="secondary">Export Discrepancy CSV</button>
+                <button id="loadSampleButton" type="button" class="secondary">Load Sample</button>
+            </div>
+            <div id="compareStatus" class="status" style="margin-top:10px;">Ready.</div>
+        </section>
+
+        <section class="panel">
+            <h2>Summary</h2>
+            <div id="summaryGrid" class="summary-grid"></div>
+        </section>
+
+        <section class="panel">
+            <h2>Discrepancy Report</h2>
+            <div id="reportOutput" class="empty">Run comparison to view categorized differences.</div>
+        </section>
+    </main>
+
+    <script type="module" src="../js/components/app-header.js"></script>
+    <script src="../js/department-profile.js"></script>
+    <script src="../js/workload-integration.js"></script>
+    <script src="../js/eaglenet-compare.js"></script>
+    <script src="eaglenet-compare.js"></script>
+</body>
+</html>

--- a/pages/eaglenet-compare.js
+++ b/pages/eaglenet-compare.js
@@ -1,0 +1,701 @@
+(function eaglenetComparePage(globalScope) {
+    'use strict';
+
+    const state = {
+        lastDiff: null,
+        lastYear: '',
+        lastSchedulerRows: [],
+        lastEagleNetRows: []
+    };
+
+    const FRIENDLY_FIELD_LABELS = {
+        credits: 'Credits',
+        instructorKey: 'Instructor',
+        days: 'Days',
+        timeRange: 'Time',
+        roomKey: 'Room',
+        modalityKey: 'Modality',
+        campusKey: 'Campus',
+        titleKey: 'Course Title'
+    };
+
+    function qs(id) {
+        if (typeof document === 'undefined') return null;
+        return document.getElementById(id);
+    }
+
+    function escapeHtml(value) {
+        return String(value == null ? '' : value)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function setStatus(message, kind = 'info') {
+        const node = qs('compareStatus');
+        if (!node) return;
+        node.className = 'status';
+        if (kind === 'error') {
+            node.classList.add('error');
+        } else if (kind === 'ok') {
+            node.classList.add('ok');
+        }
+        node.textContent = String(message || '');
+    }
+
+    function parseAcademicYearStart(academicYear) {
+        const match = String(academicYear || '').match(/^(\d{4})-(\d{2})$/);
+        return match ? Number(match[1]) : Number.NEGATIVE_INFINITY;
+    }
+
+    function formatAcademicYear(startYear) {
+        const next = String((startYear + 1) % 100).padStart(2, '0');
+        return `${startYear}-${next}`;
+    }
+
+    function getCurrentAcademicYear() {
+        const now = new Date();
+        const year = now.getFullYear();
+        const month = now.getMonth();
+        const startYear = month >= 6 ? year : year - 1;
+        return formatAcademicYear(startYear);
+    }
+
+    function getNeighborAcademicYears(baseYear) {
+        const parsed = parseAcademicYearStart(baseYear);
+        if (!Number.isFinite(parsed)) return [];
+        return [formatAcademicYear(parsed - 1), formatAcademicYear(parsed + 1)];
+    }
+
+    function getAcademicYearOptions() {
+        const years = new Set();
+        try {
+            if (globalScope.WorkloadIntegration && typeof globalScope.WorkloadIntegration.getAcademicYearOptions === 'function') {
+                const options = globalScope.WorkloadIntegration.getAcademicYearOptions();
+                (options || []).forEach((year) => years.add(String(year)));
+            }
+        } catch (error) {
+            console.warn('Could not load academic year options from workload integration:', error);
+        }
+
+        const currentYear = getCurrentAcademicYear();
+        years.add(currentYear);
+        getNeighborAcademicYears(currentYear).forEach((year) => years.add(year));
+
+        return [...years]
+            .filter((year) => /^\d{4}-\d{2}$/.test(year))
+            .sort((a, b) => parseAcademicYearStart(a) - parseAcademicYearStart(b));
+    }
+
+    function populateYearSelect() {
+        const select = qs('compareYear');
+        if (!select) return '';
+
+        const years = getAcademicYearOptions();
+        select.innerHTML = '';
+        years.forEach((year) => {
+            const option = document.createElement('option');
+            option.value = year;
+            option.textContent = year;
+            select.appendChild(option);
+        });
+
+        const preferred = years.includes(getCurrentAcademicYear())
+            ? getCurrentAcademicYear()
+            : years[years.length - 1];
+        if (preferred) {
+            select.value = preferred;
+        }
+
+        return select.value || '';
+    }
+
+    function parseCsvRows(text) {
+        const input = String(text || '').replace(/\r\n?/g, '\n');
+        const records = [];
+        let row = [];
+        let cell = '';
+        let inQuotes = false;
+
+        for (let i = 0; i < input.length; i += 1) {
+            const char = input[i];
+            const next = input[i + 1];
+
+            if (char === '"') {
+                if (inQuotes && next === '"') {
+                    cell += '"';
+                    i += 1;
+                } else {
+                    inQuotes = !inQuotes;
+                }
+                continue;
+            }
+
+            if (char === ',' && !inQuotes) {
+                row.push(cell);
+                cell = '';
+                continue;
+            }
+
+            if (char === '\n' && !inQuotes) {
+                row.push(cell);
+                records.push(row);
+                row = [];
+                cell = '';
+                continue;
+            }
+
+            cell += char;
+        }
+
+        if (cell !== '' || row.length > 0) {
+            row.push(cell);
+            records.push(row);
+        }
+
+        if (!records.length) return [];
+
+        const headers = records[0].map((value) => normalizeHeaderKey(value));
+        const rows = [];
+        for (let i = 1; i < records.length; i += 1) {
+            const values = records[i];
+            if (!values.some((value) => String(value || '').trim() !== '')) continue;
+
+            const rowObj = {};
+            headers.forEach((header, index) => {
+                if (!header) return;
+                rowObj[header] = String(values[index] == null ? '' : values[index]).trim();
+            });
+            rows.push(rowObj);
+        }
+        return rows;
+    }
+
+    function normalizeHeaderKey(value) {
+        const raw = String(value || '')
+            .replace(/^\uFEFF/, '')
+            .trim();
+        if (!raw) return '';
+
+        const cleaned = raw
+            .replace(/[_-]+/g, ' ')
+            .replace(/[^A-Za-z0-9 ]+/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .toLowerCase();
+
+        if (!cleaned) return '';
+        const parts = cleaned.split(' ');
+        return parts[0] + parts.slice(1).map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join('');
+    }
+
+    function parseRowsInput(text) {
+        const trimmed = String(text || '').trim();
+        if (!trimmed) return [];
+
+        if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+            const parsed = JSON.parse(trimmed);
+            if (Array.isArray(parsed)) return parsed;
+            if (parsed && typeof parsed === 'object') {
+                if (Array.isArray(parsed.rows)) return parsed.rows;
+                if (Array.isArray(parsed.data)) return parsed.data;
+            }
+            throw new Error('JSON input must be an array of row objects.');
+        }
+
+        return parseCsvRows(trimmed);
+    }
+
+    function withAcademicYear(rows, academicYear) {
+        return (Array.isArray(rows) ? rows : []).map((row) => ({
+            ...(row && typeof row === 'object' ? row : {}),
+            academicYear: row && row.academicYear ? row.academicYear : academicYear
+        }));
+    }
+
+    function filterRowsForYear(rows, academicYear) {
+        const compare = globalScope.EagleNetCompare;
+        const targetYear = compare && typeof compare.normalizeAcademicYear === 'function'
+            ? compare.normalizeAcademicYear(academicYear)
+            : String(academicYear || '').trim();
+
+        return (Array.isArray(rows) ? rows : []).filter((row) => {
+            const rowYear = row && row.academicYear
+                ? row.academicYear
+                : academicYear;
+            const normalizedRowYear = compare && typeof compare.normalizeAcademicYear === 'function'
+                ? compare.normalizeAcademicYear(rowYear)
+                : String(rowYear || '').trim();
+            return normalizedRowYear === targetYear;
+        });
+    }
+
+    function readSchedulerRows(academicYear) {
+        if (!globalScope.WorkloadIntegration || typeof globalScope.WorkloadIntegration.getProgramCommandScheduleCourses !== 'function') {
+            throw new Error('WorkloadIntegration.getProgramCommandScheduleCourses() is unavailable.');
+        }
+
+        const courses = globalScope.WorkloadIntegration.getProgramCommandScheduleCourses(academicYear);
+        return (Array.isArray(courses) ? courses : []).map((course) => ({
+            academicYear,
+            quarter: course?.quarter || '',
+            courseCode: course?.courseCode || course?.code || '',
+            section: course?.section || course?.sectionNumber || '',
+            crn: course?.crn || '',
+            title: course?.title || course?.name || '',
+            instructor: course?.assignedFaculty || course?.instructor || '',
+            days: course?.days || course?.day || '',
+            startTime: course?.startTime || '',
+            endTime: course?.endTime || '',
+            time: course?.time || '',
+            room: course?.room || '',
+            building: course?.building || '',
+            credits: course?.credits,
+            modality: course?.modality || '',
+            campus: course?.campus || ''
+        }));
+    }
+
+    function renderSummary(diff) {
+        const node = qs('summaryGrid');
+        if (!node) return;
+
+        if (!diff || !diff.summary) {
+            node.innerHTML = '<div class="metric"><span>No data yet.</span></div>';
+            return;
+        }
+
+        const summary = diff.summary;
+        const metrics = [
+            ['Scheduler Rows', summary.leftRows],
+            ['EagleNet Rows', summary.rightRows],
+            ['Exact Matches', summary.exactMatches],
+            ['Field Mismatches', summary.fieldMismatchRows],
+            ['Missing In EagleNet', summary.missingInRight],
+            ['Extra In EagleNet', summary.extraInRight],
+            ['Total Differences', summary.totalDifferences]
+        ];
+
+        node.innerHTML = metrics
+            .map(([label, value]) => `
+                <div class="metric">
+                    <strong>${escapeHtml(value)}</strong>
+                    <span>${escapeHtml(label)}</span>
+                </div>
+            `)
+            .join('');
+    }
+
+    function recordValue(record, field) {
+        const normalized = record && record.normalized ? record.normalized : {};
+        const value = normalized[field];
+        if (value == null || value === '') return '';
+        return String(value);
+    }
+
+    function renderRecordTable(items, typeLabel) {
+        if (!Array.isArray(items) || items.length === 0) {
+            return '<div class="empty">No rows.</div>';
+        }
+
+        const rows = items.map((item) => {
+            const record = item.record || {};
+            const normalized = record.normalized || {};
+            return `
+                <tr>
+                    <td>${escapeHtml(normalized.quarter || '')}</td>
+                    <td>${escapeHtml(normalized.courseCode || '')}</td>
+                    <td>${escapeHtml(normalized.section || '')}</td>
+                    <td>${escapeHtml(normalized.instructor || '')}</td>
+                    <td>${escapeHtml([normalized.days, normalized.timeRange].filter(Boolean).join(' '))}</td>
+                    <td>${escapeHtml(normalized.room || '')}</td>
+                    <td>${escapeHtml(typeLabel)}</td>
+                </tr>
+            `;
+        }).join('');
+
+        return `
+            <table class="report-table">
+                <thead>
+                    <tr>
+                        <th>Quarter</th>
+                        <th>Course</th>
+                        <th>Section</th>
+                        <th>Instructor</th>
+                        <th>Meeting</th>
+                        <th>Room</th>
+                        <th>Type</th>
+                    </tr>
+                </thead>
+                <tbody>${rows}</tbody>
+            </table>
+        `;
+    }
+
+    function getFriendlyFieldName(field) {
+        return FRIENDLY_FIELD_LABELS[field] || field;
+    }
+
+    function renderFieldMismatchGroups(fieldMismatches) {
+        if (!Array.isArray(fieldMismatches) || fieldMismatches.length === 0) {
+            return '<div class="empty">No field mismatches.</div>';
+        }
+
+        const grouped = new Map();
+        fieldMismatches.forEach((rowMismatch) => {
+            (rowMismatch.mismatches || []).forEach((entry) => {
+                const key = entry.field;
+                if (!grouped.has(key)) grouped.set(key, []);
+                grouped.get(key).push({
+                    rowMismatch,
+                    entry
+                });
+            });
+        });
+
+        return [...grouped.entries()]
+            .sort(([left], [right]) => left.localeCompare(right))
+            .map(([field, entries]) => {
+                const mismatchRows = entries.map(({ rowMismatch, entry }) => `
+                    <tr>
+                        <td>${escapeHtml(rowMismatch.label || '')}</td>
+                        <td>${escapeHtml(recordValue(rowMismatch.leftRecord, 'quarter'))}</td>
+                        <td>${escapeHtml(recordValue(rowMismatch.leftRecord, 'courseCode'))}</td>
+                        <td>${escapeHtml(entry.left)}</td>
+                        <td>${escapeHtml(entry.right)}</td>
+                    </tr>
+                `).join('');
+
+                return `
+                    <details>
+                        <summary>${escapeHtml(getFriendlyFieldName(field))} (${entries.length})</summary>
+                        <table class="report-table">
+                            <thead>
+                                <tr>
+                                    <th>Row</th>
+                                    <th>Quarter</th>
+                                    <th>Course</th>
+                                    <th>Scheduler</th>
+                                    <th>EagleNet</th>
+                                </tr>
+                            </thead>
+                            <tbody>${mismatchRows}</tbody>
+                        </table>
+                    </details>
+                `;
+            })
+            .join('');
+    }
+
+    function renderReport(diff) {
+        const node = qs('reportOutput');
+        if (!node) return;
+
+        if (!diff || !diff.summary) {
+            node.className = 'empty';
+            node.textContent = 'Run comparison to view categorized differences.';
+            return;
+        }
+
+        if (diff.summary.totalDifferences === 0) {
+            node.className = 'status ok';
+            node.textContent = 'No discrepancies found for selected year after normalization.';
+            return;
+        }
+
+        node.className = '';
+        node.innerHTML = `
+            <details open>
+                <summary>Missing in EagleNet (${diff.summary.missingInRight})</summary>
+                ${renderRecordTable(diff.missingInRight, 'Scheduler only')}
+            </details>
+            <details open>
+                <summary>Extra in EagleNet (${diff.summary.extraInRight})</summary>
+                ${renderRecordTable(diff.extraInRight, 'EagleNet only')}
+            </details>
+            <details open>
+                <summary>Field Mismatches (${diff.summary.fieldMismatchRows})</summary>
+                ${renderFieldMismatchGroups(diff.fieldMismatches)}
+            </details>
+        `;
+    }
+
+    function buildDiscrepancyRows(diff, academicYear) {
+        if (!diff || !diff.summary) return [];
+
+        const rows = [];
+        (diff.missingInRight || []).forEach((item) => {
+            const n = item.record?.normalized || {};
+            rows.push({
+                academicYear,
+                mismatchType: 'missing_in_eaglenet',
+                quarter: n.quarter || '',
+                courseCode: n.courseCode || '',
+                section: n.section || '',
+                label: item.label || '',
+                field: '',
+                schedulerValue: 'Present',
+                eaglenetValue: 'Missing'
+            });
+        });
+
+        (diff.extraInRight || []).forEach((item) => {
+            const n = item.record?.normalized || {};
+            rows.push({
+                academicYear,
+                mismatchType: 'extra_in_eaglenet',
+                quarter: n.quarter || '',
+                courseCode: n.courseCode || '',
+                section: n.section || '',
+                label: item.label || '',
+                field: '',
+                schedulerValue: 'Missing',
+                eaglenetValue: 'Present'
+            });
+        });
+
+        (diff.fieldMismatches || []).forEach((rowMismatch) => {
+            (rowMismatch.mismatches || []).forEach((entry) => {
+                rows.push({
+                    academicYear,
+                    mismatchType: 'field_mismatch',
+                    quarter: recordValue(rowMismatch.leftRecord, 'quarter'),
+                    courseCode: recordValue(rowMismatch.leftRecord, 'courseCode'),
+                    section: recordValue(rowMismatch.leftRecord, 'section'),
+                    label: rowMismatch.label || '',
+                    field: getFriendlyFieldName(entry.field),
+                    schedulerValue: entry.left == null ? '' : String(entry.left),
+                    eaglenetValue: entry.right == null ? '' : String(entry.right)
+                });
+            });
+        });
+
+        return rows;
+    }
+
+    function escapeCsvValue(value) {
+        const text = String(value == null ? '' : value);
+        if (/[,"\n]/.test(text)) {
+            return `"${text.replace(/"/g, '""')}"`;
+        }
+        return text;
+    }
+
+    function toCsv(rows, columns) {
+        const safeRows = Array.isArray(rows) ? rows : [];
+        const safeColumns = Array.isArray(columns) && columns.length
+            ? columns
+            : Object.keys(safeRows[0] || {});
+
+        const lines = [];
+        lines.push(safeColumns.map((column) => escapeCsvValue(column)).join(','));
+        safeRows.forEach((row) => {
+            lines.push(safeColumns.map((column) => escapeCsvValue(row?.[column])).join(','));
+        });
+
+        return `${lines.join('\n')}\n`;
+    }
+
+    function downloadTextFile(filename, content, mimeType) {
+        if (typeof document === 'undefined') return;
+        const blob = new Blob([content], { type: mimeType || 'text/plain;charset=utf-8' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+
+    function readSelectedYear() {
+        return String(qs('compareYear')?.value || '').trim();
+    }
+
+    function runComparison() {
+        try {
+            if (!globalScope.EagleNetCompare || typeof globalScope.EagleNetCompare.diffNormalizedSchedules !== 'function') {
+                throw new Error('EagleNet comparison utilities are unavailable.');
+            }
+
+            const academicYear = readSelectedYear();
+            if (!academicYear) {
+                throw new Error('Select an academic year before running comparison.');
+            }
+
+            const sourceText = String(qs('eaglenetDataInput')?.value || '').trim();
+            if (!sourceText) {
+                throw new Error('Provide EagleNet JSON or CSV data first.');
+            }
+
+            const eagleRowsInput = parseRowsInput(sourceText);
+            const schedulerRows = filterRowsForYear(withAcademicYear(readSchedulerRows(academicYear), academicYear), academicYear);
+            const eagleRows = filterRowsForYear(withAcademicYear(eagleRowsInput, academicYear), academicYear);
+
+            const diff = globalScope.EagleNetCompare.diffNormalizedSchedules(schedulerRows, eagleRows, {
+                leftSource: 'scheduler',
+                rightSource: 'eaglenet'
+            });
+
+            state.lastDiff = diff;
+            state.lastYear = academicYear;
+            state.lastSchedulerRows = schedulerRows;
+            state.lastEagleNetRows = eagleRows;
+
+            renderSummary(diff);
+            renderReport(diff);
+
+            setStatus(
+                `Compared ${diff.summary.leftRows} scheduler rows vs ${diff.summary.rightRows} EagleNet rows. `
+                + `Differences: ${diff.summary.totalDifferences}.`,
+                'ok'
+            );
+        } catch (error) {
+            state.lastDiff = null;
+            renderSummary(null);
+            renderReport(null);
+            setStatus(error?.message || String(error), 'error');
+        }
+    }
+
+    function exportDiscrepancies() {
+        try {
+            if (!state.lastDiff || !state.lastYear) {
+                throw new Error('Run a comparison before exporting discrepancies.');
+            }
+
+            const rows = buildDiscrepancyRows(state.lastDiff, state.lastYear);
+            if (!rows.length) {
+                throw new Error('No discrepancies to export for the current comparison.');
+            }
+
+            const columns = [
+                'academicYear',
+                'mismatchType',
+                'quarter',
+                'courseCode',
+                'section',
+                'label',
+                'field',
+                'schedulerValue',
+                'eaglenetValue'
+            ];
+            const csv = toCsv(rows, columns);
+            const dateTag = new Date().toISOString().slice(0, 10);
+            const filename = `eaglenet-discrepancies-${state.lastYear}-${dateTag}.csv`;
+            downloadTextFile(filename, csv, 'text/csv;charset=utf-8');
+
+            setStatus(`Exported ${rows.length} discrepancy rows to ${filename}.`, 'ok');
+        } catch (error) {
+            setStatus(error?.message || String(error), 'error');
+        }
+    }
+
+    function loadSample() {
+        const academicYear = readSelectedYear() || getCurrentAcademicYear();
+        const sampleRows = [
+            {
+                academicYear,
+                quarter: 'Fall',
+                courseCode: 'DESN 101',
+                section: '001',
+                title: 'Design Foundations I',
+                instructor: 'Travis Masingale',
+                days: 'MW',
+                time: '09:00-10:50',
+                room: 'CEB 102',
+                credits: 5
+            },
+            {
+                academicYear,
+                quarter: 'Fall',
+                courseCode: 'DESN 202',
+                section: '001',
+                title: 'Interaction Design',
+                instructor: 'Mindy Breen',
+                days: 'TR',
+                time: '13:00-14:50',
+                room: 'CEB 206',
+                credits: 5
+            }
+        ];
+
+        const textarea = qs('eaglenetDataInput');
+        if (textarea) {
+            textarea.value = JSON.stringify(sampleRows, null, 2);
+        }
+        setStatus('Sample EagleNet dataset loaded. Review and click Run Comparison.', 'ok');
+    }
+
+    function handleFileInputChange(event) {
+        const file = event?.target?.files?.[0];
+        if (!file) return;
+
+        file.text()
+            .then((text) => {
+                const textarea = qs('eaglenetDataInput');
+                if (textarea) {
+                    textarea.value = text;
+                }
+                setStatus(`Loaded file: ${file.name}.`, 'ok');
+            })
+            .catch((error) => {
+                setStatus(`Could not read file: ${error?.message || String(error)}`, 'error');
+            });
+    }
+
+    function initializePage() {
+        if (typeof document === 'undefined') return;
+        if (!qs('compareYear')) return;
+
+        if (!globalScope.EagleNetCompare) {
+            setStatus('EagleNet compare runtime failed to load.', 'error');
+            return;
+        }
+        if (!globalScope.WorkloadIntegration) {
+            setStatus('Workload integration runtime failed to load.', 'error');
+            return;
+        }
+
+        populateYearSelect();
+        renderSummary(null);
+        renderReport(null);
+        setStatus('Ready. Select year, provide EagleNet data, and run comparison.');
+
+        const runButton = qs('runCompareButton');
+        const exportButton = qs('exportDiscrepanciesButton');
+        const sampleButton = qs('loadSampleButton');
+        const fileInput = qs('eaglenetFile');
+
+        if (runButton) runButton.addEventListener('click', runComparison);
+        if (exportButton) exportButton.addEventListener('click', exportDiscrepancies);
+        if (sampleButton) sampleButton.addEventListener('click', loadSample);
+        if (fileInput) fileInput.addEventListener('change', handleFileInputChange);
+    }
+
+    const EagleNetComparePage = {
+        parseCsvRows,
+        parseRowsInput,
+        toCsv,
+        buildDiscrepancyRows,
+        getAcademicYearOptions
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = EagleNetComparePage;
+    }
+    if (globalScope) {
+        globalScope.EagleNetComparePage = EagleNetComparePage;
+    }
+
+    if (typeof document !== 'undefined') {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', initializePage);
+        } else {
+            initializePage();
+        }
+    }
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : null));

--- a/pages/schedule-builder.html
+++ b/pages/schedule-builder.html
@@ -609,6 +609,7 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="../js/supabase-config.js"></script>
     <script src="../js/db-service.js"></script>
+    <script src="../js/auth-service.js"></script>
     <!-- OpenAI Integration -->
     <script src="../js/claude-service.js"></script>
     <script src="../js/schedule-evaluator.js"></script>

--- a/pages/workload-dashboard.js
+++ b/pages/workload-dashboard.js
@@ -28,7 +28,8 @@ let SCHEDULE_STORAGE_PREFIX = 'designSchedulerData_';
 let PRODUCTION_RESET_DEFAULT_SCHEDULE_YEAR = '2026-27';
 let WORKLOAD_DASHBOARD_SUBTITLE_BASE = 'EWU Design Department - Academic Workload Analysis';
 let WORKLOAD_DASHBOARD_TITLE = '👥 Faculty Workload Dashboard';
-const WORKLOAD_PLAN_ROLE_OPTIONS = [
+let WORKLOAD_PLAN_DEPARTMENT_LABEL = 'Design';
+let WORKLOAD_PLAN_ROLE_OPTIONS = [
     'Full Professor',
     'Associate Professor',
     'Assistant Professor',
@@ -69,7 +70,7 @@ const WORKLOAD_EXPORT_FACULTY_NAME_OVERRIDES = {
     'a.sopu': 'Sopu Ariel'
 };
 const WORKLOAD_PLAN_RELEASE_ALLOCATION_QUARTERS = ['Fall', 'Winter', 'Spring', 'Summer'];
-const WORKLOAD_PLAN_RELEASE_ALLOCATION_PRESETS = [
+let WORKLOAD_PLAN_RELEASE_ALLOCATION_PRESETS = [
     {
         id: 'chair',
         label: 'Chair',
@@ -113,7 +114,7 @@ const WORKLOAD_PLAN_RELEASE_ALLOCATION_PRESETS = [
         defaultQuarters: ['Fall']
     }
 ];
-const WORKLOAD_PLAN_RELEASE_CATEGORY_OPTIONS = [
+let WORKLOAD_PLAN_RELEASE_CATEGORY_OPTIONS = [
     { id: 'chair', label: 'Chair Duties' },
     { id: 'independent_study', label: 'DESN 499 / Independent Study' },
     { id: 'applied_learning', label: 'DESN 495 / Applied Learning' },
@@ -140,6 +141,14 @@ const WORKLOAD_PLAN_GROUP_OPTIONS = [
     { id: 'status', label: 'Group by Status' },
     { id: 'chair', label: 'Group Chairs First' }
 ];
+
+function getAppliedLearningCoursesForDashboard() {
+    if (window.WorkloadIntegration?.getAppliedLearningCourses) {
+        const rows = window.WorkloadIntegration.getAppliedLearningCourses();
+        return Array.isArray(rows) ? rows : [];
+    }
+    return [];
+}
 const workloadPlanningUiState = {
     modalOpen: false,
     editingRecordId: null,
@@ -169,6 +178,8 @@ function getDepartmentIdentity() {
 }
 
 function applyDepartmentProfileToDashboardHeader() {
+    const identity = getDepartmentIdentity();
+    WORKLOAD_PLAN_DEPARTMENT_LABEL = identity.name;
     const titleEl = document.getElementById('workloadDashboardTitle');
     const subtitleEl = document.getElementById('workloadDashboardSubtitle');
     if (titleEl) {
@@ -217,11 +228,48 @@ async function initializeDepartmentProfileContext() {
                 ...profileWorkload.defaultAnnualTargets
             };
         }
+        if (Array.isArray(profileWorkload.roleOptions) && profileWorkload.roleOptions.length > 0) {
+            WORKLOAD_PLAN_ROLE_OPTIONS = profileWorkload.roleOptions
+                .map((value) => String(value || '').trim())
+                .filter(Boolean);
+        }
+        if (Array.isArray(profileWorkload.releaseAllocationPresets) && profileWorkload.releaseAllocationPresets.length > 0) {
+            WORKLOAD_PLAN_RELEASE_ALLOCATION_PRESETS = profileWorkload.releaseAllocationPresets
+                .map((preset, index) => {
+                    if (!preset || typeof preset !== 'object') return null;
+                    const id = String(preset.id || `preset_${index}`).trim();
+                    const label = String(preset.label || preset.defaultLabel || '').trim();
+                    if (!id || !label) return null;
+                    const defaultQuarters = Array.isArray(preset.defaultQuarters)
+                        ? preset.defaultQuarters.map((value) => String(value || '').trim()).filter(Boolean)
+                        : ['Fall'];
+                    return {
+                        id,
+                        label,
+                        category: String(preset.category || 'other').trim() || 'other',
+                        defaultLabel: String(preset.defaultLabel || label).trim() || label,
+                        defaultQuarters
+                    };
+                })
+                .filter(Boolean);
+        }
+        if (Array.isArray(profileWorkload.releaseCategoryOptions) && profileWorkload.releaseCategoryOptions.length > 0) {
+            WORKLOAD_PLAN_RELEASE_CATEGORY_OPTIONS = profileWorkload.releaseCategoryOptions
+                .map((option) => {
+                    if (!option || typeof option !== 'object') return null;
+                    const id = String(option.id || '').trim();
+                    const label = String(option.label || '').trim();
+                    if (!id || !label) return null;
+                    return { id, label };
+                })
+                .filter(Boolean);
+        }
         if (profileWorkload.dashboardTitle) {
             WORKLOAD_DASHBOARD_TITLE = String(profileWorkload.dashboardTitle);
         }
 
         const identity = getDepartmentIdentity();
+        WORKLOAD_PLAN_DEPARTMENT_LABEL = identity.name;
         document.title = `${WORKLOAD_DASHBOARD_TITLE.replace(/^👥\s*/, '')} - ${identity.displayName}`;
         applyDepartmentProfileToDashboardHeader();
 
@@ -795,10 +843,16 @@ function renderPreliminaryPlanningNotice(yearData) {
                 </div>
             </details>`
         : '';
-    const hasAppliedLearningRateAssumption = assumptionItems.some((item) => /DESN 399\/491\/499/i.test(String(item || '')));
-    const appliedLearningRateNoteHtml = hasAppliedLearningRateAssumption
+    const hasAppliedLearningRateAssumption = assumptionItems.some((item) => /workload multiplier|applied-learning/i.test(String(item || '')));
+    const appliedLearningCourses = getAppliedLearningCoursesForDashboard();
+    const appliedLearningRateText = appliedLearningCourses.length
+        ? appliedLearningCourses
+            .map((entry) => `${entry.code} (${formatWorkloadPlanNumber(entry.rate, 3)})`)
+            .join(', ')
+        : '';
+    const appliedLearningRateNoteHtml = hasAppliedLearningRateAssumption || !appliedLearningRateText
         ? ''
-        : '<p class="prelim-workload-note">DESN 399/491/499 use a 0.2 workload rate and DESN 495 uses a 0.1 workload rate in the preliminary scheduler-derived calculations.</p>';
+        : `<p class="prelim-workload-note">Applied-learning workload multipliers: ${escapeWorkloadPlanHtml(appliedLearningRateText)}.</p>`;
 
     notice.innerHTML = `
         <div class="prelim-workload-header">
@@ -868,15 +922,26 @@ function formatWorkloadPlanNumber(value, decimals = 1) {
 }
 
 function normalizeWorkloadPlanNameKey(name) {
-    return String(name || '')
+    if (window.WorkloadIntegration?.normalizeNameKey) {
+        return window.WorkloadIntegration.normalizeNameKey(name);
+    }
+
+    const cleaned = String(name || '')
         .replace(/\u00a0/g, ' ')
         .trim()
         .replace(/^([A-Za-z])\.\s*(PAS|IND)([A-Za-z]{2,})$/i, '$1.$3')
         .replace(/^([A-Za-z])\s+(PAS|IND)\s+([A-Za-z]{2,})$/i, '$1.$3')
         .replace(/^([A-Za-z])\s+(PAS|IND)([A-Za-z]{2,})$/i, '$1.$3')
         .replace(/^([A-Za-z]+)\s+(PAS|IND)([A-Za-z]{2,})$/i, '$1 $3')
-        .toLowerCase()
-        .replace(/[^a-z0-9]/g, '');
+        .split(/\s+/)
+        .map((token) => token.replace(/^(PAS|IND)([A-Za-z]{3,})$/i, '$2'))
+        .join(' ')
+        .trim();
+
+    const compact = cleaned.toLowerCase().replace(/[^a-z0-9]/g, '');
+    return compact
+        .replace(/^([a-z])(pas|ind)([a-z]{3,})$/, '$1$3')
+        .replace(/^(pas|ind)([a-z]{3,})$/, '$2');
 }
 
 function cloneWorkloadPlanValue(value) {
@@ -3261,7 +3326,7 @@ function renderWorkloadPlanWorksheetSnapshot(overlay, baseRow, values) {
         { label: 'AY', value: currentFilters.year || '—' },
         { label: 'Name', value: facultyName },
         { label: 'Classification', value: role },
-        { label: 'Department', value: 'Design' },
+        { label: 'Department', value: WORKLOAD_PLAN_DEPARTMENT_LABEL || getDepartmentIdentity().name || 'Design' },
         { label: 'FTE', value: `${Number.isFinite(fte) ? formatWorkloadPlanNumber(fte, 1) : '100'}%` },
         { label: 'Expected Workload', value: `${formatWorkloadPlanNumber(annualTarget)} credits` },
         { label: 'Assigned / Release', value: `${formatWorkloadPlanNumber(releaseCredits)} credits (${formatWorkloadPlanNumber(releasePercent)}%)` },
@@ -4871,10 +4936,13 @@ function roundToTenths(value) {
 
 function isAppliedLearningCode(code) {
     const normalized = String(code || '').replace(/\s+/g, ' ').trim().toUpperCase();
-    return normalized === 'DESN 399'
-        || normalized === 'DESN 491'
-        || normalized === 'DESN 495'
-        || normalized === 'DESN 499';
+    if (!normalized) return false;
+    const appliedLearningCodes = new Set(
+        getAppliedLearningCoursesForDashboard()
+            .map((entry) => String(entry?.code || '').replace(/\s+/g, ' ').trim().toUpperCase())
+            .filter(Boolean)
+    );
+    return appliedLearningCodes.has(normalized);
 }
 
 function sortQuarterRows(rows) {
@@ -4912,7 +4980,7 @@ function buildQuarterExportRows(facultyRecord) {
         }
 
         quarters[quarter].push({
-            label: code || 'DESN',
+            label: code || (getDepartmentIdentity().code || 'COURSE'),
             note: course?.section ? `Sec ${course.section}` : '',
             credits: roundToTenths(workloadCredits || course?.credits || 0),
             sortOrder: index
@@ -4924,7 +4992,7 @@ function buildQuarterExportRows(facultyRecord) {
         if (applied.credits > 0) {
             const codeList = Array.from(applied.codes).sort().join('/');
             quarters[quarter].push({
-                label: 'DESN X95/99',
+                label: `${getDepartmentIdentity().code || 'DEPT'} X95/99`,
                 note: codeList || 'Applied learning',
                 credits: roundToTenths(applied.credits),
                 sortOrder: 10_000

--- a/scripts/check-data-freshness.js
+++ b/scripts/check-data-freshness.js
@@ -1,0 +1,354 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+import { createClient } from '@supabase/supabase-js';
+
+const TABLE_CONFIG = [
+  { table: 'academic_years', scope: 'department', timestampColumn: 'created_at' },
+  { table: 'rooms', scope: 'department', timestampColumn: 'created_at' },
+  { table: 'courses', scope: 'department', timestampColumn: 'created_at' },
+  { table: 'faculty', scope: 'department', timestampColumn: 'created_at' },
+  { table: 'scheduling_constraints', scope: 'department', timestampColumn: 'created_at' },
+  { table: 'scheduled_courses', scope: 'academic_year', timestampColumn: 'updated_at' },
+  { table: 'release_time', scope: 'academic_year', timestampColumn: 'created_at' }
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+    } else {
+      args[key] = next;
+      i += 1;
+    }
+  }
+  return args;
+}
+
+function envOrArg(args, argKey, envKey, fallback = '') {
+  const fromArg = args[argKey];
+  if (typeof fromArg === 'string' && fromArg.trim()) return fromArg.trim();
+  const fromEnv = process.env[envKey];
+  if (typeof fromEnv === 'string' && fromEnv.trim()) return fromEnv.trim();
+  return fallback;
+}
+
+function usage() {
+  console.log(`\nUsage: node scripts/check-data-freshness.js [options]\n\nRequired (live mode):\n  --prod-url <url>             or PROD_SUPABASE_URL\n  --prod-key <key>             or PROD_SUPABASE_KEY\n  --dev-url <url>              or DEV_SUPABASE_URL\n  --dev-key <key>              or DEV_SUPABASE_KEY\n\nOptional:\n  --department <code>          Default: DESN\n  --year <YYYY-YY>             Default: active year in each environment\n  --prod-label <name>          Default: production\n  --dev-label <name>           Default: dev\n  --prod-snapshot <file.json>  Load production snapshot from file instead of live query\n  --dev-snapshot <file.json>   Load dev snapshot from file instead of live query\n  --output <file.json>         Write full comparison JSON\n\nExamples:\n  PROD_SUPABASE_URL=... PROD_SUPABASE_KEY=... DEV_SUPABASE_URL=... DEV_SUPABASE_KEY=... \\\n  node scripts/check-data-freshness.js --department DESN --year 2026-27\n\n  node scripts/check-data-freshness.js \\\n    --prod-snapshot output/prod.json --dev-snapshot output/dev.json\n`);
+}
+
+function fail(message, code = 1) {
+  console.error(`\nERROR: ${message}\n`);
+  process.exit(code);
+}
+
+function withScopeFilter(query, scope, scopeIds) {
+  if (scope === 'department') {
+    return query.eq('department_id', scopeIds.departmentId);
+  }
+  if (scope === 'academic_year') {
+    return query.eq('academic_year_id', scopeIds.academicYearId);
+  }
+  return query;
+}
+
+async function getDepartment(client, departmentCode) {
+  const result = await client
+    .from('departments')
+    .select('id,code,name,created_at')
+    .eq('code', departmentCode)
+    .maybeSingle();
+  if (result.error) throw new Error(`departments lookup failed: ${result.error.message}`);
+  if (!result.data) throw new Error(`department ${departmentCode} not found`);
+  return result.data;
+}
+
+async function resolveAcademicYear(client, departmentId, explicitYear = '') {
+  let query = client
+    .from('academic_years')
+    .select('id,year,is_active,created_at')
+    .eq('department_id', departmentId);
+
+  if (explicitYear) {
+    const result = await query.eq('year', explicitYear).maybeSingle();
+    if (result.error) throw new Error(`academic_year ${explicitYear} lookup failed: ${result.error.message}`);
+    if (!result.data) throw new Error(`academic_year ${explicitYear} not found for department`);
+    return result.data;
+  }
+
+  const active = await query.eq('is_active', true).order('created_at', { ascending: false }).limit(1);
+  if (!active.error && Array.isArray(active.data) && active.data.length > 0) {
+    return active.data[0];
+  }
+
+  const latest = await client
+    .from('academic_years')
+    .select('id,year,is_active,created_at')
+    .eq('department_id', departmentId)
+    .order('year', { ascending: false })
+    .limit(1);
+  if (latest.error) throw new Error(`academic_year fallback lookup failed: ${latest.error.message}`);
+  if (!Array.isArray(latest.data) || latest.data.length === 0) throw new Error('no academic_year records found');
+  return latest.data[0];
+}
+
+async function fetchTableDigest(client, config, scopeIds) {
+  let countQuery = client
+    .from(config.table)
+    .select('id', { count: 'exact', head: true });
+  countQuery = withScopeFilter(countQuery, config.scope, scopeIds);
+  const countResult = await countQuery;
+  if (countResult.error) throw new Error(`${config.table} count failed: ${countResult.error.message}`);
+
+  let latestChangeAt = null;
+  if (config.timestampColumn) {
+    let latestQuery = client
+      .from(config.table)
+      .select(config.timestampColumn)
+      .not(config.timestampColumn, 'is', null)
+      .order(config.timestampColumn, { ascending: false })
+      .limit(1);
+    latestQuery = withScopeFilter(latestQuery, config.scope, scopeIds);
+    const latestResult = await latestQuery;
+    if (!latestResult.error && Array.isArray(latestResult.data) && latestResult.data.length > 0) {
+      latestChangeAt = latestResult.data[0][config.timestampColumn] || null;
+    }
+  }
+
+  return {
+    count: Number(countResult.count) || 0,
+    latestChangeAt,
+    timestampColumn: config.timestampColumn || null
+  };
+}
+
+async function fetchEnvironmentSnapshot({ label, url, key, departmentCode, explicitYear }) {
+  const client = createClient(url, key);
+  const department = await getDepartment(client, departmentCode);
+  const academicYear = await resolveAcademicYear(client, department.id, explicitYear);
+
+  const tables = {};
+  for (const tableConfig of TABLE_CONFIG) {
+    tables[tableConfig.table] = await fetchTableDigest(client, tableConfig, {
+      departmentId: department.id,
+      academicYearId: academicYear.id
+    });
+  }
+
+  const checksumSeed = JSON.stringify({
+    departmentCode,
+    year: academicYear.year,
+    tables
+  });
+  const checksum = crypto.createHash('sha256').update(checksumSeed).digest('hex');
+
+  return {
+    label,
+    generatedAt: new Date().toISOString(),
+    department: {
+      code: department.code,
+      id: department.id,
+      name: department.name
+    },
+    academicYear: {
+      id: academicYear.id,
+      year: academicYear.year,
+      isActive: Boolean(academicYear.is_active)
+    },
+    tables,
+    checksum
+  };
+}
+
+function parseDate(value) {
+  const d = value ? new Date(value) : null;
+  return d && Number.isFinite(d.getTime()) ? d : null;
+}
+
+function compareSnapshots(prod, dev) {
+  const allTables = [...new Set([
+    ...Object.keys(prod.tables || {}),
+    ...Object.keys(dev.tables || {})
+  ])].sort();
+
+  const rows = allTables.map((table) => {
+    const p = prod.tables?.[table] || { count: 0, latestChangeAt: null };
+    const d = dev.tables?.[table] || { count: 0, latestChangeAt: null };
+    const prodDate = parseDate(p.latestChangeAt);
+    const devDate = parseDate(d.latestChangeAt);
+    const countDelta = (d.count || 0) - (p.count || 0);
+
+    let freshness = 'in-sync';
+    if ((p.count || 0) !== (d.count || 0)) {
+      freshness = countDelta > 0 ? 'dev-has-more' : 'prod-has-more';
+    } else if ((p.latestChangeAt || '') !== (d.latestChangeAt || '')) {
+      if (prodDate && devDate) {
+        freshness = prodDate > devDate ? 'prod-newer' : 'dev-newer';
+      } else {
+        freshness = 'timestamp-diff';
+      }
+    }
+
+    const inSync = freshness === 'in-sync';
+    return {
+      table,
+      production: p,
+      dev: d,
+      countDelta,
+      freshness,
+      inSync
+    };
+  });
+
+  const driftTables = rows.filter((row) => !row.inSync);
+  return {
+    generatedAt: new Date().toISOString(),
+    departmentCode: prod.department?.code || dev.department?.code || '',
+    production: {
+      label: prod.label,
+      academicYear: prod.academicYear,
+      checksum: prod.checksum
+    },
+    dev: {
+      label: dev.label,
+      academicYear: dev.academicYear,
+      checksum: dev.checksum
+    },
+    summary: {
+      totalTables: rows.length,
+      driftTables: driftTables.length,
+      inSync: driftTables.length === 0
+    },
+    rows
+  };
+}
+
+function fmtDate(value) {
+  if (!value) return '—';
+  const d = parseDate(value);
+  return d ? d.toISOString().replace('T', ' ').replace('Z', ' UTC') : String(value);
+}
+
+function printComparison(comparison, prodLabel, devLabel) {
+  console.log('\n=== Supabase Data Freshness Check ===');
+  console.log(`Department: ${comparison.departmentCode}`);
+  console.log(`Production (${prodLabel}) year: ${comparison.production.academicYear?.year || '—'}`);
+  console.log(`Dev (${devLabel}) year: ${comparison.dev.academicYear?.year || '—'}`);
+  console.log('');
+
+  const header = [
+    'Table'.padEnd(24),
+    `${prodLabel} count`.padStart(12),
+    `${devLabel} count`.padStart(12),
+    'Freshness'.padStart(14),
+    `${prodLabel} latest`.padStart(24),
+    `${devLabel} latest`.padStart(24)
+  ].join(' | ');
+  console.log(header);
+  console.log('-'.repeat(header.length));
+
+  comparison.rows.forEach((row) => {
+    const line = [
+      row.table.padEnd(24),
+      String(row.production.count ?? 0).padStart(12),
+      String(row.dev.count ?? 0).padStart(12),
+      row.freshness.padStart(14),
+      fmtDate(row.production.latestChangeAt).padStart(24),
+      fmtDate(row.dev.latestChangeAt).padStart(24)
+    ].join(' | ');
+    console.log(line);
+  });
+
+  console.log('\nSummary:');
+  if (comparison.summary.inSync) {
+    console.log('  ✅ Dev and production snapshots are in sync for tracked tables.');
+  } else {
+    console.log(`  ⚠️  Drift detected in ${comparison.summary.driftTables}/${comparison.summary.totalTables} tables.`);
+    console.log('  Tables needing carry-over review:');
+    comparison.rows
+      .filter((row) => !row.inSync)
+      .forEach((row) => console.log(`   - ${row.table}: ${row.freshness}`));
+  }
+}
+
+function readSnapshotFile(filePath) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  const raw = fs.readFileSync(resolved, 'utf8');
+  return JSON.parse(raw);
+}
+
+function writeJsonFile(filePath, value) {
+  const resolved = path.resolve(process.cwd(), filePath);
+  const dir = path.dirname(resolved);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(resolved, JSON.stringify(value, null, 2));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    usage();
+    process.exit(0);
+  }
+
+  const departmentCode = envOrArg(args, 'department', 'DEPARTMENT_CODE', 'DESN');
+  const explicitYear = envOrArg(args, 'year', 'ACADEMIC_YEAR', '');
+  const prodLabel = envOrArg(args, 'prod-label', 'PROD_LABEL', 'production');
+  const devLabel = envOrArg(args, 'dev-label', 'DEV_LABEL', 'dev');
+
+  let prodSnapshot;
+  let devSnapshot;
+
+  if (args['prod-snapshot']) {
+    prodSnapshot = readSnapshotFile(args['prod-snapshot']);
+  } else {
+    const prodUrl = envOrArg(args, 'prod-url', 'PROD_SUPABASE_URL');
+    const prodKey = envOrArg(args, 'prod-key', 'PROD_SUPABASE_KEY');
+    if (!prodUrl || !prodKey) fail('Missing production credentials (--prod-url/--prod-key or PROD_SUPABASE_URL/PROD_SUPABASE_KEY).');
+    prodSnapshot = await fetchEnvironmentSnapshot({
+      label: prodLabel,
+      url: prodUrl,
+      key: prodKey,
+      departmentCode,
+      explicitYear
+    });
+  }
+
+  if (args['dev-snapshot']) {
+    devSnapshot = readSnapshotFile(args['dev-snapshot']);
+  } else {
+    const devUrl = envOrArg(args, 'dev-url', 'DEV_SUPABASE_URL');
+    const devKey = envOrArg(args, 'dev-key', 'DEV_SUPABASE_KEY');
+    if (!devUrl || !devKey) fail('Missing dev credentials (--dev-url/--dev-key or DEV_SUPABASE_URL/DEV_SUPABASE_KEY).');
+    devSnapshot = await fetchEnvironmentSnapshot({
+      label: devLabel,
+      url: devUrl,
+      key: devKey,
+      departmentCode,
+      explicitYear
+    });
+  }
+
+  const comparison = compareSnapshots(prodSnapshot, devSnapshot);
+  printComparison(comparison, prodLabel, devLabel);
+
+  if (args.output) {
+    writeJsonFile(args.output, comparison);
+    console.log(`\nWrote report: ${path.resolve(process.cwd(), args.output)}`);
+  }
+
+  if (!comparison.summary.inSync) {
+    process.exitCode = 2;
+  }
+}
+
+main().catch((error) => {
+  fail(error?.message || String(error));
+});

--- a/tests/auth-service.test.js
+++ b/tests/auth-service.test.js
@@ -1,0 +1,159 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadAuthService({ isConfigured = true, authImpl = {} } = {}) {
+    const filePath = path.resolve(__dirname, '..', 'js/auth-service.js');
+    const source = fs.readFileSync(filePath, 'utf8');
+
+    const mockAuth = {
+        signUp: jest.fn(),
+        signInWithPassword: jest.fn(),
+        signOut: jest.fn(),
+        getSession: jest.fn(),
+        getUser: jest.fn(),
+        onAuthStateChange: jest.fn(),
+        ...authImpl
+    };
+
+    const mockClient = { auth: mockAuth };
+    const mockDocument = {
+        addEventListener: jest.fn()
+    };
+
+    const sandbox = {
+        console,
+        module: { exports: {} },
+        exports: {},
+        document: mockDocument,
+        window: {
+            getSupabaseClient: jest.fn(() => mockClient),
+            isSupabaseConfigured: jest.fn(() => isConfigured)
+        },
+        getSupabaseClient: jest.fn(() => mockClient),
+        isSupabaseConfigured: jest.fn(() => isConfigured)
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: 'js/auth-service.js' });
+
+    return {
+        AuthService: sandbox.module.exports,
+        mockAuth,
+        mockClient
+    };
+}
+
+describe('AuthService', () => {
+    test('signUp stores role metadata and returns normalized role', async () => {
+        const { AuthService, mockAuth } = loadAuthService();
+        mockAuth.signUp.mockResolvedValue({
+            data: {
+                user: {
+                    id: 'user-1',
+                    email: 'chair@example.edu',
+                    user_metadata: { role: 'chair' }
+                },
+                session: { access_token: 'token' }
+            },
+            error: null
+        });
+
+        const result = await AuthService.signUp('chair@example.edu', 'password123', 'chair');
+
+        expect(mockAuth.signUp).toHaveBeenCalledWith({
+            email: 'chair@example.edu',
+            password: 'password123',
+            options: { data: { role: 'chair' } }
+        });
+        expect(result.role).toBe('chair');
+        expect(result.user.role).toBe('chair');
+        expect(result.session).toEqual({ access_token: 'token' });
+    });
+
+    test('signIn authenticates and returns session + user role', async () => {
+        const { AuthService, mockAuth } = loadAuthService();
+        mockAuth.signInWithPassword.mockResolvedValue({
+            data: {
+                user: {
+                    id: 'user-2',
+                    email: 'admin@example.edu',
+                    app_metadata: { role: 'admin' }
+                },
+                session: { access_token: 'abc' }
+            },
+            error: null
+        });
+
+        const result = await AuthService.signIn('admin@example.edu', 'secret');
+
+        expect(mockAuth.signInWithPassword).toHaveBeenCalledWith({
+            email: 'admin@example.edu',
+            password: 'secret'
+        });
+        expect(result.user.role).toBe('admin');
+        expect(result.session).toEqual({ access_token: 'abc' });
+    });
+
+    test('getSession returns null when no active session exists', async () => {
+        const { AuthService, mockAuth } = loadAuthService();
+        mockAuth.getSession.mockResolvedValue({
+            data: { session: null },
+            error: null
+        });
+
+        await expect(AuthService.getSession()).resolves.toBeNull();
+    });
+
+    test('getUser returns normalized user with role', async () => {
+        const { AuthService, mockAuth } = loadAuthService();
+        mockAuth.getUser.mockResolvedValue({
+            data: {
+                user: {
+                    id: 'user-3',
+                    email: 'chair2@example.edu',
+                    raw_user_meta_data: { role: 'chair' }
+                }
+            },
+            error: null
+        });
+
+        const user = await AuthService.getUser();
+        expect(user.role).toBe('chair');
+        expect(user.email).toBe('chair2@example.edu');
+    });
+
+    test('onAuthStateChange subscribes and forwards normalized payload', () => {
+        const { AuthService, mockAuth } = loadAuthService();
+        const subscription = { unsubscribe: jest.fn() };
+
+        mockAuth.onAuthStateChange.mockImplementation((handler) => {
+            handler('SIGNED_IN', {
+                access_token: 'xyz',
+                user: { id: 'user-4', user_metadata: { role: 'chair' } }
+            });
+            return { data: { subscription }, error: null };
+        });
+
+        const callback = jest.fn();
+        const result = AuthService.onAuthStateChange(callback);
+
+        expect(result).toBe(subscription);
+        expect(callback).toHaveBeenCalledWith(
+            'SIGNED_IN',
+            expect.objectContaining({
+                access_token: 'xyz',
+                user: expect.objectContaining({ role: 'chair' })
+            }),
+            expect.objectContaining({ role: 'chair' })
+        );
+    });
+
+    test('throws when Supabase is not configured for auth operations', async () => {
+        const { AuthService } = loadAuthService({ isConfigured: false });
+        await expect(AuthService.signIn('chair@example.edu', 'pw')).rejects.toThrow('Supabase is not configured.');
+        await expect(AuthService.signUp('chair@example.edu', 'pw', 'chair')).rejects.toThrow('Supabase is not configured.');
+        await expect(AuthService.getSession()).resolves.toBeNull();
+        await expect(AuthService.getUser()).resolves.toBeNull();
+    });
+});

--- a/tests/department-profile.onboarding.test.js
+++ b/tests/department-profile.onboarding.test.js
@@ -1,0 +1,111 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function loadJson(relativePath) {
+    return JSON.parse(fs.readFileSync(path.join(ROOT, relativePath), 'utf8'));
+}
+
+describe('DepartmentProfileManager onboarding helpers', () => {
+    const manifest = loadJson('department-profiles/manifest.json');
+    const designProfile = loadJson('department-profiles/design-v1.json');
+    const pilotProfile = loadJson('department-profiles/itds-pilot-v1.json');
+
+    beforeEach(() => {
+        localStorage.clear();
+        delete window.DepartmentProfileManager;
+        delete window.__PROGRAM_COMMAND_ACTIVE_PROFILE__;
+
+        global.fetch = jest.fn(async (url) => {
+            const target = String(url || '');
+            if (target.endsWith('/manifest.json') || target.endsWith('department-profiles/manifest.json')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => manifest
+                };
+            }
+            if (target.endsWith('/design-v1.json') || target.endsWith('department-profiles/design-v1.json')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => designProfile
+                };
+            }
+            if (target.endsWith('/itds-pilot-v1.json') || target.endsWith('department-profiles/itds-pilot-v1.json')) {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => pilotProfile
+                };
+            }
+            return {
+                ok: false,
+                status: 404,
+                json: async () => ({})
+            };
+        });
+
+        const runtimeScript = fs.readFileSync(path.join(ROOT, 'js/department-profile.js'), 'utf8');
+        window.eval(runtimeScript);
+    });
+
+    afterEach(() => {
+        localStorage.clear();
+        delete global.fetch;
+        delete window.DepartmentProfileManager;
+    });
+
+    test('lists manifest and pilot profiles', async () => {
+        const manager = window.DepartmentProfileManager;
+        expect(manager).toBeDefined();
+
+        const listing = await manager.listProfiles();
+        const ids = listing.profiles.map((entry) => entry.id);
+
+        expect(ids).toContain('design-v1');
+        expect(ids).toContain('itds-pilot-v1');
+    });
+
+    test('saves custom profiles with versioned ids and loads them back', async () => {
+        const manager = window.DepartmentProfileManager;
+        await manager.initialize({ forceReload: true });
+
+        const base = manager.getCurrentProfile();
+        const draft = {
+            ...base,
+            identity: {
+                ...base.identity,
+                name: 'Test Department',
+                code: 'TEST',
+                displayName: 'EWU Test Department',
+                shortName: 'Test'
+            },
+            scheduler: {
+                ...base.scheduler,
+                storageKeyPrefix: 'testSchedulerData_',
+                allowedRooms: ['TEST 101', 'TEST 102'],
+                roomLabels: {
+                    'TEST 101': 'Test 101 Studio',
+                    'TEST 102': 'Test 102 Lab'
+                }
+            }
+        };
+
+        const first = await manager.saveCustomProfile(draft, { baseId: 'test-department', activate: false });
+        const second = await manager.saveCustomProfile(draft, { baseId: 'test-department', activate: false });
+
+        expect(first.profileId).toBe('test-department-v01');
+        expect(second.profileId).toBe('test-department-v02');
+
+        const loaded = await manager.loadProfile(second.profileId);
+        expect(loaded.source).toBe('custom-local');
+        expect(loaded.profile.identity.code).toBe('TEST');
+
+        const listing = await manager.listProfiles();
+        const ids = listing.profiles.map((entry) => entry.id);
+        expect(ids).toContain('test-department-v01');
+        expect(ids).toContain('test-department-v02');
+    });
+});

--- a/tests/eaglenet-compare.test.js
+++ b/tests/eaglenet-compare.test.js
@@ -1,0 +1,151 @@
+const EagleNetCompare = require('../js/eaglenet-compare.js');
+const EagleNetComparePage = require('../pages/eaglenet-compare.js');
+
+describe('EagleNet comparison normalization and mismatch grouping', () => {
+    test('treats formatting differences as exact matches after normalization', () => {
+        const schedulerRows = [
+            {
+                academicYear: '2026-27',
+                quarter: 'Fall',
+                courseCode: 'DESN-100',
+                section: '1',
+                instructor: 'Travis Masingale',
+                days: 'TTH',
+                time: '9:00 AM - 10:50 AM',
+                room: 'CEB 102',
+                credits: 5
+            }
+        ];
+
+        const eagleNetRows = [
+            {
+                academic_year: '2026/2027',
+                term: 'FA',
+                subject: 'DESN',
+                catalog_number: '100',
+                section: '001',
+                faculty: 'Masingale, Travis',
+                meeting_days: 'Tue/Thu',
+                start_time: '0900',
+                end_time: '1050',
+                building: 'CEB',
+                location: '102',
+                credit_hours: '5'
+            }
+        ];
+
+        const diff = EagleNetCompare.diffNormalizedSchedules(schedulerRows, eagleNetRows, {
+            leftSource: 'scheduler',
+            rightSource: 'eaglenet'
+        });
+
+        expect(diff.summary.leftRows).toBe(1);
+        expect(diff.summary.rightRows).toBe(1);
+        expect(diff.summary.compared).toBe(1);
+        expect(diff.summary.exactMatches).toBe(1);
+        expect(diff.summary.totalDifferences).toBe(0);
+    });
+
+    test('categorizes missing, extra, and field mismatch rows', () => {
+        const schedulerRows = [
+            {
+                academicYear: '2026-27',
+                quarter: 'Fall',
+                courseCode: 'DESN 101',
+                section: '001',
+                instructor: 'Travis Masingale',
+                days: 'MW',
+                time: '09:00-10:50',
+                room: 'CEB 102',
+                credits: 5
+            },
+            {
+                academicYear: '2026-27',
+                quarter: 'Winter',
+                courseCode: 'DESN 202',
+                section: '001',
+                instructor: 'Mindy Breen',
+                days: 'TR',
+                time: '13:00-14:50',
+                room: 'CEB 206',
+                credits: 5
+            }
+        ];
+
+        const eagleNetRows = [
+            {
+                academicYear: '2026-27',
+                quarter: 'Fall',
+                courseCode: 'DESN 101',
+                section: '001',
+                instructor: 'Travis Masingale',
+                days: 'MW',
+                time: '09:00-10:50',
+                room: 'CEB 207',
+                credits: 5
+            },
+            {
+                academicYear: '2026-27',
+                quarter: 'Spring',
+                courseCode: 'DESN 300',
+                section: '001',
+                instructor: 'Sonja Durr',
+                days: 'MW',
+                time: '11:00-12:50',
+                room: 'CEB 109',
+                credits: 5
+            }
+        ];
+
+        const diff = EagleNetCompare.diffNormalizedSchedules(schedulerRows, eagleNetRows, {
+            leftSource: 'scheduler',
+            rightSource: 'eaglenet'
+        });
+
+        expect(diff.summary.compared).toBe(1);
+        expect(diff.summary.fieldMismatchRows).toBe(1);
+        expect(diff.summary.missingInRight).toBe(1);
+        expect(diff.summary.extraInRight).toBe(1);
+        expect(diff.summary.totalDifferences).toBe(3);
+        expect(diff.fieldMismatches[0].mismatches.some((mismatch) => mismatch.field === 'roomKey')).toBe(true);
+    });
+});
+
+describe('EagleNet comparison page helpers', () => {
+    test('parses CSV headers into normalized row keys', () => {
+        const csv = [
+            'Academic Year,Quarter,Course Code,Section,Instructor,Days,Time,Room,Credits',
+            '2026-27,Fall,DESN 101,001,Travis Masingale,MW,09:00-10:50,CEB 102,5'
+        ].join('\n');
+
+        const rows = EagleNetComparePage.parseRowsInput(csv);
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            academicYear: '2026-27',
+            quarter: 'Fall',
+            courseCode: 'DESN 101',
+            section: '001',
+            instructor: 'Travis Masingale'
+        });
+    });
+
+    test('builds exportable discrepancy rows from diff output', () => {
+        const diff = EagleNetCompare.diffNormalizedSchedules(
+            [
+                { academicYear: '2026-27', quarter: 'Fall', courseCode: 'DESN 101', section: '001', room: 'CEB 102' }
+            ],
+            [
+                { academicYear: '2026-27', quarter: 'Fall', courseCode: 'DESN 101', section: '001', room: 'CEB 103' },
+                { academicYear: '2026-27', quarter: 'Fall', courseCode: 'DESN 250', section: '001' }
+            ],
+            { leftSource: 'scheduler', rightSource: 'eaglenet' }
+        );
+
+        const rows = EagleNetComparePage.buildDiscrepancyRows(diff, '2026-27');
+        const mismatchTypes = rows.map((row) => row.mismatchType);
+
+        expect(rows.length).toBeGreaterThanOrEqual(2);
+        expect(mismatchTypes).toContain('field_mismatch');
+        expect(mismatchTypes).toContain('extra_in_eaglenet');
+    });
+});


### PR DESCRIPTION
## Summary
- add `AuthService` singleton (`js/auth-service.js`) for Supabase Auth operations
- implement required API: `signUp`, `signIn`, `signOut`, `getSession`, `getUser`, `onAuthStateChange`
- persist role metadata at sign-up via Supabase `options.data.role`
- normalize user role from `app_metadata`, `user_metadata`, or `raw_user_meta_data`
- wire auth service script into Supabase-enabled pages (`schedule-builder`, `course-management`)
- add mocked unit tests for AuthService behavior and subscription flow

## Validation
- npm test -- --runInBand
  - 11/11 suites passed
  - 31/31 tests passed

## Issue
- Closes #88
