### PR TITLE
[Tree/A-04] Implement role-based access control (admin vs. chair)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5272,6 +5272,18 @@
 
 
         // Listen for the custom event from the AppHeader component
+        function canPerform(action, resource) {
+            if (!window.AuthService || typeof window.AuthService.can !== 'function') {
+                return true;
+            }
+            return window.AuthService.can(action, resource);
+        }
+
+        document.addEventListener('header-permission-denied', (e) => {
+            const message = e?.detail?.message || 'Insufficient permissions for this action.';
+            showToast(message, 'error');
+        });
+
         document.addEventListener('header-action', (e) => {
             const action = e.detail.action;
             if (action === 'save') {
@@ -5285,11 +5297,23 @@
             } else if (action === 'sheets') {
                 exportToGoogleSheets();
             } else if (action === 'rules') {
+                if (!canPerform('write', 'system-config')) {
+                    showToast('Insufficient permissions: only admins can change constraint rules.', 'error');
+                    return;
+                }
                 openConstraintsModal();
             } else if (action === 'api') {
+                if (!canPerform('manage', 'system-config')) {
+                    showToast('Insufficient permissions: only admins can access API connections.', 'error');
+                    return;
+                }
                 openApiSettingsModal();
             } else if (action === 'accounts') {
-                showToast('Users & accounts is the next build step: add Supabase Auth + role-based permissions.', 'success');
+                if (!canPerform('manage', 'accounts')) {
+                    showToast('Insufficient permissions: only admins can manage users and accounts.', 'error');
+                    return;
+                }
+                showToast('Users & accounts management UI is not implemented yet.');
             } else if (action === 'nav-enrollment') {
                 window.location.href = 'enrollment-dashboard.html';
             } else if (action === 'nav-workload') {

--- a/js/auth-guard.js
+++ b/js/auth-guard.js
@@ -25,6 +25,25 @@
             : 'index.html';
     }
 
+    function can(action, resource, user) {
+        if (window.AuthService && typeof window.AuthService.can === 'function') {
+            return window.AuthService.can(action, resource, user);
+        }
+        const role = String(user?.role || '').toLowerCase();
+        return role === 'admin';
+    }
+
+    function getRoutePolicy() {
+        if (/\/pages\/department-onboarding\.html$/i.test(window.location.pathname)) {
+            return {
+                action: 'manage',
+                resource: 'system-config',
+                message: 'Insufficient permissions: only admins can access Department Onboarding.'
+            };
+        }
+        return null;
+    }
+
     function redirectToLogin() {
         const next = encodeURIComponent(getCurrentPathWithQuery());
         window.location.replace(`${loginUrl()}?next=${next}`);
@@ -134,6 +153,57 @@
         });
     }
 
+    function renderPermissionDenied(message) {
+        if (isLoginPage()) return;
+        document.body.innerHTML = `
+            <main style="
+                min-height: 100vh;
+                display: grid;
+                place-items: center;
+                background: linear-gradient(180deg, #f6f8fa 0%, #ffffff 100%);
+                padding: 24px;
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+            ">
+                <section style="
+                    width: min(560px, 100%);
+                    background: #fff;
+                    border: 1px solid #f1b0b7;
+                    border-radius: 12px;
+                    padding: 22px;
+                    box-shadow: 0 16px 36px rgba(31, 35, 40, 0.12);
+                ">
+                    <h1 style="margin: 0 0 8px; font-size: 24px; color: #cf222e;">Access Denied</h1>
+                    <p style="margin: 0 0 16px; color: #57606a; line-height: 1.45;">
+                        ${message || 'You do not have permission to access this page.'}
+                    </p>
+                    <div style="display: flex; gap: 10px; flex-wrap: wrap;">
+                        <a href="${homeUrl()}" style="
+                            display: inline-block;
+                            padding: 10px 14px;
+                            border-radius: 8px;
+                            background: #a10022;
+                            color: #fff;
+                            text-decoration: none;
+                            font-weight: 700;
+                            font-size: 14px;
+                        ">Return to Home</a>
+                        <a href="${loginUrl()}" style="
+                            display: inline-block;
+                            padding: 10px 14px;
+                            border-radius: 8px;
+                            border: 1px solid #d0d7de;
+                            background: #fff;
+                            color: #1f2328;
+                            text-decoration: none;
+                            font-weight: 600;
+                            font-size: 14px;
+                        ">Switch Account</a>
+                    </div>
+                </section>
+            </main>
+        `;
+    }
+
     async function handleLoginPage() {
         const session = await window.AuthService.getSession();
         if (session) {
@@ -149,6 +219,12 @@
         }
 
         const user = (await window.AuthService.getUser()) || session.user || null;
+        const routePolicy = getRoutePolicy();
+        if (routePolicy && !can(routePolicy.action, routePolicy.resource, user)) {
+            renderPermissionDenied(routePolicy.message);
+            return;
+        }
+
         renderSessionIndicator(user);
     }
 

--- a/js/auth-service.js
+++ b/js/auth-service.js
@@ -6,6 +6,105 @@ const AuthService = (function() {
     'use strict';
 
     let cachedClient = null;
+    let cachedNormalizedUser = null;
+
+    const ROLE_ADMIN = 'admin';
+    const ROLE_CHAIR = 'chair';
+
+    const ACTION_ALIASES = {
+        read: 'read',
+        view: 'read',
+        list: 'read',
+        get: 'read',
+        write: 'write',
+        create: 'write',
+        insert: 'write',
+        update: 'write',
+        edit: 'write',
+        delete: 'write',
+        save: 'write',
+        manage: 'manage',
+        admin: 'manage',
+        configure: 'manage',
+        invite: 'manage'
+    };
+
+    const RESOURCE_ALIASES = {
+        schedule: 'schedule',
+        schedules: 'schedule',
+        scheduler: 'schedule',
+        workload: 'workload',
+        workloads: 'workload',
+        department: 'departments',
+        departments: 'departments',
+        academic_year: 'academic_years',
+        academic_years: 'academic_years',
+        'academic-year': 'academic_years',
+        'academic-years': 'academic_years',
+        room: 'rooms',
+        rooms: 'rooms',
+        course: 'courses',
+        courses: 'courses',
+        faculty: 'faculty',
+        scheduled_course: 'scheduled_courses',
+        scheduled_courses: 'scheduled_courses',
+        'scheduled-course': 'scheduled_courses',
+        'scheduled-courses': 'scheduled_courses',
+        faculty_preference: 'faculty_preferences',
+        faculty_preferences: 'faculty_preferences',
+        'faculty-preference': 'faculty_preferences',
+        'faculty-preferences': 'faculty_preferences',
+        scheduling_constraint: 'scheduling_constraints',
+        scheduling_constraints: 'scheduling_constraints',
+        'scheduling-constraint': 'scheduling_constraints',
+        'scheduling-constraints': 'scheduling_constraints',
+        release_time: 'release_time',
+        'release-time': 'release_time',
+        pathways: 'pathways',
+        pathway_courses: 'pathway_courses',
+        'pathway-courses': 'pathway_courses',
+        system_config: 'system_config',
+        'system-config': 'system_config',
+        config: 'system_config',
+        configuration: 'system_config',
+        accounts: 'accounts',
+        users: 'accounts',
+        auth: 'accounts'
+    };
+
+    const CHAIR_PERMISSIONS = {
+        read: new Set([
+            'schedule',
+            'workload',
+            'system_config',
+            'departments',
+            'academic_years',
+            'rooms',
+            'courses',
+            'faculty',
+            'scheduled_courses',
+            'faculty_preferences',
+            'scheduling_constraints',
+            'release_time',
+            'pathways',
+            'pathway_courses'
+        ]),
+        write: new Set([
+            'schedule',
+            'workload',
+            'academic_years',
+            'rooms',
+            'courses',
+            'faculty',
+            'scheduled_courses',
+            'faculty_preferences',
+            'scheduling_constraints',
+            'release_time',
+            'pathways',
+            'pathway_courses'
+        ]),
+        manage: new Set([])
+    };
 
     function isConfigured() {
         if (typeof isSupabaseConfigured === 'function') {
@@ -57,6 +156,58 @@ const AuthService = (function() {
         };
     }
 
+    function normalizeRole(rawRole) {
+        const role = String(rawRole || '').trim().toLowerCase();
+        if (role === ROLE_ADMIN) return ROLE_ADMIN;
+        return ROLE_CHAIR;
+    }
+
+    function normalizeAction(rawAction) {
+        const action = String(rawAction || '').trim().toLowerCase();
+        return ACTION_ALIASES[action] || null;
+    }
+
+    function normalizeResource(rawResource) {
+        const canonical = String(rawResource || '')
+            .trim()
+            .toLowerCase()
+            .replace(/[.\s]+/g, '_');
+        return RESOURCE_ALIASES[canonical] || canonical || null;
+    }
+
+    function resolveRoleFromContext(context) {
+        if (typeof context === 'string') {
+            return normalizeRole(context);
+        }
+
+        if (context && typeof context === 'object') {
+            if (typeof context.role === 'string') {
+                return normalizeRole(context.role);
+            }
+            if (context.user && typeof context.user === 'object') {
+                const userRole = extractRole(context.user) || context.user.role;
+                if (userRole) {
+                    return normalizeRole(userRole);
+                }
+            }
+        }
+
+        if (cachedNormalizedUser?.role) {
+            return normalizeRole(cachedNormalizedUser.role);
+        }
+
+        return ROLE_CHAIR;
+    }
+
+    function hasPermission(role, action, resource) {
+        if (role === ROLE_ADMIN) return true;
+        if (role !== ROLE_CHAIR) return false;
+
+        const permittedResources = CHAIR_PERMISSIONS[action];
+        if (!permittedResources) return false;
+        return permittedResources.has(resource);
+    }
+
     function init() {
         if (!isConfigured()) {
             return null;
@@ -81,6 +232,7 @@ const AuthService = (function() {
         if (error) throw error;
 
         const user = normalizeUser(data?.user || null, role);
+        cachedNormalizedUser = user;
         return {
             user,
             session: data?.session || null,
@@ -99,6 +251,7 @@ const AuthService = (function() {
         if (error) throw error;
 
         const user = normalizeUser(data?.user || data?.session?.user || null);
+        cachedNormalizedUser = user;
         return {
             user,
             session: data?.session || null
@@ -113,6 +266,7 @@ const AuthService = (function() {
         const client = getClientOrThrow();
         const { error } = await client.auth.signOut();
         if (error) throw error;
+        cachedNormalizedUser = null;
         return true;
     }
 
@@ -124,7 +278,11 @@ const AuthService = (function() {
         const client = getClientOrThrow();
         const { data, error } = await client.auth.getSession();
         if (error) throw error;
-        return data?.session || null;
+        const session = data?.session || null;
+        if (session?.user) {
+            cachedNormalizedUser = normalizeUser(session.user);
+        }
+        return session;
     }
 
     async function getUser() {
@@ -135,7 +293,9 @@ const AuthService = (function() {
         const client = getClientOrThrow();
         const { data, error } = await client.auth.getUser();
         if (error) throw error;
-        return normalizeUser(data?.user || null);
+        const user = normalizeUser(data?.user || null);
+        cachedNormalizedUser = user;
+        return user;
     }
 
     function onAuthStateChange(callback) {
@@ -146,6 +306,7 @@ const AuthService = (function() {
         const client = getClientOrThrow();
         const { data, error } = client.auth.onAuthStateChange((event, session) => {
             const normalizedUser = normalizeUser(session?.user || null);
+            cachedNormalizedUser = normalizedUser;
             const normalizedSession = session
                 ? { ...session, user: normalizedUser }
                 : null;
@@ -156,8 +317,21 @@ const AuthService = (function() {
         return data?.subscription || data || null;
     }
 
+    function can(action, resource, context = null) {
+        const normalizedAction = normalizeAction(action);
+        const normalizedResource = normalizeResource(resource);
+
+        if (!normalizedAction || !normalizedResource) {
+            return false;
+        }
+
+        const role = resolveRoleFromContext(context);
+        return hasPermission(role, normalizedAction, normalizedResource);
+    }
+
     function resetForTests() {
         cachedClient = null;
+        cachedNormalizedUser = null;
     }
 
     return {
@@ -167,6 +341,7 @@ const AuthService = (function() {
         signOut,
         getSession,
         getUser,
+        can,
         onAuthStateChange,
         _resetForTests: resetForTests
     };

--- a/js/components/app-header.js
+++ b/js/components/app-header.js
@@ -3,15 +3,81 @@ class AppHeader extends HTMLElement {
         super();
         this.attachShadow({ mode: 'open' });
         this.isOpen = false;
+        this.authSubscription = null;
+        this.permissionSyncTimer = null;
+        this.permissionSyncAttempts = 0;
     }
 
     connectedCallback() {
         this.render();
         this.setupEventListeners();
+        this.startPermissionSync();
     }
 
     disconnectedCallback() {
+        this.stopPermissionSync();
+        if (this.authSubscription && typeof this.authSubscription.unsubscribe === 'function') {
+            this.authSubscription.unsubscribe();
+            this.authSubscription = null;
+        }
         this.removeEventListeners();
+    }
+
+    startPermissionSync() {
+        this.stopPermissionSync();
+        this.permissionSyncAttempts = 0;
+        this.permissionSyncTimer = window.setInterval(async () => {
+            this.permissionSyncAttempts += 1;
+            const synced = await this.applyRolePermissions();
+            if (synced || this.permissionSyncAttempts >= 20) {
+                this.stopPermissionSync();
+            }
+        }, 250);
+    }
+
+    stopPermissionSync() {
+        if (this.permissionSyncTimer) {
+            window.clearInterval(this.permissionSyncTimer);
+            this.permissionSyncTimer = null;
+        }
+    }
+
+    async applyRolePermissions() {
+        if (!window.AuthService || typeof window.AuthService.can !== 'function') {
+            return false;
+        }
+
+        let user = null;
+        if (typeof window.AuthService.getUser === 'function') {
+            try {
+                user = await window.AuthService.getUser();
+            } catch (error) {
+                user = null;
+            }
+        }
+
+        const guardedItems = this.shadowRoot.querySelectorAll('[data-rbac-action][data-rbac-resource]');
+        guardedItems.forEach((item) => {
+            const action = item.dataset.rbacAction;
+            const resource = item.dataset.rbacResource;
+            const allowed = window.AuthService.can(action, resource, user || null);
+            item.dataset.disabled = allowed ? 'false' : 'true';
+            item.classList.toggle('header-settings-item-disabled', !allowed);
+            item.setAttribute('aria-disabled', allowed ? 'false' : 'true');
+            item.tabIndex = allowed ? 0 : -1;
+        });
+
+        if (!this.authSubscription && typeof window.AuthService.onAuthStateChange === 'function') {
+            try {
+                this.authSubscription = window.AuthService.onAuthStateChange(() => {
+                    this.applyRolePermissions();
+                });
+            } catch (error) {
+                this.authSubscription = null;
+            }
+        }
+
+        return true;
     }
 
     setupEventListeners() {
@@ -32,6 +98,18 @@ class AppHeader extends HTMLElement {
         };
 
         this.handleActionClick = (e) => {
+            if (e.currentTarget?.dataset?.disabled === 'true') {
+                this.dispatchEvent(new CustomEvent('header-permission-denied', {
+                    detail: {
+                        action: e.currentTarget.dataset.action,
+                        message: e.currentTarget.dataset.deniedMessage || 'You do not have permission to perform this action.'
+                    },
+                    bubbles: true,
+                    composed: true
+                }));
+                return;
+            }
+
             const action = e.currentTarget.dataset.action;
             if (action) {
                 // Dispatch a custom event that index.html can listen for
@@ -207,6 +285,13 @@ class AppHeader extends HTMLElement {
                     background: #f6f8fa;
                 }
 
+                .header-settings-item-disabled,
+                .header-settings-item-disabled:hover {
+                    opacity: 0.55;
+                    background: #f6f8fa;
+                    cursor: not-allowed;
+                }
+
                 .header-settings-item-icon {
                     width: 16px;
                     text-align: center;
@@ -276,15 +361,15 @@ class AppHeader extends HTMLElement {
                             </button>
                             <div class="header-settings-divider"></div>
                             <div class="header-settings-section-label">Configuration</div>
-                            <button class="header-settings-item" type="button" data-action="rules">
+                            <button class="header-settings-item" type="button" data-action="rules" data-rbac-action="write" data-rbac-resource="system-config" data-denied-message="Insufficient permissions: only admins can change constraint rules.">
                                 <span class="header-settings-item-icon">📋</span>
                                 <span>Constraint Rules</span>
                             </button>
-                            <button class="header-settings-item" type="button" data-action="api">
+                            <button class="header-settings-item" type="button" data-action="api" data-rbac-action="manage" data-rbac-resource="system-config" data-denied-message="Insufficient permissions: only admins can access API connections.">
                                 <span class="header-settings-item-icon">🔐</span>
                                 <span>API Connections</span>
                             </button>
-                            <button class="header-settings-item" type="button" data-action="accounts">
+                            <button class="header-settings-item" type="button" data-action="accounts" data-rbac-action="manage" data-rbac-resource="accounts" data-denied-message="Insufficient permissions: only admins can manage users and accounts.">
                                 <span class="header-settings-item-icon">👤</span>
                                 <span>Users & Accounts</span>
                             </button>

--- a/tests/auth-service.test.js
+++ b/tests/auth-service.test.js
@@ -149,6 +149,42 @@ describe('AuthService', () => {
         );
     });
 
+    test('can(action, resource) enforces chair permissions from auth contract', () => {
+        const { AuthService } = loadAuthService();
+
+        expect(AuthService.can('write', 'schedule', { role: 'chair' })).toBe(true);
+        expect(AuthService.can('read', 'system-config', { role: 'chair' })).toBe(true);
+        expect(AuthService.can('write', 'system-config', { role: 'chair' })).toBe(false);
+        expect(AuthService.can('manage', 'accounts', { role: 'chair' })).toBe(false);
+    });
+
+    test('can(action, resource) grants full access for admin role', () => {
+        const { AuthService } = loadAuthService();
+
+        expect(AuthService.can('read', 'departments', { role: 'admin' })).toBe(true);
+        expect(AuthService.can('write', 'system-config', { role: 'admin' })).toBe(true);
+        expect(AuthService.can('manage', 'accounts', { role: 'admin' })).toBe(true);
+        expect(AuthService.can('delete', 'unknown-resource', { role: 'admin' })).toBe(true);
+    });
+
+    test('can(action, resource) uses cached role when context is omitted', async () => {
+        const { AuthService, mockAuth } = loadAuthService();
+        mockAuth.signInWithPassword.mockResolvedValue({
+            data: {
+                user: {
+                    id: 'user-5',
+                    email: 'admin@example.edu',
+                    app_metadata: { role: 'admin' }
+                },
+                session: { access_token: 'admin-token' }
+            },
+            error: null
+        });
+
+        await AuthService.signIn('admin@example.edu', 'secret');
+        expect(AuthService.can('manage', 'accounts')).toBe(true);
+    });
+
     test('throws when Supabase is not configured for auth operations', async () => {
         const { AuthService } = loadAuthService({ isConfigured: false });
         await expect(AuthService.signIn('chair@example.edu', 'pw')).rejects.toThrow('Supabase is not configured.');


### PR DESCRIPTION
## Summary
- add AuthService.can(action, resource) with a role/resource permission matrix from the A-01 contract
- enforce admin-only route access for department onboarding with explicit access-denied messaging
- disable admin-only header actions for chair users and emit permission-denied events
- add fallback RBAC checks in main header action handlers and improve denied toasts
- extend auth service tests to cover RBAC behavior

## Testing
- npm test -- tests/auth-service.test.js --runInBand
- npm test -- --runInBand
- npm run qa:onboarding

Closes #90