### PR TITLE
[Tree/A-11] Add auth + edit-state integration tests (slim)

### DIFF
--- a/tests/auth-editstate.integration.test.js
+++ b/tests/auth-editstate.integration.test.js
@@ -1,0 +1,297 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SESSION_RECOVERY_DRAFT_KEY = 'pc_session_recovery_draft_v1';
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createLocation(url) {
+    const parsed = new URL(url);
+    return {
+        pathname: parsed.pathname,
+        search: parsed.search,
+        hash: parsed.hash,
+        replace: jest.fn()
+    };
+}
+
+function loadAuthGuardHarness({
+    url = 'https://program-command.local/index.html',
+    session = { user: { id: 'user-self' } },
+    user = { id: 'user-self', email: 'self@example.edu', role: 'chair' },
+    canResult = true,
+    presenceService = null
+} = {}) {
+    const source = fs.readFileSync(path.resolve(__dirname, '..', 'js/auth-guard.js'), 'utf8');
+
+    document.head.innerHTML = '';
+    document.body.innerHTML = `
+        <button id="editAction">Edit</button>
+        <button id="saveAction">Save</button>
+    `;
+
+    const domReadyHandlers = [];
+    const originalDocumentAddEventListener = document.addEventListener.bind(document);
+    const documentAddEventListenerSpy = jest
+        .spyOn(document, 'addEventListener')
+        .mockImplementation((eventName, handler, options) => {
+            if (eventName === 'DOMContentLoaded') {
+                domReadyHandlers.push(handler);
+                return;
+            }
+            return originalDocumentAddEventListener(eventName, handler, options);
+        });
+
+    const location = createLocation(url);
+    const listeners = {};
+
+    const authService = {
+        getSession: jest.fn().mockResolvedValue(session),
+        getUser: jest.fn().mockResolvedValue(user),
+        signOut: jest.fn().mockResolvedValue(true),
+        can: jest.fn(() => canResult)
+    };
+
+    const sandboxWindow = {
+        location,
+        AuthService: authService,
+        PresenceService: presenceService,
+        addEventListener: jest.fn((eventName, handler) => {
+            listeners[eventName] = handler;
+        }),
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        URLSearchParams
+    };
+    sandboxWindow.document = document;
+
+    const sandbox = {
+        window: sandboxWindow,
+        document,
+        console,
+        setTimeout,
+        clearTimeout,
+        setInterval,
+        clearInterval,
+        URLSearchParams,
+        module: { exports: {} },
+        exports: {}
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: 'js/auth-guard.js' });
+
+    return {
+        authService,
+        listeners,
+        location,
+        triggerDomReady: async () => {
+            expect(domReadyHandlers.length).toBeGreaterThan(0);
+            await domReadyHandlers[0]();
+            await flushPromises();
+        },
+        cleanup: () => {
+            documentAddEventListenerSpy.mockRestore();
+        }
+    };
+}
+
+function loadLoginHarness({
+    url = 'https://program-command.local/login.html?timeout=1&next=%2Findex.html',
+    authService
+} = {}) {
+    const source = fs.readFileSync(path.resolve(__dirname, '..', 'pages/login.js'), 'utf8');
+
+    document.head.innerHTML = '';
+    document.body.innerHTML = `
+        <div id="loginError" style="display:none"></div>
+        <form id="loginForm">
+            <input id="loginEmail" />
+            <input id="loginPassword" />
+            <button id="loginButton" type="submit">Sign in</button>
+        </form>
+    `;
+
+    const domReadyHandlers = [];
+    const originalDocumentAddEventListener = document.addEventListener.bind(document);
+    const documentAddEventListenerSpy = jest
+        .spyOn(document, 'addEventListener')
+        .mockImplementation((eventName, handler, options) => {
+            if (eventName === 'DOMContentLoaded') {
+                domReadyHandlers.push(handler);
+                return;
+            }
+            return originalDocumentAddEventListener(eventName, handler, options);
+        });
+
+    const location = createLocation(url);
+    const service = authService || {
+        getSession: jest.fn().mockResolvedValue(null),
+        signIn: jest.fn().mockResolvedValue({ user: { id: 'u1' } })
+    };
+
+    const sandboxWindow = {
+        location,
+        AuthService: service,
+        confirm: jest.fn(() => true),
+        localStorage,
+        setTimeout,
+        clearTimeout,
+        URLSearchParams
+    };
+    sandboxWindow.document = document;
+
+    const sandbox = {
+        window: sandboxWindow,
+        document,
+        localStorage,
+        console,
+        setTimeout,
+        clearTimeout,
+        URLSearchParams,
+        module: { exports: {} },
+        exports: {}
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: 'pages/login.js' });
+
+    return {
+        authService: service,
+        window: sandboxWindow,
+        location,
+        triggerDomReady: async () => {
+            expect(domReadyHandlers.length).toBeGreaterThan(0);
+            await domReadyHandlers[0]();
+            await flushPromises();
+        },
+        submitCredentials: async ({ email, password }) => {
+            document.getElementById('loginEmail').value = email;
+            document.getElementById('loginPassword').value = password;
+            const form = document.getElementById('loginForm');
+            form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+            await flushPromises();
+            await flushPromises();
+        },
+        cleanup: () => {
+            documentAddEventListenerSpy.mockRestore();
+        }
+    };
+}
+
+describe('Auth + Edit State Integration', () => {
+    afterEach(() => {
+        localStorage.clear();
+        document.head.innerHTML = '';
+        document.body.innerHTML = '';
+        jest.restoreAllMocks();
+    });
+
+    test('blocks chair users from admin-only onboarding route', async () => {
+        const presenceService = {
+            joinPage: jest.fn().mockResolvedValue(true),
+            onPresenceChange: jest.fn(),
+            onSaveNotice: jest.fn()
+        };
+
+        const harness = loadAuthGuardHarness({
+            url: 'https://program-command.local/pages/department-onboarding.html',
+            user: { id: 'chair-1', email: 'chair@example.edu', role: 'chair' },
+            canResult: false,
+            presenceService
+        });
+
+        await harness.triggerDomReady();
+
+        expect(harness.authService.can).toHaveBeenCalledWith(
+            'manage',
+            'system-config',
+            expect.objectContaining({ role: 'chair' })
+        );
+        expect(document.body.textContent).toContain('Access Denied');
+        expect(document.body.textContent).toContain('only admins can access Department Onboarding');
+        expect(presenceService.joinPage).not.toHaveBeenCalled();
+
+        harness.cleanup();
+    });
+
+    test('presence callbacks toggle edit-lock mode for concurrent editors', async () => {
+        let presenceCallback = null;
+        const presenceService = {
+            joinPage: jest.fn().mockResolvedValue(true),
+            onPresenceChange: jest.fn((_pageId, callback) => {
+                presenceCallback = callback;
+                callback([]);
+                return jest.fn();
+            }),
+            onSaveNotice: jest.fn(() => jest.fn()),
+            leavePage: jest.fn()
+        };
+
+        const harness = loadAuthGuardHarness({
+            url: 'https://program-command.local/index.html',
+            user: { id: 'self-user', email: 'self@example.edu', role: 'chair' },
+            canResult: true,
+            presenceService
+        });
+
+        await harness.triggerDomReady();
+
+        expect(document.getElementById('authSessionIndicator')).not.toBeNull();
+        expect(presenceService.joinPage).toHaveBeenCalledWith('/index.html');
+        expect(typeof presenceCallback).toBe('function');
+
+        presenceCallback([
+            {
+                userId: 'other-user',
+                user: 'other@example.edu',
+                since: new Date().toISOString()
+            }
+        ]);
+
+        expect(document.getElementById('editLockWarningBanner').style.display).toBe('flex');
+        expect(document.getElementById('editAction').disabled).toBe(true);
+
+        presenceCallback([]);
+        expect(document.getElementById('editAction').disabled).toBe(false);
+
+        harness.cleanup();
+    });
+
+    test('login timeout flow restores recovery draft after successful sign-in', async () => {
+        localStorage.setItem(SESSION_RECOVERY_DRAFT_KEY, JSON.stringify({
+            academicYear: '2026-27',
+            savedAt: '2026-02-28T20:00:00.000Z',
+            scheduleData: { Fall: [{ id: 'course-1' }] }
+        }));
+
+        const harness = loadLoginHarness();
+        await harness.triggerDomReady();
+
+        expect(document.getElementById('loginError').textContent).toContain('session expired due to inactivity');
+
+        await harness.submitCredentials({
+            email: 'chair@example.edu',
+            password: 'pw-123'
+        });
+
+        expect(harness.authService.signIn).toHaveBeenCalledWith('chair@example.edu', 'pw-123');
+        expect(harness.window.confirm).toHaveBeenCalledTimes(1);
+        expect(localStorage.getItem(SESSION_RECOVERY_DRAFT_KEY)).toBeNull();
+
+        const importedPayload = JSON.parse(localStorage.getItem('importedScheduleData'));
+        expect(importedPayload).toMatchObject({
+            academicYear: '2026-27',
+            source: 'session-recovery-draft'
+        });
+        expect(importedPayload.scheduleData).toEqual({ Fall: [{ id: 'course-1' }] });
+        expect(harness.location.replace).toHaveBeenCalledWith('/index.html');
+
+        harness.cleanup();
+    });
+});

--- a/tests/db-service.atomic-save.test.js
+++ b/tests/db-service.atomic-save.test.js
@@ -1,5 +1,11 @@
 describe('dbService.syncScheduledCoursesForAcademicYear', () => {
-    function createConfiguredService(rpcResult, rpcError = null) {
+    function createConfiguredService({
+        rpcResult = [],
+        rpcError = null,
+        authUserId = null,
+        latestSaveMetadata = null,
+        latestSaveMetadataError = null
+    } = {}) {
         jest.resetModules();
 
         const departmentsQuery = {
@@ -8,12 +14,31 @@ describe('dbService.syncScheduledCoursesForAcademicYear', () => {
             single: jest.fn().mockResolvedValue({ data: { id: 'dept-1' }, error: null })
         };
 
+        const scheduledCoursesQuery = {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            not: jest.fn().mockReturnThis(),
+            order: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            maybeSingle: jest.fn().mockResolvedValue({
+                data: latestSaveMetadata,
+                error: latestSaveMetadataError
+            })
+        };
+
         const client = {
             from: jest.fn((table) => {
                 if (table === 'departments') return departmentsQuery;
+                if (table === 'scheduled_courses') return scheduledCoursesQuery;
                 throw new Error(`Unexpected table: ${table}`);
             }),
-            rpc: jest.fn().mockResolvedValue({ data: rpcResult, error: rpcError })
+            rpc: jest.fn().mockResolvedValue({ data: rpcResult, error: rpcError }),
+            auth: {
+                getUser: jest.fn().mockResolvedValue({
+                    data: { user: authUserId ? { id: authUserId } : null },
+                    error: null
+                })
+            }
         };
 
         global.isSupabaseConfigured = jest.fn(() => true);
@@ -21,7 +46,7 @@ describe('dbService.syncScheduledCoursesForAcademicYear', () => {
         global.CURRENT_DEPARTMENT_CODE = 'DESN';
 
         const dbService = require('../js/db-service.js');
-        return { dbService, client };
+        return { dbService, client, scheduledCoursesQuery };
     }
 
     afterEach(() => {
@@ -31,9 +56,10 @@ describe('dbService.syncScheduledCoursesForAcademicYear', () => {
     });
 
     test('calls year-scoped schedule sync RPC and returns write counts', async () => {
-        const { dbService, client } = createConfiguredService([
-            { updated_count: 2, inserted_count: 3, deleted_count: 1 }
-        ]);
+        const { dbService, client } = createConfiguredService({
+            rpcResult: [{ updated_count: 2, inserted_count: 3, deleted_count: 1 }],
+            authUserId: 'user-123'
+        });
 
         const result = await dbService.syncScheduledCoursesForAcademicYear('ay-2026-27-id', [
             {
@@ -61,7 +87,7 @@ describe('dbService.syncScheduledCoursesForAcademicYear', () => {
                     time_slot: '10:00-12:20',
                     section: '001',
                     projected_enrollment: 24,
-                    updated_by: null,
+                    updated_by: 'user-123',
                     updated_at: null
                 }
             ]
@@ -74,7 +100,7 @@ describe('dbService.syncScheduledCoursesForAcademicYear', () => {
     });
 
     test('validates required academicYearId before calling RPC', async () => {
-        const { dbService, client } = createConfiguredService([]);
+        const { dbService, client } = createConfiguredService();
 
         await expect(
             dbService.syncScheduledCoursesForAcademicYear('', [])
@@ -84,10 +110,10 @@ describe('dbService.syncScheduledCoursesForAcademicYear', () => {
     });
 
     test('throws when RPC returns an error', async () => {
-        const { dbService } = createConfiguredService(
-            null,
-            { message: 'permission denied', code: '42501' }
-        );
+        const { dbService } = createConfiguredService({
+            rpcResult: null,
+            rpcError: { message: 'permission denied', code: '42501' }
+        });
 
         await expect(
             dbService.syncScheduledCoursesForAcademicYear('ay-2026-27-id', [])
@@ -95,7 +121,7 @@ describe('dbService.syncScheduledCoursesForAcademicYear', () => {
     });
 
     test('rejects invalid projected enrollment values', async () => {
-        const { dbService, client } = createConfiguredService([]);
+        const { dbService, client } = createConfiguredService();
 
         await expect(
             dbService.syncScheduledCoursesForAcademicYear('ay-2026-27-id', [
@@ -104,5 +130,39 @@ describe('dbService.syncScheduledCoursesForAcademicYear', () => {
         ).rejects.toThrow('records[0].projected_enrollment must be an integer when provided');
 
         expect(client.rpc).not.toHaveBeenCalled();
+    });
+
+    test('honors explicit updatedBy values on records', async () => {
+        const { dbService, client } = createConfiguredService({
+            authUserId: 'auth-user-default'
+        });
+
+        await dbService.syncScheduledCoursesForAcademicYear('ay-2026-27-id', [
+            {
+                courseId: 'course-1',
+                quarter: 'Fall',
+                updatedBy: 'override-user'
+            }
+        ]);
+
+        const payload = client.rpc.mock.calls[0][1];
+        expect(payload.p_records[0].updated_by).toBe('override-user');
+    });
+
+    test('getLatestScheduleSaveMetadata returns the most recent save attribution row', async () => {
+        const latestRow = {
+            updated_by: 'user-200',
+            updated_at: '2026-02-28T19:00:00.000Z'
+        };
+
+        const { dbService, scheduledCoursesQuery } = createConfiguredService({
+            latestSaveMetadata: latestRow
+        });
+
+        const result = await dbService.getLatestScheduleSaveMetadata('ay-2026-27-id');
+
+        expect(scheduledCoursesQuery.eq).toHaveBeenCalledWith('academic_year_id', 'ay-2026-27-id');
+        expect(scheduledCoursesQuery.order).toHaveBeenCalledWith('updated_at', { ascending: false });
+        expect(result).toEqual(latestRow);
     });
 });

--- a/tests/dirty-state-tracker.test.js
+++ b/tests/dirty-state-tracker.test.js
@@ -59,4 +59,21 @@ describe('DirtyStateTracker', () => {
         DirtyStateTracker.detachFromStateManager();
         expect(unsubscribe).toHaveBeenCalled();
     });
+
+    test('setPendingNavigation is tracked and cleared by markClean', () => {
+        DirtyStateTracker.markDirty('schedule:2026-27');
+        DirtyStateTracker.setPendingNavigation('/pages/workload-dashboard.html');
+
+        expect(DirtyStateTracker.getPendingNavigation()).toBe('/pages/workload-dashboard.html');
+
+        DirtyStateTracker.markClean();
+        expect(DirtyStateTracker.getPendingNavigation()).toBeNull();
+        expect(DirtyStateTracker.isDirty()).toBe(false);
+    });
+
+    test('rejects invalid onChange listeners and ignores invalid state managers', () => {
+        expect(() => DirtyStateTracker.onChange(null)).toThrow('DirtyStateTracker listener must be a function.');
+        expect(DirtyStateTracker.attachToStateManager(null)).toBe(false);
+        expect(DirtyStateTracker.attachToStateManager({})).toBe(false);
+    });
 });

--- a/tests/presence-service.test.js
+++ b/tests/presence-service.test.js
@@ -3,7 +3,9 @@ const path = require('path');
 const vm = require('vm');
 
 function createHarness({
-    user = { id: 'user-self', email: 'self@example.edu', role: 'chair' }
+    user = { id: 'user-self', email: 'self@example.edu', role: 'chair' },
+    fallbackAuthUser = null,
+    subscribeStatus = 'SUBSCRIBED'
 } = {}) {
     const source = fs.readFileSync(path.resolve(__dirname, '..', 'js/presence-service.js'), 'utf8');
 
@@ -16,7 +18,7 @@ function createHarness({
             return channel;
         }),
         subscribe: jest.fn((callback) => {
-            callback('SUBSCRIBED');
+            callback(subscribeStatus);
             return channel;
         }),
         track: jest.fn().mockResolvedValue({}),
@@ -30,7 +32,20 @@ function createHarness({
         channel: jest.fn(() => channel),
         removeChannel: jest.fn(),
         auth: {
-            getUser: jest.fn().mockResolvedValue({ data: { user }, error: null })
+            getUser: jest.fn().mockResolvedValue({
+                data: {
+                    user: fallbackAuthUser
+                        || (user
+                            ? {
+                                id: user.id,
+                                email: user.email,
+                                user_metadata: { role: user.role },
+                                app_metadata: { role: user.role }
+                            }
+                            : null)
+                },
+                error: null
+            })
         }
     };
 
@@ -194,5 +209,36 @@ describe('PresenceService', () => {
         }));
 
         unsubscribe();
+    });
+
+    test('joinPage returns false when no authenticated user is available', async () => {
+        const { PresenceService, channel, client } = createHarness({
+            user: null,
+            fallbackAuthUser: null
+        });
+
+        await expect(PresenceService.joinPage('/index.html')).resolves.toBe(false);
+        expect(channel.subscribe).not.toHaveBeenCalled();
+        expect(client.auth.getUser).toHaveBeenCalledTimes(1);
+    });
+
+    test('joinPage rejects when realtime channel returns CHANNEL_ERROR', async () => {
+        const { PresenceService } = createHarness({
+            subscribeStatus: 'CHANNEL_ERROR'
+        });
+
+        await expect(PresenceService.joinPage('/index.html')).rejects.toThrow(
+            'Presence subscribe failed for /index.html: CHANNEL_ERROR'
+        );
+    });
+
+    test('announceSave returns false when presence join cannot complete', async () => {
+        const { PresenceService, channel } = createHarness({
+            user: null,
+            fallbackAuthUser: null
+        });
+
+        await expect(PresenceService.announceSave('/index.html', { user_id: 'x' })).resolves.toBe(false);
+        expect(channel.send).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
## Summary
- add auth/edit-state integration tests for critical account and editing flows
- add integration coverage for:
  - chair blocked from admin onboarding route
  - two-user presence/edit-lock behavior
  - login timeout + recovery draft restore flow
- expand unit coverage for `presence-service`, `dirty-state-tracker`, and db atomic save attribution helpers

## Validation
- npm test -- tests/auth-editstate.integration.test.js --runInBand
- npm test -- --runInBand
- npm run qa:onboarding

## Notes
- This PR contains only the A-11 test commit and supersedes #135.

Closes #97
