### PR TITLE
[Tree/A-07] Track active edit sessions (presence tracking)

### DIFF
--- a/docs/presence-service-a07.md
+++ b/docs/presence-service-a07.md
@@ -1,0 +1,28 @@
+# Presence Tracking Service (Tree/A-07)
+
+Issue: [#93](https://github.com/sicxz/program-command/issues/93)
+
+## Overview
+`js/presence-service.js` provides realtime active-editor tracking per page using Supabase Realtime Presence channels.
+
+Primary API:
+- `joinPage(pageId)`
+- `leavePage(pageId)`
+- `getActiveEditors(pageId)`
+- `onPresenceChange(pageId, callback)`
+
+## Runtime Integration
+`js/auth-guard.js` now:
+- lazily loads `presence-service.js`
+- joins the current page channel after auth session validation
+- updates session UI with active editor count
+- leaves the channel on logout and tab close
+
+## Cleanup Behavior
+- Heartbeat interval: 10 seconds
+- Stale editor TTL: 30 seconds
+- Browser/tab close cleanup: `beforeunload` + channel untrack/unsubscribe
+
+## Notes
+- Presence is scoped by page path (for example, `/index.html`, `/pages/schedule-builder.html`).
+- No polling is used; updates are event-driven via Supabase Realtime Presence.

--- a/js/auth-guard.js
+++ b/js/auth-guard.js
@@ -5,6 +5,10 @@
 (function() {
     'use strict';
 
+    let activePresencePageId = null;
+    let unsubscribePresenceChange = null;
+    let presenceScriptPromise = null;
+
     function getCurrentPathWithQuery() {
         return `${window.location.pathname}${window.location.search}${window.location.hash}`;
     }
@@ -42,6 +46,95 @@
         const normalized = String(role).toLowerCase();
         if (normalized === 'admin') return 'Admin';
         return 'Chair';
+    }
+
+    function presenceScriptUrl() {
+        return window.location.pathname.includes('/pages/')
+            ? '../js/presence-service.js'
+            : 'js/presence-service.js';
+    }
+
+    async function ensurePresenceService() {
+        if (window.PresenceService) {
+            return window.PresenceService;
+        }
+
+        if (presenceScriptPromise) {
+            return presenceScriptPromise;
+        }
+
+        presenceScriptPromise = new Promise((resolve) => {
+            const existing = document.querySelector(`script[src=\"${presenceScriptUrl()}\"]`);
+            if (existing) {
+                existing.addEventListener('load', () => resolve(window.PresenceService || null), { once: true });
+                existing.addEventListener('error', () => resolve(null), { once: true });
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.src = presenceScriptUrl();
+            script.onload = () => resolve(window.PresenceService || null);
+            script.onerror = () => resolve(null);
+            document.head.appendChild(script);
+        });
+
+        return presenceScriptPromise;
+    }
+
+    function getPresencePageId() {
+        return window.location.pathname || '/';
+    }
+
+    function updatePresenceIndicator(text, titleText = '') {
+        const node = document.getElementById('authSessionPresence');
+        if (!node) return;
+        node.textContent = text;
+        node.title = titleText || text;
+    }
+
+    function leavePresencePage() {
+        if (!window.PresenceService || !activePresencePageId) return;
+
+        try {
+            window.PresenceService.leavePage(activePresencePageId);
+        } catch (error) {
+            // ignore cleanup failures during unload/logout
+        }
+
+        if (typeof unsubscribePresenceChange === 'function') {
+            unsubscribePresenceChange();
+            unsubscribePresenceChange = null;
+        }
+        activePresencePageId = null;
+    }
+
+    async function bindPresenceIndicator(user) {
+        const presenceService = await ensurePresenceService();
+        if (!presenceService) {
+            updatePresenceIndicator('Presence offline');
+            return;
+        }
+
+        const pageId = getPresencePageId();
+        activePresencePageId = pageId;
+
+        await presenceService.joinPage(pageId);
+
+        if (typeof unsubscribePresenceChange === 'function') {
+            unsubscribePresenceChange();
+        }
+
+        unsubscribePresenceChange = presenceService.onPresenceChange(pageId, (editors) => {
+            const others = (editors || []).filter((editor) => editor.userId !== user?.id);
+            if (!others.length) {
+                updatePresenceIndicator('Only you editing');
+                return;
+            }
+
+            const names = others.map((editor) => editor.user || 'Authenticated user');
+            const label = `${others.length} active editor${others.length === 1 ? '' : 's'}`;
+            updatePresenceIndicator(label, names.join(', '));
+        });
     }
 
     function ensureSessionStyles() {
@@ -84,6 +177,19 @@
                 border-radius: 999px;
                 padding: 2px 8px;
             }
+            .auth-session-presence {
+                font-size: 11px;
+                font-weight: 600;
+                color: #1f6feb;
+                background: #eef6ff;
+                border: 1px solid #b6d3ff;
+                border-radius: 999px;
+                padding: 2px 8px;
+                max-width: 170px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
             .auth-session-logout {
                 border: 1px solid #d0d7de;
                 border-radius: 999px;
@@ -119,11 +225,13 @@
         indicator.innerHTML = `
             <span class="auth-session-email" title="${email}">${email}</span>
             <span class="auth-session-role">${role}</span>
+            <span class="auth-session-presence" id="authSessionPresence">Presence offline</span>
             <button type="button" class="auth-session-logout" id="authSessionLogout">Logout</button>
         `;
 
         const logoutButton = document.getElementById('authSessionLogout');
         logoutButton.addEventListener('click', async () => {
+            leavePresencePage();
             try {
                 await window.AuthService.signOut();
             } catch (error) {
@@ -150,6 +258,7 @@
 
         const user = (await window.AuthService.getUser()) || session.user || null;
         renderSessionIndicator(user);
+        await bindPresenceIndicator(user);
     }
 
     async function initGuard() {
@@ -174,4 +283,7 @@
     }
 
     document.addEventListener('DOMContentLoaded', initGuard);
+    window.addEventListener('beforeunload', () => {
+        leavePresencePage();
+    });
 })();

--- a/js/presence-service.js
+++ b/js/presence-service.js
@@ -1,0 +1,316 @@
+/**
+ * Presence Service
+ * Tracks active editors per page using Supabase Realtime Presence.
+ */
+const PresenceService = (function() {
+    'use strict';
+
+    const CHANNEL_PREFIX = 'pc-presence:';
+    const HEARTBEAT_MS = 10000;
+    const STALE_TTL_MS = 30000;
+
+    const pageStates = new Map();
+    let unloadHandlerBound = false;
+
+    const sessionId = (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
+        ? crypto.randomUUID()
+        : `session-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+    function sanitizePageId(pageId) {
+        return String(pageId || '')
+            .trim()
+            .replace(/\s+/g, '-')
+            .replace(/[^a-zA-Z0-9_\-/:.]/g, '_');
+    }
+
+    function getClient() {
+        if (typeof getSupabaseClient === 'function') {
+            return getSupabaseClient();
+        }
+        if (typeof window !== 'undefined' && typeof window.getSupabaseClient === 'function') {
+            return window.getSupabaseClient();
+        }
+        return null;
+    }
+
+    async function resolveCurrentUser() {
+        if (typeof window !== 'undefined' && window.AuthService && typeof window.AuthService.getUser === 'function') {
+            try {
+                const user = await window.AuthService.getUser();
+                if (user?.id) {
+                    return {
+                        id: user.id,
+                        email: user.email || user.user_metadata?.email || '',
+                        role: user.role || user.user_metadata?.role || user.app_metadata?.role || 'chair'
+                    };
+                }
+            } catch (error) {
+                // fall through to direct Supabase lookup
+            }
+        }
+
+        const client = getClient();
+        if (!client?.auth || typeof client.auth.getUser !== 'function') {
+            return null;
+        }
+
+        const { data, error } = await client.auth.getUser();
+        if (error || !data?.user?.id) return null;
+        return {
+            id: data.user.id,
+            email: data.user.email || data.user.user_metadata?.email || '',
+            role: data.user.user_metadata?.role || data.user.app_metadata?.role || 'chair'
+        };
+    }
+
+    function ensurePageState(pageId) {
+        const key = sanitizePageId(pageId);
+        let state = pageStates.get(key);
+        if (!state) {
+            state = {
+                key,
+                channel: null,
+                callbacks: new Set(),
+                heartbeatTimer: null,
+                joinPromise: null,
+                joinedAt: new Date().toISOString(),
+                user: null
+            };
+            pageStates.set(key, state);
+        }
+        return state;
+    }
+
+    function normalizeEditorsFromPresenceState(state) {
+        if (!state?.channel || typeof state.channel.presenceState !== 'function') {
+            return [];
+        }
+
+        const nowMs = Date.now();
+        const raw = state.channel.presenceState() || {};
+        const deduped = new Map();
+
+        Object.values(raw).forEach((entries) => {
+            (entries || []).forEach((entry) => {
+                const userId = entry.user_id || null;
+                const userEmail = entry.user_email || 'Authenticated user';
+                const role = entry.role || 'chair';
+                const since = entry.joined_at || entry.last_seen || new Date().toISOString();
+                const lastSeen = entry.last_seen || since;
+                const lastSeenMs = Date.parse(lastSeen);
+
+                if (Number.isFinite(lastSeenMs) && nowMs - lastSeenMs > STALE_TTL_MS) {
+                    return;
+                }
+
+                const dedupeKey = `${userId || userEmail}:${entry.session_id || ''}`;
+                const existing = deduped.get(dedupeKey);
+                if (!existing || Date.parse(since) < Date.parse(existing.since)) {
+                    deduped.set(dedupeKey, {
+                        userId,
+                        user: userEmail,
+                        role,
+                        since,
+                        sessionId: entry.session_id || null
+                    });
+                }
+            });
+        });
+
+        return Array.from(deduped.values()).sort((a, b) => Date.parse(a.since) - Date.parse(b.since));
+    }
+
+    function emitPresenceChange(state) {
+        const editors = normalizeEditorsFromPresenceState(state);
+        state.callbacks.forEach((callback) => {
+            try {
+                callback(editors);
+            } catch (error) {
+                console.error('Presence callback failed:', error);
+            }
+        });
+    }
+
+    async function trackHeartbeat(state) {
+        if (!state?.channel || !state.user?.id || typeof state.channel.track !== 'function') {
+            return;
+        }
+
+        await state.channel.track({
+            session_id: sessionId,
+            user_id: state.user.id,
+            user_email: state.user.email || 'Authenticated user',
+            role: state.user.role || 'chair',
+            joined_at: state.joinedAt,
+            last_seen: new Date().toISOString()
+        });
+    }
+
+    async function joinPage(pageId) {
+        const client = getClient();
+        if (!client || typeof client.channel !== 'function') {
+            return false;
+        }
+
+        const state = ensurePageState(pageId);
+        if (state.joinPromise) {
+            return state.joinPromise;
+        }
+
+        state.joinPromise = (async () => {
+            state.user = await resolveCurrentUser();
+            if (!state.user?.id) {
+                return false;
+            }
+
+            if (!state.channel) {
+                state.channel = client.channel(`${CHANNEL_PREFIX}${state.key}`, {
+                    config: {
+                        presence: {
+                            key: `${state.user.id}:${sessionId}`
+                        }
+                    }
+                });
+
+                state.channel
+                    .on('presence', { event: 'sync' }, () => emitPresenceChange(state))
+                    .on('presence', { event: 'join' }, () => emitPresenceChange(state))
+                    .on('presence', { event: 'leave' }, () => emitPresenceChange(state));
+            }
+
+            await new Promise((resolve, reject) => {
+                let settled = false;
+                const timeout = setTimeout(() => {
+                    if (!settled) {
+                        settled = true;
+                        reject(new Error(`Presence join timed out for ${state.key}`));
+                    }
+                }, 5000);
+
+                state.channel.subscribe(async (status) => {
+                    if (status === 'SUBSCRIBED' && !settled) {
+                        settled = true;
+                        clearTimeout(timeout);
+                        resolve(true);
+                    }
+                    if ((status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') && !settled) {
+                        settled = true;
+                        clearTimeout(timeout);
+                        reject(new Error(`Presence subscribe failed for ${state.key}: ${status}`));
+                    }
+                });
+            });
+
+            await trackHeartbeat(state);
+            if (state.heartbeatTimer) {
+                clearInterval(state.heartbeatTimer);
+            }
+            state.heartbeatTimer = setInterval(() => {
+                trackHeartbeat(state).catch(() => {});
+            }, HEARTBEAT_MS);
+
+            emitPresenceChange(state);
+
+            if (!unloadHandlerBound && typeof window !== 'undefined') {
+                unloadHandlerBound = true;
+                window.addEventListener('beforeunload', () => {
+                    Array.from(pageStates.keys()).forEach((key) => {
+                        leavePage(key);
+                    });
+                });
+            }
+
+            return true;
+        })()
+            .finally(() => {
+                state.joinPromise = null;
+            });
+
+        return state.joinPromise;
+    }
+
+    function leavePage(pageId) {
+        const key = sanitizePageId(pageId);
+        const state = pageStates.get(key);
+        if (!state) return;
+
+        if (state.heartbeatTimer) {
+            clearInterval(state.heartbeatTimer);
+            state.heartbeatTimer = null;
+        }
+
+        if (state.channel) {
+            try {
+                if (typeof state.channel.untrack === 'function') {
+                    state.channel.untrack();
+                }
+            } catch (error) {
+                // ignore untrack failures during unload/disconnect
+            }
+
+            try {
+                if (typeof state.channel.unsubscribe === 'function') {
+                    state.channel.unsubscribe();
+                }
+            } catch (error) {
+                // ignore unsubscribe failures during unload/disconnect
+            }
+
+            const client = getClient();
+            if (client && typeof client.removeChannel === 'function') {
+                try {
+                    client.removeChannel(state.channel);
+                } catch (error) {
+                    // ignore remove-channel failures during unload/disconnect
+                }
+            }
+        }
+
+        state.callbacks.clear();
+        pageStates.delete(key);
+    }
+
+    function getActiveEditors(pageId) {
+        const state = pageStates.get(sanitizePageId(pageId));
+        if (!state) return [];
+        return normalizeEditorsFromPresenceState(state);
+    }
+
+    function onPresenceChange(pageId, callback) {
+        if (typeof callback !== 'function') {
+            throw new Error('Presence callback must be a function.');
+        }
+
+        const state = ensurePageState(pageId);
+        state.callbacks.add(callback);
+        callback(getActiveEditors(pageId));
+
+        joinPage(pageId).catch((error) => {
+            console.warn('Presence join failed:', error?.message || error);
+        });
+
+        return () => {
+            state.callbacks.delete(callback);
+        };
+    }
+
+    function resetForTests() {
+        Array.from(pageStates.keys()).forEach((key) => leavePage(key));
+    }
+
+    return {
+        joinPage,
+        leavePage,
+        getActiveEditors,
+        onPresenceChange,
+        _resetForTests: resetForTests
+    };
+})();
+
+if (typeof window !== 'undefined') {
+    window.PresenceService = PresenceService;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = PresenceService;
+}

--- a/tests/presence-service.test.js
+++ b/tests/presence-service.test.js
@@ -1,0 +1,160 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function createHarness({
+    user = { id: 'user-self', email: 'self@example.edu', role: 'chair' }
+} = {}) {
+    const source = fs.readFileSync(path.resolve(__dirname, '..', 'js/presence-service.js'), 'utf8');
+
+    let presenceState = {};
+    const handlers = {};
+
+    const channel = {
+        on: jest.fn((type, filter, callback) => {
+            handlers[`${type}:${filter.event}`] = callback;
+            return channel;
+        }),
+        subscribe: jest.fn((callback) => {
+            callback('SUBSCRIBED');
+            return channel;
+        }),
+        track: jest.fn().mockResolvedValue({}),
+        untrack: jest.fn(),
+        unsubscribe: jest.fn(),
+        presenceState: jest.fn(() => presenceState)
+    };
+
+    const client = {
+        channel: jest.fn(() => channel),
+        removeChannel: jest.fn(),
+        auth: {
+            getUser: jest.fn().mockResolvedValue({ data: { user }, error: null })
+        }
+    };
+
+    const sandboxWindow = {
+        AuthService: {
+            getUser: jest.fn().mockResolvedValue(user)
+        },
+        getSupabaseClient: jest.fn(() => client),
+        addEventListener: jest.fn()
+    };
+
+    const sandbox = {
+        console,
+        module: { exports: {} },
+        exports: {},
+        window: sandboxWindow,
+        getSupabaseClient: jest.fn(() => client),
+        crypto: { randomUUID: () => 'session-1' },
+        setInterval,
+        clearInterval,
+        setTimeout,
+        clearTimeout,
+        Date,
+        Math
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: 'js/presence-service.js' });
+
+    return {
+        PresenceService: sandbox.module.exports,
+        channel,
+        client,
+        handlers,
+        setPresenceState(next) {
+            presenceState = next;
+        }
+    };
+}
+
+describe('PresenceService', () => {
+    test('joinPage subscribes to Supabase presence and tracks the current user', async () => {
+        const { PresenceService, channel, client } = createHarness();
+
+        await expect(PresenceService.joinPage('/index.html')).resolves.toBe(true);
+
+        expect(client.channel).toHaveBeenCalledTimes(1);
+        expect(client.channel.mock.calls[0][0]).toContain('pc-presence:');
+        expect(channel.subscribe).toHaveBeenCalledTimes(1);
+        expect(channel.track).toHaveBeenCalled();
+    });
+
+    test('getActiveEditors filters stale sessions and returns normalized editors', async () => {
+        const { PresenceService, handlers, setPresenceState } = createHarness();
+
+        await PresenceService.joinPage('/index.html');
+
+        const now = new Date().toISOString();
+        const stale = new Date(Date.now() - 120000).toISOString();
+
+        setPresenceState({
+            'user-a:session-a': [{
+                user_id: 'user-a',
+                user_email: 'a@example.edu',
+                role: 'chair',
+                joined_at: now,
+                last_seen: now,
+                session_id: 'session-a'
+            }],
+            'user-b:session-b': [{
+                user_id: 'user-b',
+                user_email: 'b@example.edu',
+                role: 'admin',
+                joined_at: stale,
+                last_seen: stale,
+                session_id: 'session-b'
+            }]
+        });
+
+        handlers['presence:sync']();
+
+        const editors = PresenceService.getActiveEditors('/index.html');
+        expect(editors).toHaveLength(1);
+        expect(editors[0]).toMatchObject({
+            userId: 'user-a',
+            user: 'a@example.edu',
+            role: 'chair'
+        });
+    });
+
+    test('onPresenceChange subscribes callbacks and supports unsubscribe', async () => {
+        const { PresenceService, handlers, setPresenceState } = createHarness();
+        const callback = jest.fn();
+
+        const unsubscribe = PresenceService.onPresenceChange('/index.html', callback);
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        setPresenceState({
+            'user-a:session-a': [{
+                user_id: 'user-a',
+                user_email: 'a@example.edu',
+                role: 'chair',
+                joined_at: new Date().toISOString(),
+                last_seen: new Date().toISOString(),
+                session_id: 'session-a'
+            }]
+        });
+        handlers['presence:sync']();
+
+        expect(callback).toHaveBeenCalled();
+        const callsAfterSync = callback.mock.calls.length;
+
+        unsubscribe();
+        handlers['presence:sync']();
+        expect(callback.mock.calls.length).toBe(callsAfterSync);
+    });
+
+    test('leavePage clears channel resources', async () => {
+        const { PresenceService, channel, client } = createHarness();
+
+        await PresenceService.joinPage('/index.html');
+        PresenceService.leavePage('/index.html');
+
+        expect(channel.untrack).toHaveBeenCalled();
+        expect(channel.unsubscribe).toHaveBeenCalled();
+        expect(client.removeChannel).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- add PresenceService singleton at js/presence-service.js using Supabase Realtime Presence channels
- implement required API: joinPage, leavePage, getActiveEditors, onPresenceChange
- add heartbeat + stale-session filtering (30s TTL) and unload cleanup for disconnect/crash cases
- integrate presence into auth-guard session indicator so authenticated pages show active-editor state
- add unit tests for join/leave/sync/stale-session behavior
- document runtime behavior in docs/presence-service-a07.md

## Testing
- npm test -- tests/presence-service.test.js --runInBand
- npm test -- --runInBand
- npm run qa:onboarding

Closes #93