### PR TITLE
feat(auth): secure OAuth identity linking on one user_id

### DIFF
--- a/docs/auth-identity-linking.md
+++ b/docs/auth-identity-linking.md
@@ -1,0 +1,55 @@
+# Auth Identity Linking (OAuth)
+
+This document defines provider linking with Supabase Auth as the source of truth.
+
+## Goals
+- One internal `user_id` per account.
+- Multiple login methods (password + OAuth) linked to that same `user_id`.
+- No implicit email-based account merges.
+
+## Security Contract
+- OAuth providers supported: `google`, `github`, `apple`.
+- PKCE flow is enabled in the Supabase client (`flowType: 'pkce'`).
+- Redirect target is restricted to same-origin `/login.html`.
+- Linking requires an authenticated existing session.
+- Provider subject ID is used as stable key; not email.
+
+## Schema
+Run:
+- `scripts/supabase-auth-identity-linking.sql`
+
+Creates:
+- `public.user_identities`
+
+Key constraints:
+- `UNIQUE (provider, provider_user_id)`
+- `UNIQUE (user_id, provider)`
+
+RLS policies:
+- authenticated users can only read/write their own identity rows.
+
+## Existing User Backfill
+Migration reads `auth.identities` and inserts provider rows into `public.user_identities`.
+
+Backfill behavior:
+- provider key is `sub` (preferred), then provider `id`, then identity row id fallback.
+- no merge by email.
+
+## User Flows
+### OAuth Sign-In
+- user clicks provider on `login.html`
+- app stores OAuth intent in session storage
+- callback handled on `login.html`
+- app syncs linked identity rows for returned provider session
+
+### Provider Linking (Existing Account)
+- user signs into existing account first
+- user clicks **Link login** in session indicator
+- app opens linking mode on `login.html?mode=link`
+- user clicks connect provider
+- callback binds provider identity to current authenticated user
+
+## Provider Quirks
+- Apple may return private relay email and may only return name/email once.
+- GitHub email can be missing/hidden/unverified.
+- stable provider subject ID is authoritative; email is informational only.

--- a/js/auth-guard.js
+++ b/js/auth-guard.js
@@ -402,6 +402,19 @@
             .auth-session-logout:hover {
                 background: #eef2f6;
             }
+            .auth-session-link {
+                border: 1px solid #b6d3ff;
+                border-radius: 999px;
+                background: #eef6ff;
+                color: #0b5394;
+                font-size: 12px;
+                font-weight: 700;
+                padding: 4px 10px;
+                cursor: pointer;
+            }
+            .auth-session-link:hover {
+                background: #e5f1ff;
+            }
             .edit-lock-warning-banner {
                 position: fixed;
                 top: 0;
@@ -490,8 +503,15 @@
             <span class="auth-session-email" title="${email}">${email}</span>
             <span class="auth-session-role">${role}</span>
             <span class="auth-session-presence" id="authSessionPresence">Presence offline</span>
+            <button type="button" class="auth-session-link" id="authSessionLinkLogin">Link login</button>
             <button type="button" class="auth-session-logout" id="authSessionLogout">Logout</button>
         `;
+
+        const linkLoginButton = document.getElementById('authSessionLinkLogin');
+        linkLoginButton.addEventListener('click', () => {
+            const next = encodeURIComponent(getCurrentPathWithQuery());
+            window.location.assign(`${loginUrl()}?mode=link&next=${next}`);
+        });
 
         const logoutButton = document.getElementById('authSessionLogout');
         logoutButton.addEventListener('click', async () => {

--- a/js/auth-service.js
+++ b/js/auth-service.js
@@ -10,6 +10,16 @@ const AuthService = (function() {
 
     const ROLE_ADMIN = 'admin';
     const ROLE_CHAIR = 'chair';
+    const OAUTH_INTENT_STORAGE_KEY = 'pc_oauth_intent_v1';
+    const OAUTH_INTENT_MAX_AGE_MS = 10 * 60 * 1000;
+
+    const OAUTH_SCOPE_MAP = {
+        google: 'openid email profile',
+        github: 'read:user user:email',
+        apple: 'name email'
+    };
+
+    const SUPPORTED_OAUTH_PROVIDERS = new Set(Object.keys(OAUTH_SCOPE_MAP));
 
     const ACTION_ALIASES = {
         read: 'read',
@@ -162,6 +172,206 @@ const AuthService = (function() {
         return ROLE_CHAIR;
     }
 
+    function normalizeOAuthProvider(rawProvider) {
+        const provider = String(rawProvider || '').trim().toLowerCase();
+        if (!SUPPORTED_OAUTH_PROVIDERS.has(provider)) {
+            return null;
+        }
+        return provider;
+    }
+
+    function requireOAuthProvider(rawProvider) {
+        const provider = normalizeOAuthProvider(rawProvider);
+        if (!provider) {
+            throw new Error('Unsupported OAuth provider. Expected one of: google, github, apple.');
+        }
+        return provider;
+    }
+
+    function getOAuthScopes(provider) {
+        return OAUTH_SCOPE_MAP[provider] || '';
+    }
+
+    function randomNonce() {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+            return crypto.randomUUID();
+        }
+        return `nonce-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    }
+
+    function safeSessionStorage() {
+        if (typeof window === 'undefined' || !window.sessionStorage) {
+            return null;
+        }
+        return window.sessionStorage;
+    }
+
+    function writeOAuthIntent(intent) {
+        const store = safeSessionStorage();
+        if (!store) return;
+        try {
+            store.setItem(OAUTH_INTENT_STORAGE_KEY, JSON.stringify(intent));
+        } catch (error) {
+            // ignore storage failures and continue with best-effort OAuth flow
+        }
+    }
+
+    function readOAuthIntent() {
+        const store = safeSessionStorage();
+        if (!store) return null;
+        try {
+            const raw = store.getItem(OAUTH_INTENT_STORAGE_KEY);
+            if (!raw) return null;
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== 'object') return null;
+            const createdAtMs = Date.parse(parsed.createdAt || '');
+            if (!Number.isFinite(createdAtMs) || (Date.now() - createdAtMs) > OAUTH_INTENT_MAX_AGE_MS) {
+                store.removeItem(OAUTH_INTENT_STORAGE_KEY);
+                return null;
+            }
+            return parsed;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function clearOAuthIntent() {
+        const store = safeSessionStorage();
+        if (!store) return;
+        try {
+            store.removeItem(OAUTH_INTENT_STORAGE_KEY);
+        } catch (error) {
+            // ignore storage failures
+        }
+    }
+
+    function resolveCurrentPathWithQuery() {
+        if (typeof window === 'undefined' || !window.location) {
+            return '/index.html';
+        }
+        return `${window.location.pathname}${window.location.search}`;
+    }
+
+    function resolveOAuthRedirectUrl(nextPath = '') {
+        if (typeof window === 'undefined' || !window.location) {
+            return '/login.html';
+        }
+
+        const redirectUrl = new URL('/login.html', window.location.origin);
+        if (nextPath) {
+            redirectUrl.searchParams.set('next', nextPath);
+        }
+        return redirectUrl.toString();
+    }
+
+    function hasOAuthCallbackParams() {
+        if (typeof window === 'undefined' || !window.location) return false;
+        const params = new URLSearchParams(window.location.search || '');
+        if (params.has('code') || params.has('error') || params.has('error_description')) {
+            return true;
+        }
+        const hash = String(window.location.hash || '');
+        return hash.includes('access_token=') || hash.includes('id_token=') || hash.includes('refresh_token=');
+    }
+
+    function cleanOAuthCallbackUrl() {
+        if (typeof window === 'undefined' || !window.location || !window.history || !window.history.replaceState) {
+            return;
+        }
+
+        const url = new URL(window.location.href);
+        const removableKeys = ['code', 'state', 'error', 'error_description'];
+        removableKeys.forEach((key) => url.searchParams.delete(key));
+        url.hash = '';
+        const title = (typeof document !== 'undefined' && typeof document.title === 'string') ? document.title : '';
+        window.history.replaceState({}, title, `${url.pathname}${url.search}`);
+    }
+
+    function normalizeProviderIdentity(identity) {
+        if (!identity || typeof identity !== 'object') return null;
+        const provider = normalizeOAuthProvider(identity.provider);
+        if (!provider) return null;
+
+        const identityData = identity.identity_data || {};
+        const providerUserId =
+            identityData.sub ||
+            identityData.id ||
+            identity.id ||
+            null;
+
+        if (!providerUserId) return null;
+
+        return {
+            provider,
+            providerUserId: String(providerUserId),
+            providerEmail: identityData.email || identityData.preferred_username || null,
+            identityData
+        };
+    }
+
+    function extractProviderIdentities(user) {
+        if (!user || !Array.isArray(user.identities)) return [];
+        return user.identities
+            .map((identity) => normalizeProviderIdentity(identity))
+            .filter(Boolean);
+    }
+
+    async function upsertUserIdentityMappings(user, identities) {
+        if (!user?.id || !Array.isArray(identities) || identities.length === 0) {
+            return [];
+        }
+
+        const client = getClientOrThrow();
+        if (typeof client.from !== 'function') {
+            return [];
+        }
+
+        const payload = identities.map((identity) => ({
+            user_id: user.id,
+            provider: identity.provider,
+            provider_user_id: identity.providerUserId,
+            provider_email: identity.providerEmail,
+            identity_data: identity.identityData || {}
+        }));
+
+        const { data, error } = await client
+            .from('user_identities')
+            .upsert(payload, { onConflict: 'provider,provider_user_id' })
+            .select('provider, provider_user_id, provider_email, linked_at, updated_at');
+
+        if (error) throw error;
+        return data || [];
+    }
+
+    async function syncCurrentUserIdentityMappings(options = {}) {
+        const user = await getUser();
+        if (!user?.id) {
+            throw new Error('You must be signed in before linking a provider.');
+        }
+
+        const expectedProvider = options.expectedProvider
+            ? requireOAuthProvider(options.expectedProvider)
+            : null;
+
+        const identities = extractProviderIdentities(user);
+        if (!identities.length) {
+            if (expectedProvider) {
+                throw new Error(`No ${expectedProvider} identity found in the current session.`);
+            }
+            return [];
+        }
+
+        const filtered = expectedProvider
+            ? identities.filter((identity) => identity.provider === expectedProvider)
+            : identities;
+
+        if (expectedProvider && filtered.length === 0) {
+            throw new Error(`No ${expectedProvider} identity found in the current session.`);
+        }
+
+        return upsertUserIdentityMappings(user, filtered);
+    }
+
     function normalizeAction(rawAction) {
         const action = String(rawAction || '').trim().toLowerCase();
         return ACTION_ALIASES[action] || null;
@@ -258,6 +468,77 @@ const AuthService = (function() {
         };
     }
 
+    async function beginOAuthSignIn(provider, options = {}) {
+        if (!isConfigured()) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const normalizedProvider = requireOAuthProvider(provider);
+        const nextPath = String(options.nextPath || '').trim() || '/index.html';
+        const intent = {
+            mode: 'signin',
+            provider: normalizedProvider,
+            nextPath,
+            nonce: randomNonce(),
+            createdAt: new Date().toISOString()
+        };
+        writeOAuthIntent(intent);
+
+        const client = getClientOrThrow();
+        const { data, error } = await client.auth.signInWithOAuth({
+            provider: normalizedProvider,
+            options: {
+                redirectTo: resolveOAuthRedirectUrl(nextPath),
+                scopes: getOAuthScopes(normalizedProvider)
+            }
+        });
+
+        if (error) {
+            clearOAuthIntent();
+            throw error;
+        }
+
+        return data || null;
+    }
+
+    async function beginOAuthLink(provider, options = {}) {
+        if (!isConfigured()) {
+            throw new Error('Supabase is not configured.');
+        }
+
+        const session = await getSession();
+        if (!session?.user?.id) {
+            throw new Error('Sign in with your existing account before linking a provider.');
+        }
+
+        const normalizedProvider = requireOAuthProvider(provider);
+        const nextPath = String(options.nextPath || '').trim() || resolveCurrentPathWithQuery();
+        const intent = {
+            mode: 'link',
+            provider: normalizedProvider,
+            nextPath,
+            nonce: randomNonce(),
+            createdAt: new Date().toISOString()
+        };
+        writeOAuthIntent(intent);
+
+        const client = getClientOrThrow();
+        const { data, error } = await client.auth.signInWithOAuth({
+            provider: normalizedProvider,
+            options: {
+                redirectTo: resolveOAuthRedirectUrl(nextPath),
+                scopes: getOAuthScopes(normalizedProvider)
+            }
+        });
+
+        if (error) {
+            clearOAuthIntent();
+            throw error;
+        }
+
+        return data || null;
+    }
+
     async function signOut() {
         if (!isConfigured()) {
             return true;
@@ -296,6 +577,118 @@ const AuthService = (function() {
         const user = normalizeUser(data?.user || null);
         cachedNormalizedUser = user;
         return user;
+    }
+
+    async function getLinkedIdentities() {
+        if (!isConfigured()) {
+            return [];
+        }
+
+        const user = await getUser();
+        if (!user?.id) {
+            return [];
+        }
+
+        const client = getClientOrThrow();
+        if (typeof client.from !== 'function') {
+            return [];
+        }
+
+        const { data, error } = await client
+            .from('user_identities')
+            .select('provider, provider_user_id, provider_email, linked_at, updated_at')
+            .eq('user_id', user.id)
+            .order('provider', { ascending: true });
+
+        if (error) throw error;
+        return data || [];
+    }
+
+    async function linkCurrentSessionIdentity(provider) {
+        const normalizedProvider = requireOAuthProvider(provider);
+        return syncCurrentUserIdentityMappings({
+            expectedProvider: normalizedProvider
+        });
+    }
+
+    async function completeOAuthRedirect() {
+        if (!isConfigured()) {
+            return { handled: false, success: false, error: 'Supabase is not configured.' };
+        }
+
+        const intent = readOAuthIntent();
+        const hasCallback = hasOAuthCallbackParams();
+
+        if (!intent && !hasCallback) {
+            return { handled: false, success: false };
+        }
+
+        const params = new URLSearchParams((typeof window !== 'undefined' && window.location && window.location.search) || '');
+        const providerError = params.get('error_description') || params.get('error');
+        if (providerError) {
+            clearOAuthIntent();
+            cleanOAuthCallbackUrl();
+            return {
+                handled: true,
+                mode: intent?.mode || 'signin',
+                success: false,
+                error: providerError
+            };
+        }
+
+        const client = getClientOrThrow();
+        const code = params.get('code');
+        if (code && client.auth && typeof client.auth.exchangeCodeForSession === 'function') {
+            const { error } = await client.auth.exchangeCodeForSession(code);
+            if (error) {
+                clearOAuthIntent();
+                cleanOAuthCallbackUrl();
+                return {
+                    handled: true,
+                    mode: intent?.mode || 'signin',
+                    success: false,
+                    error: error.message || 'OAuth sign-in failed.'
+                };
+            }
+        }
+
+        const session = await getSession();
+        if (!session?.user) {
+            clearOAuthIntent();
+            cleanOAuthCallbackUrl();
+            return {
+                handled: true,
+                mode: intent?.mode || 'signin',
+                success: false,
+                error: 'Authentication session was not established.'
+            };
+        }
+
+        let linkedIdentities = [];
+        try {
+            linkedIdentities = await syncCurrentUserIdentityMappings({
+                expectedProvider: intent?.provider || null
+            });
+        } catch (error) {
+            clearOAuthIntent();
+            cleanOAuthCallbackUrl();
+            return {
+                handled: true,
+                mode: intent?.mode || 'signin',
+                success: false,
+                error: error?.message || 'Identity linking failed.'
+            };
+        }
+
+        clearOAuthIntent();
+        cleanOAuthCallbackUrl();
+        return {
+            handled: true,
+            mode: intent?.mode || 'signin',
+            success: true,
+            nextPath: intent?.nextPath || '/index.html',
+            linkedIdentities
+        };
     }
 
     function onAuthStateChange(callback) {
@@ -338,9 +731,14 @@ const AuthService = (function() {
         init,
         signUp,
         signIn,
+        beginOAuthSignIn,
+        beginOAuthLink,
+        completeOAuthRedirect,
         signOut,
         getSession,
         getUser,
+        getLinkedIdentities,
+        linkCurrentSessionIdentity,
         can,
         onAuthStateChange,
         _resetForTests: resetForTests

--- a/js/supabase-config.js
+++ b/js/supabase-config.js
@@ -48,7 +48,14 @@ function initSupabase() {
         return null;
     }
 
-    supabaseClient = supabaseSdk.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    supabaseClient = supabaseSdk.createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+        auth: {
+            flowType: 'pkce',
+            detectSessionInUrl: true,
+            persistSession: true,
+            autoRefreshToken: true
+        }
+    });
     supabase = supabaseClient; // Set global reference
     // Expose client for module and non-module scripts.
     window.supabaseClient = supabaseClient;

--- a/login.html
+++ b/login.html
@@ -90,6 +90,92 @@
             background: #8a001d;
         }
 
+        .oauth-divider {
+            margin: 4px 0;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            color: #57606a;
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .oauth-divider::before,
+        .oauth-divider::after {
+            content: '';
+            flex: 1;
+            height: 1px;
+            background: #d8dee4;
+        }
+
+        .oauth-buttons {
+            display: grid;
+            gap: 8px;
+        }
+
+        .oauth-button {
+            border: 1px solid #d0d7de;
+            background: #fff;
+            color: #1f2328;
+            border-radius: 8px;
+            padding: 10px 12px;
+            font-size: 14px;
+            font-weight: 600;
+            text-align: center;
+            cursor: pointer;
+        }
+
+        .oauth-button:hover {
+            background: #f6f8fa;
+        }
+
+        .linking-panel {
+            margin-top: 14px;
+            border: 1px solid #d0d7de;
+            border-radius: 8px;
+            background: #f6f8fa;
+            padding: 12px;
+            display: none;
+        }
+
+        .linking-panel.visible {
+            display: block;
+        }
+
+        .linking-title {
+            margin: 0 0 6px;
+            font-size: 13px;
+            font-weight: 700;
+            color: #1f2328;
+        }
+
+        .linking-copy {
+            margin: 0 0 8px;
+            font-size: 12px;
+            color: #57606a;
+            line-height: 1.4;
+        }
+
+        .linked-providers {
+            margin: 8px 0 0;
+            padding: 0;
+            list-style: none;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+
+        .linked-providers li {
+            border: 1px solid #b6d3ff;
+            background: #eef6ff;
+            color: #0b5394;
+            border-radius: 999px;
+            padding: 2px 8px;
+            font-size: 12px;
+            font-weight: 600;
+        }
+
         .login-error {
             display: none;
             margin-top: 12px;
@@ -130,6 +216,21 @@
 
             <button type="submit" class="login-button" id="loginButton">Sign in</button>
         </form>
+
+        <div class="oauth-divider">or continue with</div>
+        <div class="oauth-buttons">
+            <button type="button" class="oauth-button" id="oauthGoogleButton" data-provider="google">Continue with Google</button>
+            <button type="button" class="oauth-button" id="oauthGithubButton" data-provider="github">Continue with GitHub</button>
+            <button type="button" class="oauth-button" id="oauthAppleButton" data-provider="apple">Continue with Apple</button>
+        </div>
+
+        <section class="linking-panel" id="linkingPanel" aria-live="polite">
+            <h2 class="linking-title">Link Additional Login Methods</h2>
+            <p class="linking-copy">
+                Link providers only after signing into your existing account first. Accounts are not auto-merged by email.
+            </p>
+            <ul class="linked-providers" id="linkedProvidersList"></ul>
+        </section>
 
         <div class="login-error" id="loginError" role="alert"></div>
         <p class="login-help">If you need access, ask an admin for an invite.</p>

--- a/pages/login.js
+++ b/pages/login.js
@@ -5,21 +5,46 @@
     'use strict';
 
     const SESSION_RECOVERY_DRAFT_KEY = 'pc_session_recovery_draft_v1';
+    const LINK_MODE = 'link';
+
+    function getParams() {
+        return new URLSearchParams(window.location.search);
+    }
+
+    function normalizeNextPath(nextValue) {
+        const next = String(nextValue || '').trim();
+        if (!next) return 'index.html';
+        if (/^https?:\/\//i.test(next) || next.startsWith('//')) {
+            return 'index.html';
+        }
+        return next;
+    }
 
     function getNextPath() {
-        const params = new URLSearchParams(window.location.search);
-        const next = params.get('next');
-        return next || 'index.html';
+        const params = getParams();
+        return normalizeNextPath(params.get('next'));
+    }
+
+    function getMode() {
+        const params = getParams();
+        const mode = String(params.get('mode') || '').toLowerCase();
+        return mode === LINK_MODE ? LINK_MODE : 'signin';
+    }
+
+    function isLinkMode() {
+        return getMode() === LINK_MODE;
     }
 
     function showError(message) {
         const errorBox = document.getElementById('loginError');
+        if (!errorBox) return;
         errorBox.textContent = message;
         errorBox.style.display = 'block';
     }
 
     function clearError() {
         const errorBox = document.getElementById('loginError');
+        if (!errorBox) return;
         errorBox.textContent = '';
         errorBox.style.display = 'none';
     }
@@ -31,16 +56,29 @@
         button.textContent = isSubmitting ? 'Signing in...' : 'Sign in';
     }
 
-    async function redirectIfAlreadyAuthenticated() {
-        if (!window.AuthService) return;
-        const session = await window.AuthService.getSession();
-        if (session) {
-            window.location.replace(getNextPath());
-        }
+    function setOAuthBusy(isBusy, provider = null) {
+        const buttons = Array.from(document.querySelectorAll('.oauth-button'));
+        buttons.forEach((button) => {
+            if (!button.dataset.defaultLabel) {
+                button.dataset.defaultLabel = button.textContent;
+            }
+            button.disabled = isBusy;
+            if (!isBusy) {
+                button.textContent = button.dataset.defaultLabel;
+                return;
+            }
+
+            const buttonProvider = String(button.getAttribute('data-provider') || '').toLowerCase();
+            if (provider && buttonProvider === provider) {
+                button.textContent = 'Redirecting...';
+            } else {
+                button.textContent = button.dataset.defaultLabel;
+            }
+        });
     }
 
     function maybeShowTimeoutMessage() {
-        const params = new URLSearchParams(window.location.search);
+        const params = getParams();
         if (params.get('timeout') === '1') {
             showError('Your session expired due to inactivity. Sign in to continue.');
         }
@@ -73,13 +111,100 @@
         localStorage.removeItem(SESSION_RECOVERY_DRAFT_KEY);
     }
 
+    function renderLinkedProviders(identities) {
+        const list = document.getElementById('linkedProvidersList');
+        if (!list) return;
+        list.innerHTML = '';
+        const providers = Array.isArray(identities) ? identities : [];
+        if (!providers.length) {
+            const li = document.createElement('li');
+            li.textContent = 'No linked providers yet';
+            list.appendChild(li);
+            return;
+        }
+
+        providers.forEach((identity) => {
+            const li = document.createElement('li');
+            const provider = String(identity?.provider || '').trim();
+            if (!provider) return;
+            li.textContent = provider.charAt(0).toUpperCase() + provider.slice(1);
+            list.appendChild(li);
+        });
+    }
+
+    function applyLinkModeUi() {
+        const heading = document.getElementById('loginHeading');
+        const subtitle = document.querySelector('.login-subtitle');
+        const form = document.getElementById('loginForm');
+        const panel = document.getElementById('linkingPanel');
+
+        if (heading) heading.textContent = 'Connect login provider';
+        if (subtitle) subtitle.textContent = 'Add Google, GitHub, or Apple to your signed-in account.';
+        if (form) form.style.display = 'none';
+        if (panel) panel.classList.add('visible');
+    }
+
+    function attachOAuthHandlers(mode) {
+        const buttons = Array.from(document.querySelectorAll('.oauth-button'));
+        buttons.forEach((button) => {
+            button.addEventListener('click', async () => {
+                clearError();
+                const provider = String(button.getAttribute('data-provider') || '').trim().toLowerCase();
+                if (!provider) {
+                    showError('Missing OAuth provider.');
+                    return;
+                }
+
+                try {
+                    setOAuthBusy(true, provider);
+                    if (mode === LINK_MODE) {
+                        await window.AuthService.beginOAuthLink(provider, { nextPath: getNextPath() });
+                    } else {
+                        await window.AuthService.beginOAuthSignIn(provider, { nextPath: getNextPath() });
+                    }
+                } catch (error) {
+                    setOAuthBusy(false);
+                    const message = error?.message || 'OAuth sign-in failed. Try again.';
+                    showError(message);
+                }
+            });
+        });
+    }
+
+    async function completeOAuthIfNeeded() {
+        if (!window.AuthService || typeof window.AuthService.completeOAuthRedirect !== 'function') {
+            return false;
+        }
+
+        const result = await window.AuthService.completeOAuthRedirect();
+        if (!result?.handled) {
+            return false;
+        }
+
+        if (!result.success) {
+            const message = result.error || 'OAuth sign-in failed. Please try again.';
+            showError(message);
+            return true;
+        }
+
+        if (result.mode !== LINK_MODE) {
+            handleRecoveryDraftPreference();
+        }
+
+        const destination = normalizeNextPath(result.nextPath || getNextPath());
+        window.location.replace(destination);
+        return true;
+    }
+
     async function handleSubmit(event) {
         event.preventDefault();
         clearError();
         setSubmitting(true);
 
-        const email = document.getElementById('loginEmail').value.trim();
-        const password = document.getElementById('loginPassword').value;
+        const emailInput = document.getElementById('loginEmail');
+        const passwordInput = document.getElementById('loginPassword');
+        const email = emailInput ? emailInput.value.trim() : '';
+        const password = passwordInput ? passwordInput.value : '';
 
         try {
             await window.AuthService.signIn(email, password);
@@ -100,9 +225,36 @@
         }
 
         maybeShowTimeoutMessage();
-        await redirectIfAlreadyAuthenticated();
+        attachOAuthHandlers(getMode());
+
+        const oauthHandled = await completeOAuthIfNeeded();
+        if (oauthHandled) {
+            return;
+        }
+
+        const session = await window.AuthService.getSession();
+
+        if (isLinkMode()) {
+            if (!session?.user?.id) {
+                showError('Sign in with your existing account first, then use Link login.');
+            } else {
+                applyLinkModeUi();
+                try {
+                    const identities = await window.AuthService.getLinkedIdentities();
+                    renderLinkedProviders(identities);
+                } catch (error) {
+                    showError(error?.message || 'Unable to load linked providers.');
+                }
+            }
+        } else if (session) {
+            window.location.replace(getNextPath());
+            return;
+        }
+
         const form = document.getElementById('loginForm');
-        form.addEventListener('submit', handleSubmit);
+        if (form) {
+            form.addEventListener('submit', handleSubmit);
+        }
     }
 
     document.addEventListener('DOMContentLoaded', initLoginPage);

--- a/scripts/supabase-auth-identity-linking.sql
+++ b/scripts/supabase-auth-identity-linking.sql
@@ -1,0 +1,91 @@
+-- Auth identity linking table and policies
+-- Goal: maintain one internal user_id and allow multiple linked OAuth identities.
+-- Idempotent: safe to re-run.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.user_identities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    provider TEXT NOT NULL,
+    provider_user_id TEXT NOT NULL,
+    provider_email TEXT,
+    identity_data JSONB NOT NULL DEFAULT '{}'::jsonb,
+    linked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT user_identities_provider_check CHECK (provider IN ('google', 'github', 'apple')),
+    CONSTRAINT user_identities_provider_subject_unique UNIQUE (provider, provider_user_id),
+    CONSTRAINT user_identities_user_provider_unique UNIQUE (user_id, provider)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_identities_user_id ON public.user_identities(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_identities_provider_subject ON public.user_identities(provider, provider_user_id);
+
+CREATE OR REPLACE FUNCTION public.touch_user_identities_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at := NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_touch_user_identities_updated_at ON public.user_identities;
+CREATE TRIGGER trg_touch_user_identities_updated_at
+    BEFORE UPDATE ON public.user_identities
+    FOR EACH ROW
+    EXECUTE FUNCTION public.touch_user_identities_updated_at();
+
+ALTER TABLE public.user_identities ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "user_identities_select_own" ON public.user_identities;
+CREATE POLICY "user_identities_select_own"
+    ON public.user_identities
+    FOR SELECT TO authenticated
+    USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "user_identities_insert_own" ON public.user_identities;
+CREATE POLICY "user_identities_insert_own"
+    ON public.user_identities
+    FOR INSERT TO authenticated
+    WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "user_identities_update_own" ON public.user_identities;
+CREATE POLICY "user_identities_update_own"
+    ON public.user_identities
+    FOR UPDATE TO authenticated
+    USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "user_identities_delete_own" ON public.user_identities;
+CREATE POLICY "user_identities_delete_own"
+    ON public.user_identities
+    FOR DELETE TO authenticated
+    USING (auth.uid() = user_id);
+
+-- Backfill from Supabase auth identities for supported OAuth providers.
+-- Uses provider subject/id as stable key. No email-based merges.
+INSERT INTO public.user_identities (
+    user_id,
+    provider,
+    provider_user_id,
+    provider_email,
+    identity_data,
+    linked_at,
+    updated_at
+)
+SELECT
+    i.user_id,
+    lower(i.provider) AS provider,
+    COALESCE(i.identity_data->>'sub', i.identity_data->>'id', i.id::text) AS provider_user_id,
+    i.identity_data->>'email' AS provider_email,
+    COALESCE(i.identity_data, '{}'::jsonb) AS identity_data,
+    COALESCE(i.created_at, NOW()) AS linked_at,
+    COALESCE(i.updated_at, NOW()) AS updated_at
+FROM auth.identities i
+WHERE lower(i.provider) IN ('google', 'github', 'apple')
+  AND COALESCE(i.identity_data->>'sub', i.identity_data->>'id', i.id::text) IS NOT NULL
+ON CONFLICT (provider, provider_user_id) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add secure OAuth sign-in + provider-linking flows using Supabase Auth as source of truth
- keep one internal user and map provider identities in `public.user_identities`
- add explicit authenticated linking flow (no automatic email merge)
- wire login UI for Google/GitHub/Apple sign-in and link mode callbacks
- add migration SQL + docs for backfill and provider behavior notes

## Security notes
- uses PKCE auth flow in Supabase client
- callback redirects restricted to same-origin `/login.html`
- linking requires existing authenticated session
- provider subject (`sub`/provider id) used as stable identity key

## Validation
- `npm test -- --runInBand`
- `npm run qa:onboarding`

Closes #3
