### PR TITLE
feat(profile): complete T-05 program profile schema + validator

### DIFF
--- a/department-profiles/design-v1.json
+++ b/department-profiles/design-v1.json
@@ -9,6 +9,8 @@
   },
   "branding": {
     "appTitle": "Program Command - EWU Design",
+    "logoUrl": "",
+    "brandColor": "#a10022",
     "headerEyebrow": "EWU DESIGN · PROGRAM COMMAND",
     "headerSubtitle": "Design Program Planning, Scheduling, and Scenario Control",
     "textSlots": {
@@ -39,6 +41,7 @@
   "academic": {
     "system": "quarter",
     "quarters": ["fall", "winter", "spring"],
+    "yearLabelFormat": "YYYY-YY",
     "defaultTargetYearMode": "current",
     "defaultWorkloadImportYearMode": "next",
     "defaultSchedulerYear": "2025-26"
@@ -69,6 +72,23 @@
     "dashboardTitle": "Faculty Workload Dashboard",
     "dashboardSubtitleBase": "EWU Design Department - Academic Workload Analysis",
     "productionResetDefaultScheduleYear": "2026-27",
+    "utilizationThresholds": {
+      "overloadedPercent": 100,
+      "optimalMinPercent": 60
+    },
+    "courseTypeMultipliers": {
+      "scheduled": 1,
+      "independentStudy": 0.2,
+      "seniorProject": 0.2,
+      "internship": 0.1,
+      "practicum": 0.2
+    },
+    "appliedLearningCourses": {
+      "DESN 399": { "title": "Independent Study", "rate": 0.2 },
+      "DESN 491": { "title": "Senior Project", "rate": 0.2 },
+      "DESN 495": { "title": "Internship", "rate": 0.1 },
+      "DESN 499": { "title": "Independent Study", "rate": 0.2 }
+    },
     "defaultAnnualTargets": {
       "Full Professor": 36,
       "Associate Professor": 36,
@@ -89,6 +109,20 @@
       ],
       "facultyAliases": {},
       "courseAliases": {}
+    }
+  },
+  "courseModel": {
+    "courseCodePrefix": "DESN",
+    "catalogStructure": "course-catalog.json"
+  },
+  "dashboard": {
+    "modules": {
+      "schedule": true,
+      "workload": true,
+      "capacity": true,
+      "releaseTime": true,
+      "constraints": true,
+      "onboarding": true
     }
   }
 }

--- a/department-profiles/itds-pilot-v1.json
+++ b/department-profiles/itds-pilot-v1.json
@@ -9,6 +9,8 @@
   },
   "branding": {
     "appTitle": "Program Command - EWU ITDS",
+    "logoUrl": "",
+    "brandColor": "#1f3b4d",
     "headerEyebrow": "EWU ITDS · PROGRAM COMMAND",
     "headerSubtitle": "ITDS Program Planning and Schedule Operations",
     "textSlots": {
@@ -39,6 +41,7 @@
   "academic": {
     "system": "quarter",
     "quarters": ["fall", "winter", "spring"],
+    "yearLabelFormat": "YYYY-YY",
     "defaultTargetYearMode": "current",
     "defaultWorkloadImportYearMode": "next",
     "defaultSchedulerYear": "2026-27"
@@ -67,6 +70,17 @@
     "dashboardTitle": "Faculty Workload Dashboard",
     "dashboardSubtitleBase": "EWU ITDS Department - Academic Workload Analysis",
     "productionResetDefaultScheduleYear": "2027-28",
+    "utilizationThresholds": {
+      "overloadedPercent": 100,
+      "optimalMinPercent": 60
+    },
+    "courseTypeMultipliers": {
+      "scheduled": 1,
+      "independentStudy": 0.2,
+      "seniorProject": 0.2,
+      "internship": 0.1,
+      "practicum": 0.2
+    },
     "defaultAnnualTargets": {
       "Full Professor": 36,
       "Associate Professor": 36,
@@ -97,6 +111,20 @@
         "ITD 101": "ITDS 101",
         "ITD 220": "ITDS 220"
       }
+    }
+  },
+  "courseModel": {
+    "courseCodePrefix": "ITDS",
+    "catalogStructure": "course-catalog.json"
+  },
+  "dashboard": {
+    "modules": {
+      "schedule": true,
+      "workload": true,
+      "capacity": true,
+      "releaseTime": true,
+      "constraints": true,
+      "onboarding": true
     }
   }
 }

--- a/docs/department-profile-schema-v1.md
+++ b/docs/department-profile-schema-v1.md
@@ -11,8 +11,10 @@ This schema defines the runtime configuration contract for department onboarding
   - `code` (string, required)
   - `displayName` (string, required)
   - `shortName` (string, optional)
-- `branding` (object, optional):
+- `branding` (object, required):
   - `appTitle` (string)
+  - `logoUrl` (string, optional)
+  - `brandColor` (hex string, optional)
   - `headerEyebrow` (string)
   - `headerSubtitle` (string)
   - `textSlots` (object map, optional): profile-driven UI labels/help copy
@@ -20,6 +22,7 @@ This schema defines the runtime configuration contract for department onboarding
 - `academic` (object, required):
   - `system` (string, currently `quarter`)
   - `quarters` (array of strings, required)
+  - `yearLabelFormat` (string, required): e.g. `YYYY-YY`
   - `defaultTargetYearMode` (string, optional)
   - `defaultWorkloadImportYearMode` (string, optional)
   - `defaultSchedulerYear` (string, optional)
@@ -42,11 +45,21 @@ This schema defines the runtime configuration contract for department onboarding
   - `dashboardSubtitleBase` (string, optional)
   - `productionResetDefaultScheduleYear` (string, optional)
   - `defaultAnnualTargets` (object, optional)
+  - `appliedLearningCourses` (object, required): course-code map to `{ title, rate }`
+  - `courseTypeMultipliers` (object, required): named multipliers such as internship/practicum/independentStudy
+  - `utilizationThresholds` (object, required):
+    - `overloadedPercent` (number, > 0)
+    - `optimalMinPercent` (number, > 0)
 - `import` (object, optional):
   - `clss.roomMatchPriority` (array of strings, optional)
   - `clss.preferredMatchingOrder` (array of strings, optional)
   - `clss.facultyAliases` (object map, optional): alias to canonical faculty name
   - `clss.courseAliases` (object map, optional): alias code to canonical course code
+- `courseModel` (object, required):
+  - `courseCodePrefix` (string, required) e.g. `DESN`
+  - `catalogStructure` (string, optional)
+- `dashboard` (object, required):
+  - `modules` (object, required): boolean feature toggles (schedule/workload/capacity/etc.)
 
 ## Runtime Loader
 
@@ -65,6 +78,7 @@ If manifest/profile loading fails or validation fails, runtime falls back to the
 
 - Unsupported profile versions fail validation.
 - Missing required fields fail validation.
+- Invalid primitive types fail validation (string/boolean/number checks).
 - Runtime applies v1 defaults for optional fields.
 - Runtime emits contrast warnings when branding foreground/background header tokens fail a 4.5:1 ratio check.
 - Migration hook entry point exists in `js/department-profile.js` (`migrateProfile`) for future version upgrades.

--- a/docs/program-profile-schema.md
+++ b/docs/program-profile-schema.md
@@ -1,0 +1,25 @@
+# Program Profile Schema (v1)
+
+Issue: [#103](https://github.com/sicxz/program-command/issues/103)
+
+The authoritative v1 schema is documented in:
+
+- [`docs/department-profile-schema-v1.md`](./department-profile-schema-v1.md)
+
+This schema powers `programs.config` compatibility and runtime profile loading in:
+
+- `js/department-profile.js`
+- `department-profiles/design-v1.json` (EWU Design default profile)
+
+## Validation Function
+
+Runtime validator:
+
+- `DepartmentProfileManager.validateProfile(profile)`
+
+Returns:
+
+- `valid` (boolean)
+- `errors` (array of strings)
+- `warnings` (array of strings)
+- `normalizedProfile` (profile with v1 defaults applied)

--- a/js/department-profile.js
+++ b/js/department-profile.js
@@ -22,6 +22,8 @@
         },
         branding: {
             appTitle: 'Program Command - EWU Design',
+            logoUrl: '',
+            brandColor: '#a10022',
             headerEyebrow: 'EWU DESIGN · PROGRAM COMMAND',
             headerSubtitle: 'Design Program Planning, Scheduling, and Scenario Control',
             textSlots: {
@@ -52,6 +54,7 @@
         academic: {
             system: 'quarter',
             quarters: ['fall', 'winter', 'spring'],
+            yearLabelFormat: 'YYYY-YY',
             defaultTargetYearMode: 'current',
             defaultWorkloadImportYearMode: 'next',
             defaultSchedulerYear: '2025-26'
@@ -82,6 +85,23 @@
             dashboardTitle: 'Faculty Workload Dashboard',
             dashboardSubtitleBase: 'EWU Design Department - Academic Workload Analysis',
             productionResetDefaultScheduleYear: '2026-27',
+            utilizationThresholds: {
+                overloadedPercent: 100,
+                optimalMinPercent: 60
+            },
+            courseTypeMultipliers: {
+                scheduled: 1,
+                independentStudy: 0.2,
+                seniorProject: 0.2,
+                internship: 0.1,
+                practicum: 0.2
+            },
+            appliedLearningCourses: {
+                'DESN 399': { title: 'Independent Study', rate: 0.2 },
+                'DESN 491': { title: 'Senior Project', rate: 0.2 },
+                'DESN 495': { title: 'Internship', rate: 0.1 },
+                'DESN 499': { title: 'Independent Study', rate: 0.2 }
+            },
             defaultAnnualTargets: {
                 'Full Professor': 36,
                 'Associate Professor': 36,
@@ -102,6 +122,20 @@
                 ],
                 facultyAliases: {},
                 courseAliases: {}
+            }
+        },
+        courseModel: {
+            courseCodePrefix: 'DESN',
+            catalogStructure: 'course-catalog.json'
+        },
+        dashboard: {
+            modules: {
+                schedule: true,
+                workload: true,
+                capacity: true,
+                releaseTime: true,
+                constraints: true,
+                onboarding: true
             }
         }
     });
@@ -289,9 +323,18 @@
         merged.academic.quarters = merged.academic.quarters
             .map((quarter) => String(quarter || '').toLowerCase())
             .filter(Boolean);
+        if (!String(merged.academic.yearLabelFormat || '').trim()) {
+            merged.academic.yearLabelFormat = DEFAULT_PROFILE.academic.yearLabelFormat;
+        }
 
         if (!isObject(merged.branding.textSlots)) {
             merged.branding.textSlots = { ...DEFAULT_PROFILE.branding.textSlots };
+        }
+        if (!String(merged.branding.logoUrl || '').trim() && DEFAULT_PROFILE.branding.logoUrl) {
+            merged.branding.logoUrl = DEFAULT_PROFILE.branding.logoUrl;
+        }
+        if (!String(merged.branding.brandColor || '').trim()) {
+            merged.branding.brandColor = DEFAULT_PROFILE.branding.brandColor;
         }
 
         if (!Array.isArray(merged.scheduler.allowedRooms)) {
@@ -325,12 +368,36 @@
             merged.import.clss.courseAliases = {};
         }
 
+        if (!isObject(merged.workload.appliedLearningCourses)) {
+            merged.workload.appliedLearningCourses = deepClone(DEFAULT_PROFILE.workload.appliedLearningCourses);
+        }
+
+        if (!isObject(merged.workload.utilizationThresholds)) {
+            merged.workload.utilizationThresholds = deepClone(DEFAULT_PROFILE.workload.utilizationThresholds);
+        }
+
+        if (!isObject(merged.workload.courseTypeMultipliers)) {
+            merged.workload.courseTypeMultipliers = deepClone(DEFAULT_PROFILE.workload.courseTypeMultipliers);
+        }
+
+        if (!isObject(merged.courseModel)) {
+            merged.courseModel = deepClone(DEFAULT_PROFILE.courseModel);
+        }
+
+        if (!isObject(merged.dashboard)) {
+            merged.dashboard = deepClone(DEFAULT_PROFILE.dashboard);
+        }
+        if (!isObject(merged.dashboard.modules)) {
+            merged.dashboard.modules = deepClone(DEFAULT_PROFILE.dashboard.modules);
+        }
+
         return merged;
     }
 
     function validateProfile(profile) {
         const errors = [];
         const warnings = [];
+        const hexColorPattern = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
         if (!isObject(profile)) {
             return { valid: false, errors: ['Profile must be a JSON object.'], warnings };
@@ -347,9 +414,26 @@
         if (!isObject(profile.identity)) {
             errors.push('identity object is required.');
         } else {
-            if (!String(profile.identity.name || '').trim()) errors.push('identity.name is required.');
-            if (!String(profile.identity.code || '').trim()) errors.push('identity.code is required.');
-            if (!String(profile.identity.displayName || '').trim()) errors.push('identity.displayName is required.');
+            if (typeof profile.identity.name !== 'string' || !profile.identity.name.trim()) errors.push('identity.name must be a non-empty string.');
+            if (typeof profile.identity.code !== 'string' || !profile.identity.code.trim()) errors.push('identity.code must be a non-empty string.');
+            if (typeof profile.identity.displayName !== 'string' || !profile.identity.displayName.trim()) errors.push('identity.displayName must be a non-empty string.');
+            if (profile.identity.shortName != null && typeof profile.identity.shortName !== 'string') {
+                errors.push('identity.shortName must be a string when provided.');
+            }
+        }
+
+        if (!isObject(profile.branding)) {
+            errors.push('branding object is required.');
+        } else {
+            if (profile.branding.logoUrl != null && typeof profile.branding.logoUrl !== 'string') {
+                errors.push('branding.logoUrl must be a string when provided.');
+            }
+            if (profile.branding.brandColor != null && (typeof profile.branding.brandColor !== 'string' || !hexColorPattern.test(profile.branding.brandColor))) {
+                errors.push('branding.brandColor must be a valid hex color (for example #a10022).');
+            }
+            if (!isObject(profile.branding.textSlots)) {
+                warnings.push('branding.textSlots should be an object map of UI labels.');
+            }
         }
 
         if (!isObject(profile.academic)) {
@@ -360,6 +444,9 @@
             }
             if (!Array.isArray(profile.academic.quarters) || profile.academic.quarters.length === 0) {
                 errors.push('academic.quarters must be a non-empty array.');
+            }
+            if (typeof profile.academic.yearLabelFormat !== 'string' || !profile.academic.yearLabelFormat.trim()) {
+                errors.push('academic.yearLabelFormat must be a non-empty string.');
             }
         }
 
@@ -376,8 +463,49 @@
 
         if (!isObject(profile.workload)) {
             errors.push('workload object is required.');
-        } else if (!isObject(profile.workload.defaultAnnualTargets)) {
-            warnings.push('workload.defaultAnnualTargets missing; workload UI will fall back to runtime defaults.');
+        } else {
+            if (!isObject(profile.workload.defaultAnnualTargets)) {
+                warnings.push('workload.defaultAnnualTargets missing; workload UI will fall back to runtime defaults.');
+            }
+            if (!isObject(profile.workload.appliedLearningCourses)) {
+                errors.push('workload.appliedLearningCourses must be an object map.');
+            }
+            if (!isObject(profile.workload.courseTypeMultipliers)) {
+                errors.push('workload.courseTypeMultipliers must be an object map.');
+            }
+            if (!isObject(profile.workload.utilizationThresholds)) {
+                errors.push('workload.utilizationThresholds must be an object.');
+            } else {
+                const overloadedPercent = Number(profile.workload.utilizationThresholds.overloadedPercent);
+                const optimalMinPercent = Number(profile.workload.utilizationThresholds.optimalMinPercent);
+                if (!Number.isFinite(overloadedPercent) || overloadedPercent <= 0) {
+                    errors.push('workload.utilizationThresholds.overloadedPercent must be a positive number.');
+                }
+                if (!Number.isFinite(optimalMinPercent) || optimalMinPercent <= 0) {
+                    errors.push('workload.utilizationThresholds.optimalMinPercent must be a positive number.');
+                }
+            }
+        }
+
+        if (!isObject(profile.courseModel)) {
+            errors.push('courseModel object is required.');
+        } else {
+            if (typeof profile.courseModel.courseCodePrefix !== 'string' || !profile.courseModel.courseCodePrefix.trim()) {
+                errors.push('courseModel.courseCodePrefix must be a non-empty string.');
+            }
+            if (profile.courseModel.catalogStructure != null && typeof profile.courseModel.catalogStructure !== 'string') {
+                errors.push('courseModel.catalogStructure must be a string when provided.');
+            }
+        }
+
+        if (!isObject(profile.dashboard) || !isObject(profile.dashboard.modules)) {
+            errors.push('dashboard.modules object is required.');
+        } else {
+            Object.entries(profile.dashboard.modules).forEach(([moduleName, enabled]) => {
+                if (typeof enabled !== 'boolean') {
+                    errors.push(`dashboard.modules.${moduleName} must be a boolean.`);
+                }
+            });
         }
 
         return { valid: errors.length === 0, errors, warnings };

--- a/tests/department-profile.onboarding.test.js
+++ b/tests/department-profile.onboarding.test.js
@@ -108,4 +108,56 @@ describe('DepartmentProfileManager onboarding helpers', () => {
         expect(ids).toContain('test-department-v01');
         expect(ids).toContain('test-department-v02');
     });
+
+    test('validation rejects missing/invalid schema fields for program profile v1', async () => {
+        const manager = window.DepartmentProfileManager;
+        await manager.initialize({ forceReload: true });
+
+        const invalid = {
+            version: 1,
+            id: '',
+            identity: {
+                name: '',
+                code: '',
+                displayName: ''
+            },
+            branding: {
+                logoUrl: 42,
+                brandColor: 'not-a-color'
+            },
+            academic: {
+                system: 'semester',
+                quarters: [],
+                yearLabelFormat: ''
+            },
+            scheduler: {
+                storageKeyPrefix: '',
+                allowedRooms: []
+            },
+            workload: {
+                appliedLearningCourses: [],
+                courseTypeMultipliers: [],
+                utilizationThresholds: {
+                    overloadedPercent: 'high',
+                    optimalMinPercent: 0
+                }
+            },
+            courseModel: {
+                courseCodePrefix: '',
+                catalogStructure: 123
+            },
+            dashboard: {
+                modules: {
+                    schedule: 'yes'
+                }
+            }
+        };
+
+        const report = manager.validateProfile(invalid);
+        expect(report.valid).toBe(false);
+        expect(report.errors.join(' | ')).toContain('identity.name');
+        expect(report.errors.join(' | ')).toContain('branding.logoUrl');
+        expect(report.errors.join(' | ')).toContain('workload.utilizationThresholds.overloadedPercent');
+        expect(report.errors.join(' | ')).toContain('dashboard.modules.schedule');
+    });
 });


### PR DESCRIPTION
## Summary
- finalize v1 program profile schema in runtime + docs (`js/department-profile.js`, `docs/department-profile-schema-v1.md`, `docs/program-profile-schema.md`)
- extend EWU Design default profile with explicit T-05 fields (branding metadata, year label format, course model, module toggles, workload multipliers, utilization thresholds)
- align pilot profile with the same schema surface (`department-profiles/itds-pilot-v1.json`)
- strengthen validation to catch missing required fields and invalid primitive types
- add onboarding validation test coverage for invalid schema payloads

## Validation
- `npm test -- --runInBand`
- `npm run qa:onboarding`

Closes #103
