### PR TITLE
[Tree/A-09] Add unsaved-changes guard (beforeunload + in-app navigation)

### DIFF
--- a/docs/unsaved-changes-guard-a09.md
+++ b/docs/unsaved-changes-guard-a09.md
@@ -1,0 +1,30 @@
+# Unsaved Changes Guard (Tree/A-09)
+
+Issue: [#95](https://github.com/sicxz/program-command/issues/95)
+
+## Overview
+This implementation adds a shared dirty-state tracker and guards users against losing unsaved scheduler edits.
+
+## Components
+- `js/dirty-state-tracker.js`
+  - `markDirty(context)`
+  - `markClean()`
+  - `isDirty()`
+  - `attachToStateManager(stateManager, { ignoreKeys })`
+- `index.html`
+  - browser `beforeunload` warning when dirty
+  - in-app navigation guard modal with **Save now / Discard / Cancel**
+  - save button pending badge (`save-dirty-dot`) while unsaved edits exist
+
+## Flow
+1. Scheduler edits call existing dirty state wiring (`setScheduleDirty(true)`), which now also updates `DirtyStateTracker`.
+2. Closing/reloading tab triggers native browser confirmation when dirty.
+3. Internal navigation attempts (header nav or links) open a modal:
+   - **Save now**: runs save flow, then navigates if clean
+   - **Discard**: clears dirty state and navigates
+   - **Cancel**: stay on page
+4. Successful save clears dirty state and removes warning prompts.
+
+## Notes
+- StateManager integration is attached with ignored keys for transient UI filters.
+- Save-failure path keeps dirty state active and blocks navigation.

--- a/index.html
+++ b/index.html
@@ -3697,6 +3697,66 @@
             background: #14532d !important;
         }
 
+        .save-dirty-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 999px;
+            background: #f59e0b;
+            box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+            display: none;
+        }
+
+        .save-dirty-dot.visible {
+            display: inline-block;
+        }
+
+        .unsaved-modal-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(15, 23, 42, 0.5);
+            z-index: 1600;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 16px;
+        }
+
+        .unsaved-modal-overlay.visible {
+            display: flex;
+        }
+
+        .unsaved-modal {
+            width: min(480px, 100%);
+            background: #ffffff;
+            border: 1px solid #d0d7de;
+            border-radius: 12px;
+            padding: 18px;
+            box-shadow: 0 24px 40px rgba(15, 23, 42, 0.2);
+        }
+
+        .unsaved-modal h3 {
+            margin: 0 0 8px;
+            font-size: 18px;
+            color: #1f2328;
+        }
+
+        .unsaved-modal p {
+            margin: 0 0 14px;
+            color: #4b5563;
+            line-height: 1.45;
+        }
+
+        .unsaved-modal-actions {
+            display: flex;
+            gap: 8px;
+            justify-content: flex-end;
+            flex-wrap: wrap;
+        }
+
+        .unsaved-modal-actions button {
+            min-width: 108px;
+        }
+
         .btn-add-icon {
             font-family: var(--ewu-mono);
             font-size: 16px;
@@ -4319,6 +4379,7 @@
     <script type="module" src="js/supabase-config.js"></script>
     <script src="js/auth-service.js"></script>
     <script src="js/auth-guard.js"></script>
+    <script src="js/dirty-state-tracker.js"></script>
 
     <!-- Schedule Manager Scripts -->
     <script type="module" src="js/config/constants.js"></script>
@@ -4484,6 +4545,7 @@
                         <span class="swap-toggle-label" id="swapLabel">Swap</span>
                     </div>
                     <button type="button" id="saveDbButton" class="btn-ewu-accent btn-add-course-main btn-save-db" onclick="saveScheduleToDatabase()">
+                        <span class="save-dirty-dot" id="saveDirtyDot" aria-hidden="true"></span>
                         <span id="saveDbButtonText">Save Schedule</span>
                     </button>
                     <button class="btn-ewu-accent btn-add-course-main" onclick="openAddCourseModal()">
@@ -5269,6 +5331,89 @@
             content.classList.toggle('collapsed');
         }
 
+        let unsavedModalResolver = null;
+
+        function closeUnsavedChangesModal(choice = 'cancel') {
+            const modal = document.getElementById('unsavedChangesModal');
+            if (modal) {
+                modal.classList.remove('visible');
+            }
+
+            if (typeof unsavedModalResolver === 'function') {
+                unsavedModalResolver(choice);
+            }
+            unsavedModalResolver = null;
+        }
+
+        function openUnsavedChangesModal() {
+            const modal = document.getElementById('unsavedChangesModal');
+            if (!modal) return Promise.resolve('cancel');
+
+            const saveButton = document.getElementById('unsavedSaveBtn');
+            const discardButton = document.getElementById('unsavedDiscardBtn');
+            const cancelButton = document.getElementById('unsavedCancelBtn');
+
+            if (saveButton && !saveButton.dataset.boundUnsavedAction) {
+                saveButton.dataset.boundUnsavedAction = '1';
+                saveButton.addEventListener('click', () => closeUnsavedChangesModal('save'));
+            }
+            if (discardButton && !discardButton.dataset.boundUnsavedAction) {
+                discardButton.dataset.boundUnsavedAction = '1';
+                discardButton.addEventListener('click', () => closeUnsavedChangesModal('discard'));
+            }
+            if (cancelButton && !cancelButton.dataset.boundUnsavedAction) {
+                cancelButton.dataset.boundUnsavedAction = '1';
+                cancelButton.addEventListener('click', () => closeUnsavedChangesModal('cancel'));
+            }
+            if (!modal.dataset.boundUnsavedBackdrop) {
+                modal.dataset.boundUnsavedBackdrop = '1';
+                modal.addEventListener('click', (event) => {
+                    if (event.target === modal) {
+                        closeUnsavedChangesModal('cancel');
+                    }
+                });
+            }
+
+            modal.classList.add('visible');
+            return new Promise((resolve) => {
+                unsavedModalResolver = resolve;
+            });
+        }
+
+        async function navigateWithDirtyGuard(targetUrl) {
+            const hasUnsavedChanges = Boolean(window.DirtyStateTracker?.isDirty?.() || scheduleDirty);
+            if (!hasUnsavedChanges) {
+                window.location.href = targetUrl;
+                return true;
+            }
+
+            window.DirtyStateTracker?.setPendingNavigation(targetUrl);
+            const choice = await openUnsavedChangesModal();
+            if (choice === 'cancel') {
+                window.DirtyStateTracker?.setPendingNavigation(null);
+            }
+
+            if (choice === 'save') {
+                await saveScheduleToDatabase();
+                if (window.DirtyStateTracker?.isDirty?.() || scheduleDirty) {
+                    showToast('Save failed or still pending. Navigation canceled.', 'error');
+                    return false;
+                }
+                window.DirtyStateTracker?.setPendingNavigation(null);
+                window.location.href = targetUrl;
+                return true;
+            }
+
+            if (choice === 'discard') {
+                setScheduleDirty(false);
+                window.DirtyStateTracker?.markClean();
+                window.location.href = targetUrl;
+                return true;
+            }
+
+            return false;
+        }
+
 
 
         // Listen for the custom event from the AppHeader component
@@ -5291,11 +5436,46 @@
             } else if (action === 'accounts') {
                 showToast('Users & accounts is the next build step: add Supabase Auth + role-based permissions.', 'success');
             } else if (action === 'nav-enrollment') {
-                window.location.href = 'enrollment-dashboard.html';
+                navigateWithDirtyGuard('enrollment-dashboard.html');
             } else if (action === 'nav-workload') {
-                window.location.href = 'pages/workload-dashboard.html';
+                navigateWithDirtyGuard('pages/workload-dashboard.html');
             }
         });
+
+        window.addEventListener('beforeunload', (event) => {
+            if (!window.DirtyStateTracker?.isDirty?.()) return;
+            event.preventDefault();
+            event.returnValue = '';
+        });
+
+        document.addEventListener('click', (event) => {
+            const anchor = event.target.closest('a[href]');
+            if (!anchor || anchor.target === '_blank' || anchor.hasAttribute('download')) return;
+
+            const url = new URL(anchor.href, window.location.href);
+            if (url.origin !== window.location.origin) return;
+            if (url.pathname === window.location.pathname && !url.search) return;
+
+            if (!window.DirtyStateTracker?.isDirty?.()) return;
+
+            event.preventDefault();
+            navigateWithDirtyGuard(url.pathname + url.search + url.hash);
+        });
+
+        function attachDirtyTrackerToStateManager(attempt = 0) {
+            if (!window.DirtyStateTracker) return;
+            if (window.StateManager && typeof window.StateManager.subscribe === 'function') {
+                window.DirtyStateTracker.attachToStateManager(window.StateManager, {
+                    ignoreKeys: ['currentQuarter', 'currentAcademicYear', 'currentTrack', 'currentMinor']
+                });
+                return;
+            }
+
+            if (attempt >= 10) return;
+            setTimeout(() => attachDirtyTrackerToStateManager(attempt + 1), 250);
+        }
+
+        attachDirtyTrackerToStateManager();
 
         // Listen for quarter-nav component events
         document.addEventListener('quarter-change', (e) => {
@@ -8184,11 +8364,15 @@
         function updateSaveDbButtonState() {
             const button = document.getElementById('saveDbButton');
             const label = document.getElementById('saveDbButtonText');
+            const dirtyDot = document.getElementById('saveDirtyDot');
             if (!button || !label) return;
 
             const shouldShow = scheduleDirty || scheduleSaveInProgress;
             button.classList.toggle('visible', shouldShow);
             button.disabled = scheduleSaveInProgress;
+            if (dirtyDot) {
+                dirtyDot.classList.toggle('visible', scheduleDirty);
+            }
 
             if (scheduleSaveInProgress) {
                 label.textContent = 'Saving...';
@@ -8204,14 +8388,23 @@
             scheduleDirty = dirty;
             if (dirty) {
                 dirtyYears.add(currentAcademicYear);
+                window.DirtyStateTracker?.markDirty(`schedule:${currentAcademicYear}`);
             } else {
                 dirtyYears.delete(currentAcademicYear);
+                if (dirtyYears.size === 0) {
+                    window.DirtyStateTracker?.markClean();
+                }
             }
             updateSaveDbButtonState();
         }
 
         function syncDirtyStateForCurrentYear() {
             scheduleDirty = dirtyYears.has(currentAcademicYear);
+            if (scheduleDirty) {
+                window.DirtyStateTracker?.markDirty(`schedule:${currentAcademicYear}`);
+            } else if (dirtyYears.size === 0) {
+                window.DirtyStateTracker?.markClean();
+            }
             updateSaveDbButtonState();
         }
 
@@ -12772,6 +12965,18 @@
     <!-- Toast Notification -->
     <div class="toast" id="toast">
         <span id="toastMessage">Changes saved</span>
+    </div>
+
+    <div class="unsaved-modal-overlay" id="unsavedChangesModal" role="dialog" aria-modal="true" aria-labelledby="unsavedModalTitle">
+        <div class="unsaved-modal">
+            <h3 id="unsavedModalTitle">You Have Unsaved Changes</h3>
+            <p>Your schedule has unsaved edits. Save now, discard changes, or cancel navigation.</p>
+            <div class="unsaved-modal-actions">
+                <button type="button" class="btn-secondary" id="unsavedCancelBtn">Cancel</button>
+                <button type="button" class="btn-secondary" id="unsavedDiscardBtn">Discard</button>
+                <button type="button" class="btn-ewu-accent" id="unsavedSaveBtn">Save now</button>
+            </div>
+        </div>
     </div>
 
     <!-- Add Faculty Modal -->

--- a/js/dirty-state-tracker.js
+++ b/js/dirty-state-tracker.js
@@ -1,0 +1,133 @@
+/**
+ * Dirty State Tracker
+ * Tracks unsaved changes and integrates with StateManager change events.
+ */
+const DirtyStateTracker = (function() {
+    'use strict';
+
+    let dirty = false;
+    let dirtyContext = null;
+    let pendingNavigationUrl = null;
+    const listeners = new Set();
+
+    let stateManagerUnsubscribe = null;
+    let ignoredStateKeys = new Set();
+
+    function emit() {
+        const snapshot = {
+            dirty,
+            context: dirtyContext,
+            pendingNavigationUrl
+        };
+
+        listeners.forEach((listener) => {
+            try {
+                listener(snapshot);
+            } catch (error) {
+                console.error('DirtyStateTracker listener failed:', error);
+            }
+        });
+    }
+
+    function markDirty(context = null) {
+        dirty = true;
+        if (context) {
+            dirtyContext = context;
+        }
+        emit();
+    }
+
+    function markClean() {
+        dirty = false;
+        dirtyContext = null;
+        pendingNavigationUrl = null;
+        emit();
+    }
+
+    function isDirty() {
+        return dirty;
+    }
+
+    function getContext() {
+        return dirtyContext;
+    }
+
+    function setPendingNavigation(url) {
+        pendingNavigationUrl = url || null;
+        emit();
+    }
+
+    function getPendingNavigation() {
+        return pendingNavigationUrl;
+    }
+
+    function onChange(listener) {
+        if (typeof listener !== 'function') {
+            throw new Error('DirtyStateTracker listener must be a function.');
+        }
+
+        listeners.add(listener);
+        listener({ dirty, context: dirtyContext, pendingNavigationUrl });
+
+        return () => {
+            listeners.delete(listener);
+        };
+    }
+
+    function attachToStateManager(stateManager, options = {}) {
+        if (!stateManager || typeof stateManager.subscribe !== 'function') {
+            return false;
+        }
+
+        if (typeof stateManagerUnsubscribe === 'function') {
+            stateManagerUnsubscribe();
+            stateManagerUnsubscribe = null;
+        }
+
+        ignoredStateKeys = new Set(options.ignoreKeys || []);
+
+        stateManagerUnsubscribe = stateManager.subscribe('*', (_newValue, _oldValue, key) => {
+            if (ignoredStateKeys.has(key)) return;
+            markDirty(`state:${key}`);
+        });
+
+        return true;
+    }
+
+    function detachFromStateManager() {
+        if (typeof stateManagerUnsubscribe === 'function') {
+            stateManagerUnsubscribe();
+            stateManagerUnsubscribe = null;
+        }
+        ignoredStateKeys = new Set();
+    }
+
+    function resetForTests() {
+        dirty = false;
+        dirtyContext = null;
+        pendingNavigationUrl = null;
+        detachFromStateManager();
+        listeners.clear();
+    }
+
+    return {
+        markDirty,
+        markClean,
+        isDirty,
+        getContext,
+        setPendingNavigation,
+        getPendingNavigation,
+        onChange,
+        attachToStateManager,
+        detachFromStateManager,
+        _resetForTests: resetForTests
+    };
+})();
+
+if (typeof window !== 'undefined') {
+    window.DirtyStateTracker = DirtyStateTracker;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = DirtyStateTracker;
+}

--- a/tests/dirty-state-tracker.test.js
+++ b/tests/dirty-state-tracker.test.js
@@ -1,0 +1,62 @@
+const DirtyStateTracker = require('../js/dirty-state-tracker.js');
+
+describe('DirtyStateTracker', () => {
+    afterEach(() => {
+        DirtyStateTracker._resetForTests();
+    });
+
+    test('markDirty and markClean update dirty state and context', () => {
+        expect(DirtyStateTracker.isDirty()).toBe(false);
+
+        DirtyStateTracker.markDirty('schedule:2026-27');
+        expect(DirtyStateTracker.isDirty()).toBe(true);
+        expect(DirtyStateTracker.getContext()).toBe('schedule:2026-27');
+
+        DirtyStateTracker.markClean();
+        expect(DirtyStateTracker.isDirty()).toBe(false);
+        expect(DirtyStateTracker.getContext()).toBeNull();
+    });
+
+    test('onChange listener receives updates', () => {
+        const listener = jest.fn();
+        const unsubscribe = DirtyStateTracker.onChange(listener);
+
+        expect(listener).toHaveBeenCalledWith(expect.objectContaining({ dirty: false }));
+
+        DirtyStateTracker.markDirty('state:currentQuarter');
+        expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({
+            dirty: true,
+            context: 'state:currentQuarter'
+        }));
+
+        unsubscribe();
+    });
+
+    test('attachToStateManager marks dirty for non-ignored state keys', () => {
+        let callback = null;
+        const unsubscribe = jest.fn();
+        const stateManager = {
+            subscribe: jest.fn((_key, cb) => {
+                callback = cb;
+                return unsubscribe;
+            })
+        };
+
+        const attached = DirtyStateTracker.attachToStateManager(stateManager, {
+            ignoreKeys: ['currentQuarter']
+        });
+
+        expect(attached).toBe(true);
+        expect(stateManager.subscribe).toHaveBeenCalledWith('*', expect.any(Function));
+
+        callback('fall', 'winter', 'currentQuarter');
+        expect(DirtyStateTracker.isDirty()).toBe(false);
+
+        callback('changed', 'old', 'scheduleData');
+        expect(DirtyStateTracker.isDirty()).toBe(true);
+        expect(DirtyStateTracker.getContext()).toBe('state:scheduleData');
+
+        DirtyStateTracker.detachFromStateManager();
+        expect(unsubscribe).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- add DirtyStateTracker singleton (markDirty, markClean, isDirty, StateManager integration)
- wire scheduler dirty-state flows to DirtyStateTracker
- add browser beforeunload guard for unsaved scheduler changes
- add in-app navigation confirmation modal (Save now / Discard / Cancel)
- add subtle unsaved-change indicator dot near the Save button
- document flow in docs/unsaved-changes-guard-a09.md
- add DirtyStateTracker unit tests

## Testing
- npm test -- tests/dirty-state-tracker.test.js --runInBand
- npm test -- --runInBand
- npm run qa:onboarding

Closes #95