### PR TITLE
[Tree/A-05] Update RLS policies to scope writes by authenticated user

### DIFF
--- a/docs/auth-contract.md
+++ b/docs/auth-contract.md
@@ -72,26 +72,33 @@ Reasoning:
 ## 6) Permission Matrix (Phase 1)
 Legend:
 - `R` = read
-- `W` = insert/update/delete
+- `I/U` = insert + update
+- `D` = delete
 - `-` = no direct access
 
 | Table | chair | admin |
 |---|---|---|
-| `departments` | R | R/W |
-| `academic_years` | R/W (scoped) | R/W |
-| `rooms` | R/W (scoped) | R/W |
-| `courses` | R/W (scoped) | R/W |
-| `faculty` | R/W (scoped) | R/W |
-| `scheduled_courses` | R/W (scoped) | R/W |
-| `faculty_preferences` | R/W (scoped) | R/W |
-| `scheduling_constraints` | R/W (scoped) | R/W |
-| `release_time` | R/W (scoped) | R/W |
-| `pathways` | R/W (scoped) | R/W |
-| `pathway_courses` | R/W (scoped) | R/W |
+| `departments` | R | R/I/U/D |
+| `academic_years` | R/I/U (scoped) | R/I/U/D |
+| `rooms` | R/I/U (scoped) | R/I/U/D |
+| `courses` | R/I/U (scoped) | R/I/U/D |
+| `faculty` | R/I/U (scoped) | R/I/U/D |
+| `scheduled_courses` | R/I/U (scoped) | R/I/U/D |
+| `faculty_preferences` | R/I/U (scoped) | R/I/U/D |
+| `scheduling_constraints` | R/I/U (scoped) | R/I/U/D |
+| `release_time` | R/I/U (scoped) | R/I/U/D |
+| `pathways` | R/I/U (scoped) | R/I/U/D |
+| `pathway_courses` | R/I/U (scoped) | R/I/U/D |
 
 Scoping contract:
 - all chair writes must be constrained to the current program/department context
 - all chair reads should be program-scoped once T-series multi-tenant schema lands
+
+A-05 RLS enforcement contract:
+- all write policies require `auth.uid() IS NOT NULL`
+- `admin` role can INSERT/UPDATE/DELETE on scheduling tables and system config tables
+- `chair` role can INSERT/UPDATE on scheduling tables, but cannot DELETE
+- anonymous (`anon`) write attempts are denied by policy
 
 ## 7) Downstream Issue Contracts
 This spec is normative input for:

--- a/docs/supabase-rls-auth-user-scope.md
+++ b/docs/supabase-rls-auth-user-scope.md
@@ -1,0 +1,50 @@
+# Supabase Role-Scoped RLS Migration (Tree/A-05)
+
+Issue: [#91](https://github.com/sicxz/program-command/issues/91)
+
+## Purpose
+Apply role-aware write policies so authenticated requests are scoped by role:
+- `admin`: INSERT/UPDATE/DELETE on scheduling and system-config tables
+- `chair`: INSERT/UPDATE on scheduling tables
+- `anon`: no write access
+
+Migration script:
+- `scripts/supabase-rls-auth-user-scope.sql`
+
+## Apply
+From Supabase SQL Editor or `psql` against the project database, run:
+
+```sql
+\i scripts/supabase-rls-auth-user-scope.sql
+```
+
+The migration is idempotent and safe to re-run.
+
+## Verify Policy Definitions
+
+```sql
+select tablename, policyname, cmd, roles, qual, with_check
+from pg_policies
+where schemaname = 'public'
+  and tablename in (
+    'departments',
+    'academic_years','rooms','courses','faculty','scheduled_courses',
+    'faculty_preferences','scheduling_constraints','release_time',
+    'pathways','pathway_courses'
+  )
+order by tablename, policyname;
+```
+
+Expected:
+- INSERT/UPDATE policies on scheduling tables reference `public.can_write_schedule_data()`.
+- DELETE policies reference `public.is_admin_role()`.
+- Department write policies reference `public.is_admin_role()`.
+
+## Smoke Check
+Run the existing smoke check to confirm anonymous writes are blocked:
+
+```bash
+npm run check:rls
+```
+
+For role-specific behavior, test with authenticated user sessions that include role claim `admin` and `chair`.

--- a/scripts/supabase-rls-auth-user-scope.sql
+++ b/scripts/supabase-rls-auth-user-scope.sql
@@ -1,0 +1,226 @@
+-- Tree/A-05: Scope Supabase writes by authenticated user role (admin vs chair)
+-- Idempotent: safe to run multiple times.
+
+BEGIN;
+
+-- Role helpers based on Supabase JWT claims.
+CREATE OR REPLACE FUNCTION public.auth_role()
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT lower(coalesce(
+        nullif(auth.jwt() ->> 'role', ''),
+        nullif(auth.jwt() -> 'app_metadata' ->> 'role', ''),
+        nullif(auth.jwt() -> 'user_metadata' ->> 'role', ''),
+        nullif(auth.jwt() -> 'raw_user_meta_data' ->> 'role', '')
+    ));
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_admin_role()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT auth.uid() IS NOT NULL
+       AND public.auth_role() = 'admin';
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_chair_role()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT auth.uid() IS NOT NULL
+       AND public.auth_role() = 'chair';
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_write_schedule_data()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT public.is_admin_role() OR public.is_chair_role();
+$$;
+
+-- Remove legacy broad write policies.
+DROP POLICY IF EXISTS "Authenticated write" ON public.departments;
+DROP POLICY IF EXISTS "Authenticated write" ON public.academic_years;
+DROP POLICY IF EXISTS "Authenticated write" ON public.rooms;
+DROP POLICY IF EXISTS "Authenticated write" ON public.courses;
+DROP POLICY IF EXISTS "Authenticated write" ON public.faculty;
+DROP POLICY IF EXISTS "Authenticated write" ON public.scheduled_courses;
+DROP POLICY IF EXISTS "Authenticated write" ON public.faculty_preferences;
+DROP POLICY IF EXISTS "Authenticated write" ON public.scheduling_constraints;
+DROP POLICY IF EXISTS "Authenticated write" ON public.release_time;
+DROP POLICY IF EXISTS "Authenticated write" ON public.pathways;
+DROP POLICY IF EXISTS "Authenticated write" ON public.pathway_courses;
+
+-- Remove previous operation policies so this script is re-runnable.
+DROP POLICY IF EXISTS "auth_insert_departments" ON public.departments;
+DROP POLICY IF EXISTS "auth_update_departments" ON public.departments;
+DROP POLICY IF EXISTS "auth_delete_departments" ON public.departments;
+DROP POLICY IF EXISTS "auth_insert_academic_years" ON public.academic_years;
+DROP POLICY IF EXISTS "auth_update_academic_years" ON public.academic_years;
+DROP POLICY IF EXISTS "auth_delete_academic_years" ON public.academic_years;
+DROP POLICY IF EXISTS "auth_insert_rooms" ON public.rooms;
+DROP POLICY IF EXISTS "auth_update_rooms" ON public.rooms;
+DROP POLICY IF EXISTS "auth_delete_rooms" ON public.rooms;
+DROP POLICY IF EXISTS "auth_insert_courses" ON public.courses;
+DROP POLICY IF EXISTS "auth_update_courses" ON public.courses;
+DROP POLICY IF EXISTS "auth_delete_courses" ON public.courses;
+DROP POLICY IF EXISTS "auth_insert_faculty" ON public.faculty;
+DROP POLICY IF EXISTS "auth_update_faculty" ON public.faculty;
+DROP POLICY IF EXISTS "auth_delete_faculty" ON public.faculty;
+DROP POLICY IF EXISTS "auth_insert_scheduled_courses" ON public.scheduled_courses;
+DROP POLICY IF EXISTS "auth_update_scheduled_courses" ON public.scheduled_courses;
+DROP POLICY IF EXISTS "auth_delete_scheduled_courses" ON public.scheduled_courses;
+DROP POLICY IF EXISTS "auth_insert_faculty_preferences" ON public.faculty_preferences;
+DROP POLICY IF EXISTS "auth_update_faculty_preferences" ON public.faculty_preferences;
+DROP POLICY IF EXISTS "auth_delete_faculty_preferences" ON public.faculty_preferences;
+DROP POLICY IF EXISTS "auth_insert_scheduling_constraints" ON public.scheduling_constraints;
+DROP POLICY IF EXISTS "auth_update_scheduling_constraints" ON public.scheduling_constraints;
+DROP POLICY IF EXISTS "auth_delete_scheduling_constraints" ON public.scheduling_constraints;
+DROP POLICY IF EXISTS "auth_insert_release_time" ON public.release_time;
+DROP POLICY IF EXISTS "auth_update_release_time" ON public.release_time;
+DROP POLICY IF EXISTS "auth_delete_release_time" ON public.release_time;
+DROP POLICY IF EXISTS "auth_insert_pathways" ON public.pathways;
+DROP POLICY IF EXISTS "auth_update_pathways" ON public.pathways;
+DROP POLICY IF EXISTS "auth_delete_pathways" ON public.pathways;
+DROP POLICY IF EXISTS "auth_insert_pathway_courses" ON public.pathway_courses;
+DROP POLICY IF EXISTS "auth_update_pathway_courses" ON public.pathway_courses;
+DROP POLICY IF EXISTS "auth_delete_pathway_courses" ON public.pathway_courses;
+
+-- departments (system config): admin writes only
+CREATE POLICY "auth_insert_departments" ON public.departments
+    FOR INSERT TO authenticated
+    WITH CHECK (public.is_admin_role());
+CREATE POLICY "auth_update_departments" ON public.departments
+    FOR UPDATE TO authenticated
+    USING (public.is_admin_role())
+    WITH CHECK (public.is_admin_role());
+CREATE POLICY "auth_delete_departments" ON public.departments
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- academic_years
+CREATE POLICY "auth_insert_academic_years" ON public.academic_years
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_academic_years" ON public.academic_years
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_academic_years" ON public.academic_years
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- rooms
+CREATE POLICY "auth_insert_rooms" ON public.rooms
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_rooms" ON public.rooms
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_rooms" ON public.rooms
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- courses
+CREATE POLICY "auth_insert_courses" ON public.courses
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_courses" ON public.courses
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_courses" ON public.courses
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- faculty
+CREATE POLICY "auth_insert_faculty" ON public.faculty
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_faculty" ON public.faculty
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_faculty" ON public.faculty
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- scheduled_courses
+CREATE POLICY "auth_insert_scheduled_courses" ON public.scheduled_courses
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_scheduled_courses" ON public.scheduled_courses
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_scheduled_courses" ON public.scheduled_courses
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- faculty_preferences
+CREATE POLICY "auth_insert_faculty_preferences" ON public.faculty_preferences
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_faculty_preferences" ON public.faculty_preferences
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_faculty_preferences" ON public.faculty_preferences
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- scheduling_constraints
+CREATE POLICY "auth_insert_scheduling_constraints" ON public.scheduling_constraints
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_scheduling_constraints" ON public.scheduling_constraints
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_scheduling_constraints" ON public.scheduling_constraints
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- release_time
+CREATE POLICY "auth_insert_release_time" ON public.release_time
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_release_time" ON public.release_time
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_release_time" ON public.release_time
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- pathways
+CREATE POLICY "auth_insert_pathways" ON public.pathways
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_pathways" ON public.pathways
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_pathways" ON public.pathways
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+-- pathway_courses
+CREATE POLICY "auth_insert_pathway_courses" ON public.pathway_courses
+    FOR INSERT TO authenticated
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_update_pathway_courses" ON public.pathway_courses
+    FOR UPDATE TO authenticated
+    USING (public.can_write_schedule_data())
+    WITH CHECK (public.can_write_schedule_data());
+CREATE POLICY "auth_delete_pathway_courses" ON public.pathway_courses
+    FOR DELETE TO authenticated
+    USING (public.is_admin_role());
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add idempotent migration script at scripts/supabase-rls-auth-user-scope.sql
- add role helper SQL functions (auth_role, is_admin_role, is_chair_role, can_write_schedule_data)
- enforce policy boundaries: admin full write, chair insert/update on schedule tables, anon blocked
- add runbook at docs/supabase-rls-auth-user-scope.md
- update docs/auth-contract.md permission matrix to align with A-05 role-scoped policy behavior

## Testing
- npm test -- --runInBand
- npm run qa:onboarding
- not run: npm run check:rls (requires live Supabase credentials and performs production writes)

Closes #91