### PR TITLE
[Tree/T-02] Add program_id columns and migrate existing EWU Design data as program #1

### DIFF
--- a/docs/supabase-program-id-migration-t02.md
+++ b/docs/supabase-program-id-migration-t02.md
@@ -1,0 +1,143 @@
+# Supabase Program ID Migration (T-02)
+
+Issue: [#100](https://github.com/sicxz/program-command/issues/100)  
+Parent epic: [#98](https://github.com/sicxz/program-command/issues/98)
+
+## Purpose
+Execute the first tenantization migration by adding `program_id` to all program-scoped tables and backfilling existing EWU Design data into `programs`.
+
+## Files
+- Forward migration: `scripts/supabase-program-id-migration-t02.sql`
+- Emergency rollback: `scripts/supabase-program-id-migration-t02-rollback.sql`
+
+## What The Migration Does
+1. Creates `public.programs` (if missing).
+2. Inserts/updates EWU Design tenant row (`code='ewu-design'`).
+3. Adds `program_id` to all scoped tables.
+4. Backfills existing rows based on current FK hierarchy.
+5. Applies transition default (`program_id = EWU Design`) for backward-compatible inserts.
+6. Sets `program_id` to `NOT NULL`.
+7. Adds `program_id` FK constraints to `public.programs(id)`.
+8. Adds required indexes on every `program_id` column plus high-value query indexes.
+
+## Program-Scoped Tables Updated
+- `departments`
+- `academic_years`
+- `rooms`
+- `courses`
+- `faculty`
+- `scheduled_courses`
+- `faculty_preferences`
+- `scheduling_constraints`
+- `release_time`
+- `pathways`
+- `pathway_courses`
+
+## Apply (SQL Editor)
+Run in Supabase SQL Editor:
+
+```sql
+-- copy/paste the full file contents
+-- scripts/supabase-program-id-migration-t02.sql
+```
+
+Or with `psql`:
+
+```bash
+psql "$SUPABASE_DB_URL" -f scripts/supabase-program-id-migration-t02.sql
+```
+
+## Verification Queries
+
+### 1) Confirm EWU Design program row exists
+```sql
+select id, name, code, created_at, updated_at
+from public.programs
+where code = 'ewu-design';
+```
+
+### 2) Confirm every scoped table has non-null `program_id`
+```sql
+with scoped(table_name) as (
+  values
+    ('departments'),
+    ('academic_years'),
+    ('rooms'),
+    ('courses'),
+    ('faculty'),
+    ('scheduled_courses'),
+    ('faculty_preferences'),
+    ('scheduling_constraints'),
+    ('release_time'),
+    ('pathways'),
+    ('pathway_courses')
+)
+select
+  s.table_name,
+  c.is_nullable,
+  c.column_default
+from scoped s
+join information_schema.columns c
+  on c.table_schema = 'public'
+ and c.table_name = s.table_name
+ and c.column_name = 'program_id'
+order by s.table_name;
+```
+
+Expected:
+- `is_nullable = NO` for all rows.
+- `column_default` resolves to EWU Design UUID for transition compatibility.
+
+### 3) Check data backfill completed
+```sql
+select 'departments' as table_name, count(*) filter (where program_id is null) as null_count from public.departments
+union all
+select 'academic_years', count(*) filter (where program_id is null) from public.academic_years
+union all
+select 'rooms', count(*) filter (where program_id is null) from public.rooms
+union all
+select 'courses', count(*) filter (where program_id is null) from public.courses
+union all
+select 'faculty', count(*) filter (where program_id is null) from public.faculty
+union all
+select 'scheduled_courses', count(*) filter (where program_id is null) from public.scheduled_courses
+union all
+select 'faculty_preferences', count(*) filter (where program_id is null) from public.faculty_preferences
+union all
+select 'scheduling_constraints', count(*) filter (where program_id is null) from public.scheduling_constraints
+union all
+select 'release_time', count(*) filter (where program_id is null) from public.release_time
+union all
+select 'pathways', count(*) filter (where program_id is null) from public.pathways
+union all
+select 'pathway_courses', count(*) filter (where program_id is null) from public.pathway_courses;
+```
+
+Expected: `null_count = 0` for every row.
+
+### 4) Check FK constraints exist
+```sql
+select
+  conrelid::regclass as table_name,
+  conname,
+  pg_get_constraintdef(oid) as definition
+from pg_constraint
+where conname like '%_program_id_fkey'
+order by conrelid::regclass::text, conname;
+```
+
+## Rollback (Emergency)
+
+```bash
+psql "$SUPABASE_DB_URL" -f scripts/supabase-program-id-migration-t02-rollback.sql
+```
+
+Rollback removes:
+- all `program_id` indexes
+- all `<table>_program_id_fkey` constraints
+- all `program_id` columns
+- `public.programs`
+
+## Notes
+- This migration intentionally keeps a temporary EWU Design `program_id` default for backward compatibility while application writes are updated in later T-series tasks.
+- After app writes are tenant-aware, remove static defaults and rely on explicit `program_id` plus RLS (`current_program()`) in T-03/T-04.

--- a/scripts/supabase-program-id-migration-t02-rollback.sql
+++ b/scripts/supabase-program-id-migration-t02-rollback.sql
@@ -1,0 +1,63 @@
+-- Tree/T-02 rollback: remove program_id migration artifacts
+-- Use only for emergency reversal.
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.idx_pathway_courses_program_pathway;
+DROP INDEX IF EXISTS public.idx_pathways_program_type_name;
+DROP INDEX IF EXISTS public.idx_release_time_program_year;
+DROP INDEX IF EXISTS public.idx_scheduled_courses_program_room;
+DROP INDEX IF EXISTS public.idx_scheduled_courses_program_faculty;
+DROP INDEX IF EXISTS public.idx_scheduled_courses_program_year_quarter;
+DROP INDEX IF EXISTS public.idx_academic_years_program_year;
+
+DROP INDEX IF EXISTS public.idx_pathway_courses_program_id;
+DROP INDEX IF EXISTS public.idx_pathways_program_id;
+DROP INDEX IF EXISTS public.idx_release_time_program_id;
+DROP INDEX IF EXISTS public.idx_scheduling_constraints_program_id;
+DROP INDEX IF EXISTS public.idx_faculty_preferences_program_id;
+DROP INDEX IF EXISTS public.idx_scheduled_courses_program_id;
+DROP INDEX IF EXISTS public.idx_faculty_program_id;
+DROP INDEX IF EXISTS public.idx_courses_program_id;
+DROP INDEX IF EXISTS public.idx_rooms_program_id;
+DROP INDEX IF EXISTS public.idx_academic_years_program_id;
+DROP INDEX IF EXISTS public.idx_departments_program_id;
+
+DO $$
+DECLARE
+    v_table TEXT;
+    v_tables TEXT[] := ARRAY[
+        'departments',
+        'academic_years',
+        'rooms',
+        'courses',
+        'faculty',
+        'scheduled_courses',
+        'faculty_preferences',
+        'scheduling_constraints',
+        'release_time',
+        'pathways',
+        'pathway_courses'
+    ];
+BEGIN
+    FOREACH v_table IN ARRAY v_tables
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT IF EXISTS %I', v_table, format('%s_program_id_fkey', v_table));
+
+        IF EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = v_table
+              AND column_name = 'program_id'
+        ) THEN
+            EXECUTE format('ALTER TABLE public.%I ALTER COLUMN program_id DROP DEFAULT', v_table);
+            EXECUTE format('ALTER TABLE public.%I DROP COLUMN IF EXISTS program_id', v_table);
+        END IF;
+    END LOOP;
+END $$;
+
+DROP INDEX IF EXISTS public.idx_programs_created_by;
+DROP TABLE IF EXISTS public.programs;
+
+COMMIT;

--- a/scripts/supabase-program-id-migration-t02.sql
+++ b/scripts/supabase-program-id-migration-t02.sql
@@ -1,0 +1,200 @@
+-- Tree/T-02: Add program_id columns and backfill existing EWU Design data
+-- Idempotent migration: safe to re-run.
+
+BEGIN;
+
+-- 1) Canonical tenant table
+CREATE TABLE IF NOT EXISTS public.programs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    code TEXT NOT NULL UNIQUE,
+    config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_by UUID REFERENCES auth.users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_programs_created_by ON public.programs(created_by);
+
+-- 2) Ensure EWU Design program exists
+INSERT INTO public.programs (name, code, config)
+VALUES ('EWU Design', 'ewu-design', '{"legacy_department_code":"DESN"}'::jsonb)
+ON CONFLICT (code) DO UPDATE
+SET
+    name = EXCLUDED.name,
+    updated_at = NOW();
+
+-- 3) Add program_id to scoped tables, backfill, enforce constraints and defaults
+DO $$
+DECLARE
+    v_program_id UUID;
+    v_table TEXT;
+    v_tables TEXT[] := ARRAY[
+        'departments',
+        'academic_years',
+        'rooms',
+        'courses',
+        'faculty',
+        'scheduled_courses',
+        'faculty_preferences',
+        'scheduling_constraints',
+        'release_time',
+        'pathways',
+        'pathway_courses'
+    ];
+    v_constraint_name TEXT;
+BEGIN
+    SELECT id INTO v_program_id
+    FROM public.programs
+    WHERE code = 'ewu-design'
+    LIMIT 1;
+
+    IF v_program_id IS NULL THEN
+        RAISE EXCEPTION 'Could not resolve EWU Design program id for code=ewu-design';
+    END IF;
+
+    -- 3a) Add nullable program_id columns first
+    FOREACH v_table IN ARRAY v_tables
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I ADD COLUMN IF NOT EXISTS program_id UUID', v_table);
+    END LOOP;
+
+    -- 3b) Backfill program_id values using existing hierarchy
+    UPDATE public.departments d
+    SET program_id = v_program_id
+    WHERE d.program_id IS NULL;
+
+    UPDATE public.academic_years ay
+    SET program_id = COALESCE(d.program_id, v_program_id)
+    FROM public.departments d
+    WHERE ay.department_id = d.id
+      AND ay.program_id IS NULL;
+
+    UPDATE public.rooms r
+    SET program_id = COALESCE(d.program_id, v_program_id)
+    FROM public.departments d
+    WHERE r.department_id = d.id
+      AND r.program_id IS NULL;
+
+    UPDATE public.courses c
+    SET program_id = COALESCE(d.program_id, v_program_id)
+    FROM public.departments d
+    WHERE c.department_id = d.id
+      AND c.program_id IS NULL;
+
+    UPDATE public.faculty f
+    SET program_id = COALESCE(d.program_id, v_program_id)
+    FROM public.departments d
+    WHERE f.department_id = d.id
+      AND f.program_id IS NULL;
+
+    UPDATE public.scheduling_constraints scn
+    SET program_id = COALESCE(d.program_id, v_program_id)
+    FROM public.departments d
+    WHERE scn.department_id = d.id
+      AND scn.program_id IS NULL;
+
+    UPDATE public.pathways p
+    SET program_id = COALESCE(d.program_id, v_program_id)
+    FROM public.departments d
+    WHERE p.department_id = d.id
+      AND p.program_id IS NULL;
+
+    UPDATE public.scheduled_courses sc
+    SET program_id = ay.program_id
+    FROM public.academic_years ay
+    WHERE sc.academic_year_id = ay.id
+      AND sc.program_id IS NULL;
+
+    UPDATE public.scheduled_courses sc
+    SET program_id = c.program_id
+    FROM public.courses c
+    WHERE sc.course_id = c.id
+      AND sc.program_id IS NULL;
+
+    UPDATE public.faculty_preferences fp
+    SET program_id = f.program_id
+    FROM public.faculty f
+    WHERE fp.faculty_id = f.id
+      AND fp.program_id IS NULL;
+
+    UPDATE public.release_time rt
+    SET program_id = f.program_id
+    FROM public.faculty f
+    WHERE rt.faculty_id = f.id
+      AND rt.program_id IS NULL;
+
+    UPDATE public.release_time rt
+    SET program_id = ay.program_id
+    FROM public.academic_years ay
+    WHERE rt.academic_year_id = ay.id
+      AND rt.program_id IS NULL;
+
+    UPDATE public.pathway_courses pc
+    SET program_id = p.program_id
+    FROM public.pathways p
+    WHERE pc.pathway_id = p.id
+      AND pc.program_id IS NULL;
+
+    UPDATE public.pathway_courses pc
+    SET program_id = c.program_id
+    FROM public.courses c
+    WHERE pc.course_id = c.id
+      AND pc.program_id IS NULL;
+
+    -- Any remaining NULLs are legacy stragglers; assign to EWU Design for safe transition.
+    FOREACH v_table IN ARRAY v_tables
+    LOOP
+        EXECUTE format('UPDATE public.%I SET program_id = %L::uuid WHERE program_id IS NULL', v_table, v_program_id::text);
+    END LOOP;
+
+    -- 3c) Temporary transition default so old inserts continue to work until app payloads are fully tenant-aware.
+    FOREACH v_table IN ARRAY v_tables
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I ALTER COLUMN program_id SET DEFAULT %L::uuid', v_table, v_program_id::text);
+    END LOOP;
+
+    -- 3d) Enforce non-null and FK constraints
+    FOREACH v_table IN ARRAY v_tables
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I ALTER COLUMN program_id SET NOT NULL', v_table);
+
+        v_constraint_name := format('%s_program_id_fkey', v_table);
+        IF NOT EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conname = v_constraint_name
+              AND conrelid = to_regclass('public.' || v_table)
+        ) THEN
+            EXECUTE format(
+                'ALTER TABLE public.%I ADD CONSTRAINT %I FOREIGN KEY (program_id) REFERENCES public.programs(id)',
+                v_table,
+                v_constraint_name
+            );
+        END IF;
+    END LOOP;
+END $$;
+
+-- 4) program_id indexes for every scoped table
+CREATE INDEX IF NOT EXISTS idx_departments_program_id ON public.departments(program_id);
+CREATE INDEX IF NOT EXISTS idx_academic_years_program_id ON public.academic_years(program_id);
+CREATE INDEX IF NOT EXISTS idx_rooms_program_id ON public.rooms(program_id);
+CREATE INDEX IF NOT EXISTS idx_courses_program_id ON public.courses(program_id);
+CREATE INDEX IF NOT EXISTS idx_faculty_program_id ON public.faculty(program_id);
+CREATE INDEX IF NOT EXISTS idx_scheduled_courses_program_id ON public.scheduled_courses(program_id);
+CREATE INDEX IF NOT EXISTS idx_faculty_preferences_program_id ON public.faculty_preferences(program_id);
+CREATE INDEX IF NOT EXISTS idx_scheduling_constraints_program_id ON public.scheduling_constraints(program_id);
+CREATE INDEX IF NOT EXISTS idx_release_time_program_id ON public.release_time(program_id);
+CREATE INDEX IF NOT EXISTS idx_pathways_program_id ON public.pathways(program_id);
+CREATE INDEX IF NOT EXISTS idx_pathway_courses_program_id ON public.pathway_courses(program_id);
+
+-- High-value query path indexes
+CREATE INDEX IF NOT EXISTS idx_academic_years_program_year ON public.academic_years(program_id, year);
+CREATE INDEX IF NOT EXISTS idx_scheduled_courses_program_year_quarter ON public.scheduled_courses(program_id, academic_year_id, quarter);
+CREATE INDEX IF NOT EXISTS idx_scheduled_courses_program_faculty ON public.scheduled_courses(program_id, faculty_id);
+CREATE INDEX IF NOT EXISTS idx_scheduled_courses_program_room ON public.scheduled_courses(program_id, room_id);
+CREATE INDEX IF NOT EXISTS idx_release_time_program_year ON public.release_time(program_id, academic_year_id);
+CREATE INDEX IF NOT EXISTS idx_pathways_program_type_name ON public.pathways(program_id, type, name);
+CREATE INDEX IF NOT EXISTS idx_pathway_courses_program_pathway ON public.pathway_courses(program_id, pathway_id);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add idempotent forward migration for tenantization: `scripts/supabase-program-id-migration-t02.sql`
- create `public.programs` and seed EWU Design (`code='ewu-design'`)
- add `program_id` to all scoped tables, backfill existing data, enforce `NOT NULL`
- add `program_id` foreign keys to `public.programs(id)` for each scoped table
- add `program_id` indexes across all scoped tables plus high-value query indexes
- keep temporary EWU default `program_id` for backward-compatible inserts during transition
- add emergency rollback script and migration runbook doc

## Validation
- npm test -- --runInBand
- npm run qa:onboarding

## Notes
- PR is stacked on T-01 design branch.

Closes #100
