### PR TITLE
feat(supabase): implement current_program() helper for tenant RLS

### DIFF
--- a/docs/supabase-current-program-helper-t04.md
+++ b/docs/supabase-current-program-helper-t04.md
@@ -1,0 +1,49 @@
+# T-04 Current Program Helper
+
+Issue: [#102](https://github.com/sicxz/program-command/issues/102)
+
+## Migration
+Run:
+
+- `scripts/supabase-current-program-helper-t04.sql`
+
+This migration adds:
+
+- `public.user_programs` mapping table (`user_id` ↔ `program_id`)
+- `public.jwt_program_id()` helper (safe JWT claim parse)
+- `public.current_program()` helper for RLS policy usage
+- metadata sync triggers so `auth.users.raw_app_meta_data.program_id` tracks membership defaults
+
+## Behavior
+
+`public.current_program()` resolves in order:
+
+1. `auth.jwt() -> app_metadata.program_id` (preferred)
+2. fallback query from `public.user_programs` for `auth.uid()`
+
+It returns `NULL` for unauthenticated calls.
+
+## Verification Queries
+
+Run these in Supabase SQL editor after migration:
+
+```sql
+-- Confirm helper functions exist and are STABLE
+select proname, provolatile
+from pg_proc
+where proname in ('jwt_program_id', 'current_program', 'is_platform_admin')
+order by proname;
+
+-- Should return either a UUID (if claim or fallback mapping exists) or NULL
+select public.current_program();
+
+-- Validate fallback mapping table
+select user_id, program_id, role, is_default
+from public.user_programs
+order by updated_at desc
+limit 20;
+```
+
+Expected `provolatile`:
+
+- `s` for all helper functions above (`STABLE`).

--- a/scripts/supabase-current-program-helper-t04.sql
+++ b/scripts/supabase-current-program-helper-t04.sql
@@ -1,0 +1,182 @@
+-- Tree/T-04: Add current_program() SQL helper (JWT claim + user_programs fallback)
+-- Idempotent migration: safe to re-run.
+
+BEGIN;
+
+-- Ensure tenant root table exists (created in T-02, included here for safety).
+CREATE TABLE IF NOT EXISTS public.programs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name TEXT NOT NULL,
+    code TEXT NOT NULL UNIQUE,
+    config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_by UUID REFERENCES auth.users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- User-to-program membership map used as current_program() fallback.
+CREATE TABLE IF NOT EXISTS public.user_programs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    program_id UUID NOT NULL REFERENCES public.programs(id) ON DELETE CASCADE,
+    role TEXT NOT NULL DEFAULT 'member',
+    is_default BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT user_programs_user_program_unique UNIQUE (user_id, program_id),
+    CONSTRAINT user_programs_role_check CHECK (role IN ('member', 'chair', 'program_admin', 'platform_admin'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_programs_user_id ON public.user_programs(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_programs_program_id ON public.user_programs(program_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_programs_single_default
+    ON public.user_programs(user_id)
+    WHERE is_default;
+
+CREATE OR REPLACE FUNCTION public.touch_user_programs_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at := NOW();
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_touch_user_programs_updated_at ON public.user_programs;
+CREATE TRIGGER trg_touch_user_programs_updated_at
+    BEFORE UPDATE ON public.user_programs
+    FOR EACH ROW
+    EXECUTE FUNCTION public.touch_user_programs_updated_at();
+
+-- Helper: parse app_metadata.program_id claim safely from JWT.
+CREATE OR REPLACE FUNCTION public.jwt_program_id()
+RETURNS UUID
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT CASE
+        WHEN auth.uid() IS NULL THEN NULL
+        WHEN COALESCE(auth.jwt() -> 'app_metadata' ->> 'program_id', '') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+            THEN (auth.jwt() -> 'app_metadata' ->> 'program_id')::uuid
+        ELSE NULL
+    END;
+$$;
+
+-- Main helper for tenant-scoped RLS checks.
+-- Preferred source: JWT app_metadata.program_id.
+-- Fallback source: public.user_programs by auth.uid().
+CREATE OR REPLACE FUNCTION public.current_program()
+RETURNS UUID
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT COALESCE(
+        public.jwt_program_id(),
+        (
+            SELECT up.program_id
+            FROM public.user_programs up
+            WHERE up.user_id = auth.uid()
+            ORDER BY up.is_default DESC, up.updated_at DESC, up.created_at DESC
+            LIMIT 1
+        )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_platform_admin()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT auth.uid() IS NOT NULL
+      AND lower(COALESCE(
+            auth.jwt() -> 'app_metadata' ->> 'role',
+            auth.jwt() ->> 'role',
+            ''
+      )) IN ('admin', 'platform_admin');
+$$;
+
+-- Keep auth.users.raw_app_meta_data.program_id in sync with default user_programs membership.
+-- This updates future JWTs issued at sign-in/refresh without needing client-side mutation.
+CREATE OR REPLACE FUNCTION public.sync_user_program_claims(p_user_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+DECLARE
+    v_program_id UUID;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RETURN;
+    END IF;
+
+    SELECT up.program_id INTO v_program_id
+    FROM public.user_programs up
+    WHERE up.user_id = p_user_id
+    ORDER BY up.is_default DESC, up.updated_at DESC, up.created_at DESC
+    LIMIT 1;
+
+    UPDATE auth.users u
+    SET raw_app_meta_data = CASE
+        WHEN v_program_id IS NULL
+            THEN COALESCE(u.raw_app_meta_data, '{}'::jsonb) - 'program_id'
+        ELSE jsonb_set(
+            COALESCE(u.raw_app_meta_data, '{}'::jsonb),
+            '{program_id}',
+            to_jsonb(v_program_id::text),
+            true
+        )
+    END
+    WHERE u.id = p_user_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_user_program_claims_from_membership()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, auth
+AS $$
+BEGIN
+    PERFORM public.sync_user_program_claims(COALESCE(NEW.user_id, OLD.user_id));
+    RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_user_program_claims ON public.user_programs;
+CREATE TRIGGER trg_sync_user_program_claims
+    AFTER INSERT OR UPDATE OR DELETE ON public.user_programs
+    FOR EACH ROW
+    EXECUTE FUNCTION public.sync_user_program_claims_from_membership();
+
+ALTER TABLE public.user_programs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "user_programs_select_self_or_platform_admin" ON public.user_programs;
+CREATE POLICY "user_programs_select_self_or_platform_admin"
+    ON public.user_programs
+    FOR SELECT TO authenticated
+    USING (user_id = auth.uid() OR public.is_platform_admin());
+
+DROP POLICY IF EXISTS "user_programs_modify_platform_admin_only" ON public.user_programs;
+CREATE POLICY "user_programs_modify_platform_admin_only"
+    ON public.user_programs
+    FOR ALL TO authenticated
+    USING (public.is_platform_admin())
+    WITH CHECK (public.is_platform_admin());
+
+-- Backfill metadata claims for any existing memberships.
+DO $$
+DECLARE
+    v_user_id UUID;
+BEGIN
+    FOR v_user_id IN
+        SELECT DISTINCT user_id
+        FROM public.user_programs
+    LOOP
+        PERFORM public.sync_user_program_claims(v_user_id);
+    END LOOP;
+END;
+$$;
+
+COMMIT;

--- a/tests/supabase-current-program-helper-t04.test.js
+++ b/tests/supabase-current-program-helper-t04.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadMigrationSql() {
+    const filePath = path.resolve(__dirname, '..', 'scripts', 'supabase-current-program-helper-t04.sql');
+    return fs.readFileSync(filePath, 'utf8');
+}
+
+describe('T-04 current_program migration contract', () => {
+    test('creates user_programs mapping table and default-membership index', () => {
+        const sql = loadMigrationSql();
+        expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS public\.user_programs/i);
+        expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS idx_user_programs_single_default/i);
+    });
+
+    test('defines STABLE current_program helper with JWT + fallback resolution', () => {
+        const sql = loadMigrationSql();
+        expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.current_program\(\)/i);
+        expect(sql).toMatch(/RETURNS UUID/i);
+        expect(sql).toMatch(/LANGUAGE sql\s+STABLE/i);
+        expect(sql).toMatch(/public\.jwt_program_id\(\)/i);
+        expect(sql).toMatch(/FROM public\.user_programs/i);
+        expect(sql).toMatch(/WHERE up\.user_id = auth\.uid\(\)/i);
+    });
+
+    test('adds claim-sync trigger so app_metadata program_id stays aligned', () => {
+        const sql = loadMigrationSql();
+        expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.sync_user_program_claims\(/i);
+        expect(sql).toMatch(/UPDATE auth\.users/i);
+        expect(sql).toMatch(/DROP TRIGGER IF EXISTS trg_sync_user_program_claims ON public\.user_programs/i);
+        expect(sql).toMatch(/CREATE TRIGGER trg_sync_user_program_claims/i);
+    });
+});


### PR DESCRIPTION
## Summary
- add `scripts/supabase-current-program-helper-t04.sql` to implement tenant context helpers for RLS
- create `public.user_programs` membership mapping for fallback program resolution
- add `public.jwt_program_id()` and `public.current_program()` (`STABLE`) helpers
- add metadata sync trigger to keep `auth.users.raw_app_meta_data.program_id` aligned with default membership
- add migration contract test and docs for rollout/verification

## Validation
- `npm test -- --runInBand`
- `npm run qa:onboarding`

Closes #102
