### PR TITLE
[Tree/A-06] Attribute saves to user (user_id + timestamp on every write)

### DIFF
--- a/css/schedule-builder.css
+++ b/css/schedule-builder.css
@@ -1067,6 +1067,13 @@ body {
     line-height: 1.35;
 }
 
+.action-bar-attribution {
+    margin-top: 6px;
+    font-size: 0.74rem;
+    color: #374151;
+    font-family: var(--mono-font);
+}
+
 /* Toast */
 .toast {
     position: fixed;

--- a/docs/supabase-save-attribution-a06.md
+++ b/docs/supabase-save-attribution-a06.md
@@ -1,0 +1,55 @@
+# Supabase Save Attribution Migration (Tree/A-06)
+
+Issue: [#92](https://github.com/sicxz/program-command/issues/92)
+
+## Purpose
+Track who changed scheduler data and when on every write.
+
+Migration script:
+- `scripts/supabase-save-attribution-a06.sql`
+
+RPC update:
+- `scripts/supabase-schedule-sync-rpc.sql`
+
+## Behavior
+- Adds `updated_by` (`uuid`, references `auth.users(id)`) and `updated_at` columns across scheduling/system tables.
+- Adds trigger `public.set_row_write_audit_fields()` to stamp:
+  - `updated_at = now()` on INSERT/UPDATE
+  - `updated_by = auth.uid()` when an authenticated user exists
+- Keeps existing rows by backfilling `updated_at` where missing.
+
+## Apply
+Run both SQL files in Supabase SQL Editor (or `psql`):
+
+```sql
+\i scripts/supabase-save-attribution-a06.sql
+\i scripts/supabase-schedule-sync-rpc.sql
+```
+
+## Verify
+
+```sql
+select table_name, column_name, data_type
+from information_schema.columns
+where table_schema = 'public'
+  and table_name in (
+    'departments','academic_years','rooms','courses','faculty',
+    'scheduled_courses','faculty_preferences','scheduling_constraints',
+    'release_time','pathways','pathway_courses'
+  )
+  and column_name in ('updated_by','updated_at')
+order by table_name, column_name;
+```
+
+```sql
+select tgname, tgrelid::regclass as table_name
+from pg_trigger
+where tgname like 'trg_write_audit_%'
+  and not tgisinternal
+order by tgname;
+```
+
+Expected:
+- All listed tables expose `updated_at` and `updated_by`.
+- Write-audit triggers exist for each table.
+- New scheduler writes populate `updated_by` and refresh `updated_at`.

--- a/js/db-service.js
+++ b/js/db-service.js
@@ -7,6 +7,7 @@
 const dbService = {
     departmentId: null,
     initialized: false,
+    lastSaveAttribution: null,
 
     /**
      * Initialize the database service
@@ -88,6 +89,7 @@ const dbService = {
         }
 
         await this.initialize();
+        const currentUserId = await this._resolveCurrentAuthUserId();
         const { data, error } = await getSupabaseClient()
             .from('courses')
             .insert({
@@ -106,7 +108,8 @@ const dbService = {
                 // Constraint flags
                 room_constraint_hard: course.roomConstraintHard || false,
                 time_constraint_hard: course.timeConstraintHard || false,
-                is_case_by_case: course.isCaseByCase || false
+                is_case_by_case: course.isCaseByCase || false,
+                updated_by: currentUserId
             })
             .select()
             .single();
@@ -125,12 +128,14 @@ const dbService = {
         }
 
         await this.initialize();
+        const currentUserId = await this._resolveCurrentAuthUserId();
         const updateData = {
             code: course.code,
             title: course.title,
             default_credits: course.defaultCredits || 5,
             typical_cap: course.typicalCap || 24,
             level: course.level,
+            updated_by: currentUserId,
             updated_at: new Date().toISOString()
         };
 
@@ -231,6 +236,7 @@ const dbService = {
         }
 
         await this.initialize();
+        const currentUserId = await this._resolveCurrentAuthUserId();
         const { data, error } = await getSupabaseClient()
             .from('faculty')
             .insert({
@@ -238,7 +244,8 @@ const dbService = {
                 name: faculty.name,
                 email: faculty.email,
                 category: faculty.category || 'fullTime',
-                max_workload: faculty.maxWorkload || 45
+                max_workload: faculty.maxWorkload || 45,
+                updated_by: currentUserId
             })
             .select()
             .single();
@@ -355,6 +362,7 @@ const dbService = {
         if (!isSupabaseConfigured()) return null;
 
         await this.initialize();
+        const currentUserId = await this._resolveCurrentAuthUserId();
 
         // Try to get existing
         const { data: existing } = await getSupabaseClient()
@@ -372,7 +380,8 @@ const dbService = {
             .insert({
                 department_id: this.departmentId,
                 year: yearString,
-                is_active: false
+                is_active: false,
+                updated_by: currentUserId
             })
             .select()
             .single();
@@ -422,6 +431,7 @@ const dbService = {
             return null;
         }
 
+        const currentUserId = await this._resolveCurrentAuthUserId();
         const record = {
             academic_year_id: courseData.academicYearId,
             course_id: courseData.courseId,
@@ -432,6 +442,7 @@ const dbService = {
             time_slot: courseData.timeSlot,
             section: courseData.section,
             projected_enrollment: courseData.projectedEnrollment || null,
+            updated_by: currentUserId,
             updated_at: new Date().toISOString()
         };
 
@@ -486,6 +497,7 @@ const dbService = {
             return [];
         }
 
+        const currentUserId = await this._resolveCurrentAuthUserId();
         const records = courses.map(c => ({
             academic_year_id: yearId,
             course_id: c.courseId,
@@ -495,7 +507,8 @@ const dbService = {
             day_pattern: c.dayPattern,
             time_slot: c.timeSlot,
             section: c.section,
-            projected_enrollment: c.projectedEnrollment || null
+            projected_enrollment: c.projectedEnrollment || null,
+            updated_by: currentUserId
         }));
 
         const { data, error } = await getSupabaseClient()
@@ -527,6 +540,7 @@ const dbService = {
         }
 
         await this.initialize();
+        const currentUserId = await this._resolveCurrentAuthUserId();
 
         const normalizedRecords = records.map((record, index) => {
             if (!record || typeof record !== 'object') {
@@ -557,6 +571,7 @@ const dbService = {
                 time_slot: this._normalizeNullableString(record.time_slot ?? record.timeSlot),
                 section: this._normalizeNullableString(record.section) || '001',
                 projected_enrollment: projectedEnrollment,
+                updated_by: this._normalizeNullableString(record.updated_by ?? record.updatedBy ?? currentUserId),
                 updated_at: this._normalizeNullableString(record.updated_at ?? record.updatedAt)
             };
         });
@@ -607,6 +622,7 @@ const dbService = {
             return null;
         }
 
+        const currentUserId = await this._resolveCurrentAuthUserId();
         const record = {
             faculty_id: facultyId,
             time_preferred: prefs.timePreferred || [],
@@ -616,6 +632,7 @@ const dbService = {
             campus_assignment: prefs.campusAssignment || 'any',
             qualified_courses: prefs.qualifiedCourses || [],
             notes: prefs.notes || '',
+            updated_by: currentUserId,
             updated_at: new Date().toISOString()
         };
 
@@ -662,12 +679,14 @@ const dbService = {
         }
 
         await this.initialize();
+        const currentUserId = await this._resolveCurrentAuthUserId();
         const record = {
             department_id: this.departmentId,
             constraint_type: constraint.type,
             description: constraint.description,
             rule_details: constraint.ruleDetails,
-            enabled: constraint.enabled !== false
+            enabled: constraint.enabled !== false,
+            updated_by: currentUserId
         };
 
         if (constraint.id) {
@@ -728,13 +747,15 @@ const dbService = {
             return null;
         }
 
+        const currentUserId = await this._resolveCurrentAuthUserId();
         const record = {
             faculty_id: allocation.facultyId,
             academic_year_id: allocation.academicYearId,
             category: allocation.category,
             credits: allocation.credits,
             quarters: allocation.quarters || ['Fall', 'Winter', 'Spring'],
-            notes: allocation.notes || ''
+            notes: allocation.notes || '',
+            updated_by: currentUserId
         };
 
         if (allocation.id) {
@@ -901,10 +922,56 @@ const dbService = {
         return data?.id;
     },
 
+    async getLatestScheduleSaveMetadata(academicYearId) {
+        if (!isSupabaseConfigured()) return null;
+        if (!academicYearId) return null;
+
+        const { data, error } = await getSupabaseClient()
+            .from('scheduled_courses')
+            .select('updated_by, updated_at')
+            .eq('academic_year_id', academicYearId)
+            .not('updated_at', 'is', null)
+            .order('updated_at', { ascending: false })
+            .limit(1)
+            .maybeSingle();
+
+        if (error) throw error;
+        return data || null;
+    },
+
     _normalizeNullableString(value) {
         if (value === null || value === undefined) return null;
         const normalized = String(value).trim();
         return normalized ? normalized : null;
+    },
+
+    async _resolveCurrentAuthUserId() {
+        if (!isSupabaseConfigured()) return null;
+
+        try {
+            if (typeof window !== 'undefined' && window.AuthService && typeof window.AuthService.getUser === 'function') {
+                const user = await window.AuthService.getUser();
+                if (user?.id) {
+                    return user.id;
+                }
+            }
+        } catch (error) {
+            // fall through to direct Supabase lookup
+        }
+
+        try {
+            const client = getSupabaseClient();
+            if (client?.auth && typeof client.auth.getUser === 'function') {
+                const { data, error } = await client.auth.getUser();
+                if (!error && data?.user?.id) {
+                    return data.user.id;
+                }
+            }
+        } catch (error) {
+            return null;
+        }
+
+        return null;
     }
 };
 

--- a/pages/schedule-builder.html
+++ b/pages/schedule-builder.html
@@ -343,6 +343,7 @@
             <div class="action-bar-lead">
                 <div class="action-bar-title">Step 3 · Finalize Draft &amp; Handoff</div>
                 <div class="action-bar-subtitle">Save the builder draft, export to the main scheduler, or go straight to workload review.</div>
+                <div class="action-bar-attribution" id="saveAttributionLabel">Last saved by -- at --</div>
             </div>
             <button class="btn-secondary" onclick="saveDraft()">
                 💾 Save Draft

--- a/pages/schedule-builder.js
+++ b/pages/schedule-builder.js
@@ -51,6 +51,7 @@ let dbCourses = [];
 const SCHEDULE_PLACEMENTS_KEY = 'schedule_placements';
 const FACULTY_BUILD_STORAGE_KEY = 'faculty_build_scenario_v1';
 const FACULTY_PREFERENCES_LOCAL_KEY = 'faculty_preferences_local_v1';
+const SAVE_ATTRIBUTION_STORAGE_KEY = 'schedule_builder_last_save_attribution_v1';
 
 const DEFAULT_FACULTY_BUILD_SCENARIO = {
     faculty: [
@@ -106,6 +107,60 @@ function saveFacultyPreferencesCache() {
     } catch (error) {
         console.warn('Could not save faculty preferences cache:', error);
     }
+}
+
+function formatSaveAttributionDate(isoString) {
+    if (!isoString) return '--';
+    const date = new Date(isoString);
+    if (Number.isNaN(date.getTime())) return '--';
+    return date.toLocaleString();
+}
+
+function setSaveAttributionLabel(userLabel, savedAt) {
+    const label = document.getElementById('saveAttributionLabel');
+    if (!label) return;
+    label.textContent = `Last saved by ${userLabel || '--'} at ${formatSaveAttributionDate(savedAt)}`;
+}
+
+function readSaveAttributionState() {
+    try {
+        const raw = localStorage.getItem(SAVE_ATTRIBUTION_STORAGE_KEY);
+        return raw ? JSON.parse(raw) : null;
+    } catch (error) {
+        return null;
+    }
+}
+
+function writeSaveAttributionState(state) {
+    try {
+        localStorage.setItem(SAVE_ATTRIBUTION_STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+        console.warn('Could not persist save attribution state:', error);
+    }
+}
+
+function refreshSaveAttributionLabelForYear(targetYear) {
+    const state = readSaveAttributionState();
+    if (!state || state.year !== targetYear) {
+        setSaveAttributionLabel('--', null);
+        return;
+    }
+    setSaveAttributionLabel(state.userLabel, state.savedAt);
+}
+
+async function resolveCurrentUserAttribution() {
+    if (typeof window !== 'undefined' && window.AuthService && typeof window.AuthService.getUser === 'function') {
+        try {
+            const user = await window.AuthService.getUser();
+            if (user?.id) {
+                const preferredName = user.user_metadata?.full_name || user.user_metadata?.name || user.email || user.id;
+                return { id: user.id, label: preferredName };
+            }
+        } catch (error) {
+            // fallback below
+        }
+    }
+    return { id: null, label: 'Authenticated user' };
 }
 
 function setFacultyPreference(name, preference) {
@@ -553,6 +608,15 @@ document.addEventListener('DOMContentLoaded', async function() {
         loadFacultyPreferencesCache();
         initializeFacultyBuildScenario();
         loadDraft();
+
+        const activeYear = document.getElementById('academicYear')?.value || '2026-27';
+        refreshSaveAttributionLabelForYear(activeYear);
+        const academicYearSelect = document.getElementById('academicYear');
+        if (academicYearSelect) {
+            academicYearSelect.addEventListener('change', (event) => {
+                refreshSaveAttributionLabelForYear(event.target.value);
+            });
+        }
 
     } catch (error) {
         console.error('Initialization error:', error);
@@ -2628,6 +2692,7 @@ async function saveToDatabase() {
 
     try {
         showToast('Saving to database...');
+        const userAttribution = await resolveCurrentUserAttribution();
 
         // Initialize database service
         await dbService.initialize();
@@ -2643,7 +2708,11 @@ async function saveToDatabase() {
 
         const quarterSchedules = getAllQuarterSchedulesForSave();
         const records = await buildYearScopedScheduleSyncRecords(quarterSchedules);
-        const syncResult = await dbService.syncScheduledCoursesForAcademicYear(yearRecord.id, records);
+        const recordsWithUserContext = records.map((record) => ({
+            ...record,
+            updated_by: userAttribution.id
+        }));
+        const syncResult = await dbService.syncScheduledCoursesForAcademicYear(yearRecord.id, recordsWithUserContext);
 
         if (!syncResult) {
             showToast('Error saving to database', 'error');
@@ -2653,6 +2722,14 @@ async function saveToDatabase() {
         const updatedCount = Number(syncResult.updated_count || 0);
         const insertedCount = Number(syncResult.inserted_count || 0);
         const deletedCount = Number(syncResult.deleted_count || 0);
+        const savedAt = new Date().toISOString();
+        writeSaveAttributionState({
+            year: targetYear,
+            userId: userAttribution.id,
+            userLabel: userAttribution.label,
+            savedAt
+        });
+        setSaveAttributionLabel(userAttribution.label, savedAt);
         showToast(`Saved ${targetYear}: ${updatedCount} updated, ${insertedCount} inserted, ${deletedCount} removed`);
 
     } catch (error) {

--- a/scripts/supabase-save-attribution-a06.sql
+++ b/scripts/supabase-save-attribution-a06.sql
@@ -1,0 +1,125 @@
+-- Tree/A-06: Save attribution columns + triggers
+-- Idempotent migration to record who wrote each row and when.
+
+BEGIN;
+
+-- Add audit columns across scheduling/system tables.
+ALTER TABLE public.departments ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.departments ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+ALTER TABLE public.academic_years ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.academic_years ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+ALTER TABLE public.rooms ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.rooms ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+ALTER TABLE public.courses ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.courses ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+ALTER TABLE public.faculty ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.faculty ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+ALTER TABLE public.scheduled_courses ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+ALTER TABLE public.scheduled_courses ALTER COLUMN updated_at SET DEFAULT NOW();
+
+ALTER TABLE public.faculty_preferences ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+ALTER TABLE public.faculty_preferences ALTER COLUMN updated_at SET DEFAULT NOW();
+
+ALTER TABLE public.scheduling_constraints ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.scheduling_constraints ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+ALTER TABLE public.release_time ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.release_time ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+ALTER TABLE public.pathways ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.pathways ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+ALTER TABLE public.pathway_courses ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE public.pathway_courses ADD COLUMN IF NOT EXISTS updated_by UUID REFERENCES auth.users(id);
+
+-- Backfill updated_at for historical rows.
+UPDATE public.departments SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.academic_years SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.rooms SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.courses SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.faculty SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.scheduled_courses SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.faculty_preferences SET updated_at = COALESCE(updated_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.scheduling_constraints SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.release_time SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.pathways SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+UPDATE public.pathway_courses SET updated_at = COALESCE(updated_at, created_at, NOW()) WHERE updated_at IS NULL;
+
+-- Trigger function: stamp updated_at and updated_by on every insert/update.
+CREATE OR REPLACE FUNCTION public.set_row_write_audit_fields()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at := NOW();
+
+    IF auth.uid() IS NOT NULL THEN
+        NEW.updated_by := auth.uid();
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+-- Attach trigger to each table.
+DROP TRIGGER IF EXISTS trg_write_audit_departments ON public.departments;
+CREATE TRIGGER trg_write_audit_departments
+    BEFORE INSERT OR UPDATE ON public.departments
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_academic_years ON public.academic_years;
+CREATE TRIGGER trg_write_audit_academic_years
+    BEFORE INSERT OR UPDATE ON public.academic_years
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_rooms ON public.rooms;
+CREATE TRIGGER trg_write_audit_rooms
+    BEFORE INSERT OR UPDATE ON public.rooms
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_courses ON public.courses;
+CREATE TRIGGER trg_write_audit_courses
+    BEFORE INSERT OR UPDATE ON public.courses
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_faculty ON public.faculty;
+CREATE TRIGGER trg_write_audit_faculty
+    BEFORE INSERT OR UPDATE ON public.faculty
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_scheduled_courses ON public.scheduled_courses;
+CREATE TRIGGER trg_write_audit_scheduled_courses
+    BEFORE INSERT OR UPDATE ON public.scheduled_courses
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_faculty_preferences ON public.faculty_preferences;
+CREATE TRIGGER trg_write_audit_faculty_preferences
+    BEFORE INSERT OR UPDATE ON public.faculty_preferences
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_scheduling_constraints ON public.scheduling_constraints;
+CREATE TRIGGER trg_write_audit_scheduling_constraints
+    BEFORE INSERT OR UPDATE ON public.scheduling_constraints
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_release_time ON public.release_time;
+CREATE TRIGGER trg_write_audit_release_time
+    BEFORE INSERT OR UPDATE ON public.release_time
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_pathways ON public.pathways;
+CREATE TRIGGER trg_write_audit_pathways
+    BEFORE INSERT OR UPDATE ON public.pathways
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+DROP TRIGGER IF EXISTS trg_write_audit_pathway_courses ON public.pathway_courses;
+CREATE TRIGGER trg_write_audit_pathway_courses
+    BEFORE INSERT OR UPDATE ON public.pathway_courses
+    FOR EACH ROW EXECUTE FUNCTION public.set_row_write_audit_fields();
+
+COMMIT;

--- a/scripts/supabase-schedule-sync-rpc.sql
+++ b/scripts/supabase-schedule-sync-rpc.sql
@@ -34,6 +34,7 @@ BEGIN
         time_slot VARCHAR(20) NULL,
         section VARCHAR(10) NULL,
         projected_enrollment INTEGER NULL,
+        updated_by UUID NULL,
         updated_at TIMESTAMPTZ NULL,
         sync_key TEXT NOT NULL,
         row_rank INTEGER NOT NULL
@@ -49,6 +50,7 @@ BEGIN
         time_slot,
         section,
         projected_enrollment,
+        updated_by,
         updated_at,
         sync_key,
         row_rank
@@ -65,6 +67,7 @@ BEGIN
             NULLIF(rec->>'time_slot', '')::VARCHAR(20) AS time_slot,
             NULLIF(rec->>'section', '')::VARCHAR(10) AS section,
             NULLIF(rec->>'projected_enrollment', '')::INTEGER AS projected_enrollment,
+            COALESCE(NULLIF(rec->>'updated_by', '')::UUID, auth.uid()) AS updated_by,
             COALESCE(NULLIF(rec->>'updated_at', '')::TIMESTAMPTZ, NOW()) AS updated_at
         FROM jsonb_array_elements(COALESCE(p_records, '[]'::JSONB)) WITH ORDINALITY AS t(rec, ord)
     ),
@@ -79,6 +82,7 @@ BEGIN
             time_slot,
             section,
             projected_enrollment,
+            updated_by,
             updated_at,
             CONCAT_WS(
                 '|',
@@ -103,6 +107,7 @@ BEGIN
         time_slot,
         section,
         projected_enrollment,
+        updated_by,
         updated_at,
         sync_key,
         ROW_NUMBER() OVER (PARTITION BY sync_key ORDER BY ordinal) AS row_rank
@@ -156,6 +161,7 @@ BEGIN
         time_slot = src.time_slot,
         section = src.section,
         projected_enrollment = src.projected_enrollment,
+        updated_by = src.updated_by,
         updated_at = src.updated_at
     FROM _existing_schedule_sync existing
     JOIN _incoming_schedule_sync src
@@ -174,6 +180,7 @@ BEGIN
         time_slot,
         section,
         projected_enrollment,
+        updated_by,
         updated_at
     )
     SELECT
@@ -186,6 +193,7 @@ BEGIN
         src.time_slot,
         src.section,
         src.projected_enrollment,
+        src.updated_by,
         src.updated_at
     FROM _incoming_schedule_sync src
     LEFT JOIN _existing_schedule_sync existing

--- a/tests/db-service.atomic-save.test.js
+++ b/tests/db-service.atomic-save.test.js
@@ -61,6 +61,7 @@ describe('dbService.syncScheduledCoursesForAcademicYear', () => {
                     time_slot: '10:00-12:20',
                     section: '001',
                     projected_enrollment: 24,
+                    updated_by: null,
                     updated_at: null
                 }
             ]


### PR DESCRIPTION
## Summary
- add idempotent audit migration at scripts/supabase-save-attribution-a06.sql
- update schedule sync RPC to accept and persist updated_by alongside updated_at
- stamp db-service write payloads with authenticated user context (updated_by)
- add latest-save metadata accessor in db-service for schedule rows
- surface "Last saved by ... at ..." in schedule-builder action bar and persist the latest attribution state by year
- add migration runbook docs at docs/supabase-save-attribution-a06.md
- update db-service atomic sync tests for updated_by payload

## Testing
- npm test -- tests/db-service.atomic-save.test.js --runInBand
- npm test -- --runInBand
- npm run qa:onboarding

Closes #92