### PR TITLE
[Tree/A-10] Add session timeout, auto-save, and recovery

### DIFF
--- a/docs/session-timeout-autosave-a10.md
+++ b/docs/session-timeout-autosave-a10.md
@@ -1,0 +1,36 @@
+# Session Timeout, Auto-Save, and Recovery (Tree/A-10)
+
+Issue: [#96](https://github.com/sicxz/program-command/issues/96)
+
+## Implemented Behavior
+
+### 1) Session timeout
+- Idle timeout window: 30 minutes
+- Warning toast: 5 minutes before timeout
+- On timeout:
+  1. attempt resilient auto-save
+  2. persist local recovery draft if remote save fails
+  3. sign out and redirect to `login.html?timeout=1`
+
+### 2) Auto-save
+- Periodic auto-save every 2 minutes when dirty
+- Auto-save trigger on tab hide / visibility change
+- Save path uses existing `saveScheduleToDatabase` flow with silent mode for background saves
+- If Supabase save fails, draft fallback is written to localStorage key `pc_session_recovery_draft_v1`
+
+### 3) Recovery
+- Login page checks for recovery draft key after successful sign-in
+- Prompt: restore or discard unsaved draft from previous session
+- On restore, draft is mapped to `importedScheduleData` and loaded by scheduler import path
+
+## Files
+- `index.html`
+  - session resilience timers, activity tracking, auto-save hooks, recovery draft persistence
+- `pages/login.js`
+  - timeout message and recovery prompt flow
+- `js/dirty-state-tracker.js`
+  - dirty-state source used by auto-save/timeout gating
+
+## Notes
+- Background auto-save is debounced and skipped while save is already in progress.
+- Successful save clears the local recovery draft key.

--- a/index.html
+++ b/index.html
@@ -5476,6 +5476,9 @@
         }
 
         attachDirtyTrackerToStateManager();
+        document.addEventListener('DOMContentLoaded', () => {
+            initializeSessionResilience();
+        });
 
         // Listen for quarter-nav component events
         document.addEventListener('quarter-change', (e) => {
@@ -8325,6 +8328,17 @@
         let scheduleDirty = false;
         let scheduleSaveInProgress = false;
         const dirtyYears = new Set();
+        const SESSION_RECOVERY_DRAFT_KEY = 'pc_session_recovery_draft_v1';
+        const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+        const SESSION_IDLE_WARNING_MS = 5 * 60 * 1000;
+        const AUTO_SAVE_INTERVAL_MS = 2 * 60 * 1000;
+
+        let sessionIdleTimerId = null;
+        let sessionWarningTimerId = null;
+        let autoSaveTimerId = null;
+        let lastActivityResetAt = 0;
+        let autoSaveRunning = false;
+        let lastAutoSaveAt = 0;
 
         // Update swap mode labels when toggle changes
         function updateSwapModeLabels() {
@@ -8406,6 +8420,121 @@
                 window.DirtyStateTracker?.markClean();
             }
             updateSaveDbButtonState();
+        }
+
+        function captureRecoveryDraft(reason = 'autosave-fallback') {
+            try {
+                const payload = {
+                    reason,
+                    savedAt: new Date().toISOString(),
+                    academicYear: currentAcademicYear,
+                    scheduleData
+                };
+                localStorage.setItem(SESSION_RECOVERY_DRAFT_KEY, JSON.stringify(payload));
+            } catch (error) {
+                console.warn('Could not persist session recovery draft:', error);
+            }
+        }
+
+        function clearRecoveryDraft() {
+            try {
+                localStorage.removeItem(SESSION_RECOVERY_DRAFT_KEY);
+            } catch (error) {
+                // ignore cleanup errors
+            }
+        }
+
+        async function attemptResilientAutoSave(trigger = 'interval') {
+            const hasDirtyState = Boolean(window.DirtyStateTracker?.isDirty?.() || scheduleDirty);
+            if (!hasDirtyState || scheduleSaveInProgress || autoSaveRunning) {
+                return false;
+            }
+
+            const now = Date.now();
+            if (now - lastAutoSaveAt < 60 * 1000) {
+                return false;
+            }
+            lastAutoSaveAt = now;
+            autoSaveRunning = true;
+
+            try {
+                const success = await saveScheduleToDatabase({
+                    silent: trigger !== 'timeout',
+                    trigger
+                });
+                if (!success) {
+                    captureRecoveryDraft(`autosave-${trigger}`);
+                }
+                return success;
+            } catch (error) {
+                captureRecoveryDraft(`autosave-${trigger}`);
+                return false;
+            } finally {
+                autoSaveRunning = false;
+            }
+        }
+
+        async function handleSessionTimeout() {
+            showToast('Session timed out. Saving pending changes and signing out...', 'error');
+            const saved = await attemptResilientAutoSave('timeout');
+            if (!saved && (window.DirtyStateTracker?.isDirty?.() || scheduleDirty)) {
+                captureRecoveryDraft('timeout');
+            }
+
+            try {
+                await window.AuthService?.signOut?.();
+            } catch (error) {
+                console.warn('Sign-out during timeout failed:', error);
+            } finally {
+                window.location.replace('login.html?timeout=1');
+            }
+        }
+
+        function resetSessionIdleTimers() {
+            if (sessionWarningTimerId) clearTimeout(sessionWarningTimerId);
+            if (sessionIdleTimerId) clearTimeout(sessionIdleTimerId);
+
+            sessionWarningTimerId = setTimeout(() => {
+                showToast('Your session will expire in 5 minutes due to inactivity.');
+            }, SESSION_IDLE_TIMEOUT_MS - SESSION_IDLE_WARNING_MS);
+
+            sessionIdleTimerId = setTimeout(() => {
+                handleSessionTimeout();
+            }, SESSION_IDLE_TIMEOUT_MS);
+        }
+
+        function registerSessionActivityListeners() {
+            const activityHandler = () => {
+                const now = Date.now();
+                if (now - lastActivityResetAt < 15000) return;
+                lastActivityResetAt = now;
+                resetSessionIdleTimers();
+            };
+
+            ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll'].forEach((eventName) => {
+                window.addEventListener(eventName, activityHandler, { passive: true });
+            });
+
+            document.addEventListener('visibilitychange', () => {
+                if (document.hidden) {
+                    if (window.DirtyStateTracker?.isDirty?.() || scheduleDirty) {
+                        captureRecoveryDraft('visibility-hidden');
+                        attemptResilientAutoSave('visibility-hidden');
+                    }
+                    return;
+                }
+                resetSessionIdleTimers();
+            });
+        }
+
+        function initializeSessionResilience() {
+            if (autoSaveTimerId) clearInterval(autoSaveTimerId);
+            autoSaveTimerId = setInterval(() => {
+                attemptResilientAutoSave('interval');
+            }, AUTO_SAVE_INTERVAL_MS);
+
+            registerSessionActivityListeners();
+            resetSessionIdleTimers();
         }
 
         function syncDisplacedTrayUI() {
@@ -13499,13 +13628,17 @@
         /**
          * Save all schedule changes to Supabase in one explicit action.
          */
-        async function saveScheduleToDatabase() {
-            if (scheduleSaveInProgress) return;
+        async function saveScheduleToDatabase(options = {}) {
+            const { silent = false, trigger = 'manual' } = options || {};
+            if (scheduleSaveInProgress) return false;
 
             const client = getDatabaseClient();
             if (!client) {
-                showToast('Supabase is not connected. Changes are still saved locally.', 'error');
-                return;
+                if (!silent) {
+                    showToast('Supabase is not connected. Changes are still saved locally.', 'error');
+                }
+                captureRecoveryDraft(`save-no-client-${trigger}`);
+                return false;
             }
 
             const rows = collectScheduleCoursesForDatabase();
@@ -13648,10 +13781,18 @@
                 }
 
                 setScheduleDirty(false);
-                showToast(`Saved ${records.length} schedule entries to Supabase (${saveCounts.updated} updated, ${saveCounts.inserted} new${saveCounts.deleted ? `, ${saveCounts.deleted} removed` : ''}).`);
+                clearRecoveryDraft();
+                if (!silent) {
+                    showToast(`Saved ${records.length} schedule entries to Supabase (${saveCounts.updated} updated, ${saveCounts.inserted} new${saveCounts.deleted ? `, ${saveCounts.deleted} removed` : ''}).`);
+                }
+                return true;
             } catch (error) {
                 console.error('Error saving schedule to Supabase:', error);
-                showToast('Database save failed: ' + (error.message || 'Unknown error'), 'error');
+                captureRecoveryDraft(`save-failed-${trigger}`);
+                if (!silent) {
+                    showToast('Database save failed: ' + (error.message || 'Unknown error'), 'error');
+                }
+                return false;
             } finally {
                 scheduleSaveInProgress = false;
                 updateSaveDbButtonState();

--- a/pages/login.js
+++ b/pages/login.js
@@ -4,6 +4,8 @@
 (function() {
     'use strict';
 
+    const SESSION_RECOVERY_DRAFT_KEY = 'pc_session_recovery_draft_v1';
+
     function getNextPath() {
         const params = new URLSearchParams(window.location.search);
         const next = params.get('next');
@@ -37,6 +39,40 @@
         }
     }
 
+    function maybeShowTimeoutMessage() {
+        const params = new URLSearchParams(window.location.search);
+        if (params.get('timeout') === '1') {
+            showError('Your session expired due to inactivity. Sign in to continue.');
+        }
+    }
+
+    function handleRecoveryDraftPreference() {
+        let draft = null;
+        try {
+            const raw = localStorage.getItem(SESSION_RECOVERY_DRAFT_KEY);
+            draft = raw ? JSON.parse(raw) : null;
+        } catch (error) {
+            draft = null;
+        }
+
+        if (!draft || !draft.scheduleData) return;
+
+        const savedAt = draft.savedAt ? new Date(draft.savedAt).toLocaleString() : 'a previous session';
+        const shouldRestore = window.confirm(`You have unsaved changes from ${savedAt}. Restore them after login?`);
+
+        if (shouldRestore) {
+            const payload = {
+                academicYear: draft.academicYear || '2025-26',
+                generatedAt: draft.savedAt || new Date().toISOString(),
+                scheduleData: draft.scheduleData,
+                source: 'session-recovery-draft'
+            };
+            localStorage.setItem('importedScheduleData', JSON.stringify(payload));
+        }
+
+        localStorage.removeItem(SESSION_RECOVERY_DRAFT_KEY);
+    }
+
     async function handleSubmit(event) {
         event.preventDefault();
         clearError();
@@ -47,6 +83,7 @@
 
         try {
             await window.AuthService.signIn(email, password);
+            handleRecoveryDraftPreference();
             window.location.replace(getNextPath());
         } catch (error) {
             const message = error?.message || 'Login failed. Please verify your email and password.';
@@ -62,6 +99,7 @@
             return;
         }
 
+        maybeShowTimeoutMessage();
         await redirectIfAlreadyAuthenticated();
         const form = document.getElementById('loginForm');
         form.addEventListener('submit', handleSubmit);


### PR DESCRIPTION
## Summary
- add session resilience timers in scheduler: 30m idle timeout + 5m warning
- add periodic auto-save (2m dirty-only) and visibility-change auto-save triggers
- add local recovery draft fallback (pc_session_recovery_draft_v1) when remote save is unavailable/fails
- extend save flow to support silent/background autosave and return success/failure status
- on timeout, attempt save, then sign out and redirect to login with timeout reason
- add login recovery prompt to restore/discard unsaved draft from previous session
- document behavior in docs/session-timeout-autosave-a10.md

## Testing
- npm test -- --runInBand
- npm run qa:onboarding
- npm run build

Closes #96