### PR TITLE
feat(runtime): implement ProfileLoader singleton for program config

### DIFF
--- a/docs/profile-loader-t06.md
+++ b/docs/profile-loader-t06.md
@@ -1,0 +1,31 @@
+# Profile Loader (T-06)
+
+Issue: [#104](https://github.com/sicxz/program-command/issues/104)
+
+## Runtime Singleton
+
+File:
+
+- `js/profile-loader.js`
+
+Public API:
+
+- `ProfileLoader.init(programId?, options?)`
+- `ProfileLoader.get(path, fallback?)`
+- `ProfileLoader.getAll()`
+- `ProfileLoader.isLoaded()`
+
+## Resolution Order
+
+1. Supabase `programs.config` (when `getSupabaseClient()` is available)
+2. Runtime default profile from `DepartmentProfileManager.getDefaultProfile()` (if available)
+3. Embedded EWU Design fallback profile
+
+Profiles are cached in-memory after first load. Use `init(..., { forceRefresh: true })` to refresh.
+
+## Current Integration
+
+- `js/schedule-manager.js` now checks `ProfileLoader.get(...)` for:
+  - `workload.defaultAnnualTargets`
+  - `workload.appliedLearningCourses`
+- falls back to existing constants if loader data is not available.

--- a/js/profile-loader.js
+++ b/js/profile-loader.js
@@ -1,0 +1,314 @@
+/**
+ * ProfileLoader runtime singleton
+ * Loads program profile config from Supabase with in-memory caching and safe fallback defaults.
+ */
+const ProfileLoader = (function() {
+    'use strict';
+
+    const DEFAULT_PROFILE = Object.freeze({
+        version: 1,
+        id: 'design-v1',
+        identity: {
+            name: 'Design',
+            code: 'DESN',
+            displayName: 'EWU Design',
+            shortName: 'Design'
+        },
+        scheduler: {
+            storageKeyPrefix: 'designSchedulerData_'
+        },
+        workload: {
+            defaultAnnualTargets: {
+                'Full Professor': 36,
+                'Associate Professor': 36,
+                'Assistant Professor': 36,
+                'Tenure/Tenure-track': 36,
+                'Senior Lecturer': 45,
+                Lecturer: 45,
+                Adjunct: 15
+            },
+            appliedLearningCourses: {
+                'DESN 399': { title: 'Independent Study', rate: 0.2 },
+                'DESN 491': { title: 'Senior Project', rate: 0.2 },
+                'DESN 495': { title: 'Internship', rate: 0.1 },
+                'DESN 499': { title: 'Independent Study', rate: 0.2 }
+            },
+            courseTypeMultipliers: {
+                scheduled: 1,
+                independentStudy: 0.2,
+                seniorProject: 0.2,
+                internship: 0.1,
+                practicum: 0.2
+            },
+            utilizationThresholds: {
+                overloadedPercent: 100,
+                optimalMinPercent: 60
+            }
+        },
+        faculty: {
+            ranks: {
+                professor: { limit: 36 },
+                associateProfessor: { limit: 36 },
+                assistantProfessor: { limit: 36 },
+                seniorLecturer: { limit: 45 },
+                lecturer: { limit: 45 },
+                adjunct: { limit: 15 }
+            }
+        }
+    });
+
+    const state = {
+        loaded: false,
+        loadingPromise: null,
+        profile: deepClone(DEFAULT_PROFILE),
+        source: 'fallback-default',
+        programId: null
+    };
+
+    function deepClone(value) {
+        return value ? JSON.parse(JSON.stringify(value)) : value;
+    }
+
+    function isObject(value) {
+        return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+    }
+
+    function deepMerge(base, override) {
+        if (!isObject(base)) return deepClone(override);
+        const merged = deepClone(base);
+        if (!isObject(override)) return merged;
+
+        Object.keys(override).forEach((key) => {
+            const incoming = override[key];
+            if (Array.isArray(incoming)) {
+                merged[key] = incoming.slice();
+                return;
+            }
+            if (isObject(incoming) && isObject(merged[key])) {
+                merged[key] = deepMerge(merged[key], incoming);
+                return;
+            }
+            merged[key] = incoming;
+        });
+
+        return merged;
+    }
+
+    function getClient() {
+        if (typeof getSupabaseClient === 'function') {
+            return getSupabaseClient();
+        }
+        if (typeof window !== 'undefined' && typeof window.getSupabaseClient === 'function') {
+            return window.getSupabaseClient();
+        }
+        return null;
+    }
+
+    async function resolveProgramId(explicitProgramId = null) {
+        if (explicitProgramId) return String(explicitProgramId);
+
+        const authService = (typeof window !== 'undefined' && window.AuthService) ? window.AuthService : null;
+        if (!authService || typeof authService.getUser !== 'function') return null;
+
+        try {
+            const user = await authService.getUser();
+            const metadataProgramId = user?.app_metadata?.program_id || user?.user_metadata?.program_id || null;
+            return metadataProgramId ? String(metadataProgramId) : null;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function normalizeLoadedProfile(rawProgramConfig) {
+        if (!isObject(rawProgramConfig)) return null;
+
+        if (isObject(rawProgramConfig.profile)) {
+            return rawProgramConfig.profile;
+        }
+
+        return rawProgramConfig;
+    }
+
+    function ensureDerivedFacultyLimits(profile) {
+        const result = deepClone(profile);
+        if (!isObject(result.faculty)) result.faculty = {};
+        if (!isObject(result.faculty.ranks)) result.faculty.ranks = {};
+
+        const targets = isObject(result.workload?.defaultAnnualTargets)
+            ? result.workload.defaultAnnualTargets
+            : {};
+
+        const mapping = [
+            ['Full Professor', 'professor'],
+            ['Associate Professor', 'associateProfessor'],
+            ['Assistant Professor', 'assistantProfessor'],
+            ['Senior Lecturer', 'seniorLecturer'],
+            ['Lecturer', 'lecturer'],
+            ['Adjunct', 'adjunct']
+        ];
+
+        mapping.forEach(([targetKey, rankKey]) => {
+            if (!isObject(result.faculty.ranks[rankKey])) {
+                result.faculty.ranks[rankKey] = {};
+            }
+            const fallback = Number(targets[targetKey]);
+            if (Number.isFinite(fallback) && fallback > 0) {
+                result.faculty.ranks[rankKey].limit = fallback;
+                return;
+            }
+            if (!Number.isFinite(Number(result.faculty.ranks[rankKey].limit))) {
+                result.faculty.ranks[rankKey].limit = DEFAULT_PROFILE.faculty.ranks[rankKey].limit;
+            }
+        });
+
+        return result;
+    }
+
+    async function loadFromSupabase(explicitProgramId = null) {
+        const client = getClient();
+        if (!client || typeof client.from !== 'function') {
+            return null;
+        }
+
+        const resolvedProgramId = await resolveProgramId(explicitProgramId);
+        let query = client.from('programs').select('id, code, config');
+        if (resolvedProgramId) {
+            query = query.eq('id', resolvedProgramId);
+        } else {
+            query = query.eq('code', 'ewu-design');
+        }
+
+        const { data, error } = await query.maybeSingle();
+        if (error || !data) {
+            return null;
+        }
+
+        const profile = normalizeLoadedProfile(data.config);
+        if (!isObject(profile)) {
+            return null;
+        }
+
+        return {
+            programId: data.id || resolvedProgramId || null,
+            profile
+        };
+    }
+
+    function resolveRuntimeDefaultProfile() {
+        if (typeof window !== 'undefined' &&
+            window.DepartmentProfileManager &&
+            typeof window.DepartmentProfileManager.getDefaultProfile === 'function') {
+            try {
+                const runtimeDefault = window.DepartmentProfileManager.getDefaultProfile();
+                if (isObject(runtimeDefault)) {
+                    return runtimeDefault;
+                }
+            } catch (error) {
+                // fall back to embedded default
+            }
+        }
+        return deepClone(DEFAULT_PROFILE);
+    }
+
+    async function init(programId = null, options = {}) {
+        const config = isObject(options) ? options : {};
+        const forceRefresh = Boolean(config.forceRefresh);
+        const requestedProgramId = programId ? String(programId) : null;
+
+        if (!forceRefresh && state.loaded && state.programId === requestedProgramId) {
+            return getSnapshot();
+        }
+
+        if (!forceRefresh && state.loadingPromise) {
+            return state.loadingPromise;
+        }
+
+        state.loadingPromise = (async () => {
+            let profile = resolveRuntimeDefaultProfile();
+            let source = 'fallback-default';
+            let resolvedProgramId = requestedProgramId;
+
+            try {
+                const fromSupabase = await loadFromSupabase(requestedProgramId);
+                if (fromSupabase && isObject(fromSupabase.profile)) {
+                    profile = deepMerge(profile, fromSupabase.profile);
+                    resolvedProgramId = fromSupabase.programId || resolvedProgramId;
+                    source = 'supabase-programs';
+                }
+            } catch (error) {
+                // keep fallback profile if Supabase read fails
+            }
+
+            profile = ensureDerivedFacultyLimits(profile);
+            state.profile = profile;
+            state.source = source;
+            state.programId = resolvedProgramId || null;
+            state.loaded = true;
+            return getSnapshot();
+        })();
+
+        try {
+            return await state.loadingPromise;
+        } finally {
+            state.loadingPromise = null;
+        }
+    }
+
+    function getSnapshot() {
+        return {
+            loaded: state.loaded,
+            source: state.source,
+            programId: state.programId,
+            profile: deepClone(state.profile)
+        };
+    }
+
+    function get(path, fallbackValue = undefined) {
+        const normalizedPath = String(path || '').trim();
+        if (!normalizedPath) return fallbackValue;
+
+        const parts = normalizedPath.split('.').filter(Boolean);
+        let cursor = state.profile;
+
+        for (const part of parts) {
+            if (!cursor || typeof cursor !== 'object' || !(part in cursor)) {
+                return fallbackValue;
+            }
+            cursor = cursor[part];
+        }
+
+        return cursor === undefined ? fallbackValue : cursor;
+    }
+
+    function getAll() {
+        return deepClone(state.profile);
+    }
+
+    function isLoaded() {
+        return state.loaded;
+    }
+
+    function resetForTests() {
+        state.loaded = false;
+        state.loadingPromise = null;
+        state.profile = deepClone(DEFAULT_PROFILE);
+        state.source = 'fallback-default';
+        state.programId = null;
+    }
+
+    return {
+        init,
+        get,
+        getAll,
+        isLoaded,
+        _resetForTests: resetForTests
+    };
+})();
+
+if (typeof window !== 'undefined') {
+    window.ProfileLoader = ProfileLoader;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = ProfileLoader;
+}

--- a/js/schedule-manager.js
+++ b/js/schedule-manager.js
@@ -9,6 +9,66 @@ const ScheduleManager = (function() {
 
     // Get constants if available
     const getConstants = () => {
+        const profileLoader =
+            (typeof ProfileLoader !== 'undefined' && ProfileLoader && typeof ProfileLoader.get === 'function')
+                ? ProfileLoader
+                : ((typeof window !== 'undefined' && window.ProfileLoader && typeof window.ProfileLoader.get === 'function')
+                    ? window.ProfileLoader
+                    : null);
+
+        if (profileLoader) {
+            const profileTargets = profileLoader.get('workload.defaultAnnualTargets', null);
+            const profileAppliedLearning = profileLoader.get('workload.appliedLearningCourses', null);
+            const hasProfileTargets = profileTargets && typeof profileTargets === 'object' && !Array.isArray(profileTargets);
+            const hasAppliedLearning = profileAppliedLearning && typeof profileAppliedLearning === 'object' && !Array.isArray(profileAppliedLearning);
+
+            if (hasProfileTargets || hasAppliedLearning) {
+                const defaultMultipliers = {
+                    'DESN 399': 0.2,
+                    'DESN 491': 0.2,
+                    'DESN 499': 0.2,
+                    'DESN 495': 0.1,
+                    DEFAULT: 1.0
+                };
+
+                const mergedMultipliers = { ...defaultMultipliers };
+                if (hasAppliedLearning) {
+                    Object.entries(profileAppliedLearning).forEach(([courseCode, details]) => {
+                        const normalizedCode = String(courseCode || '').trim().toUpperCase();
+                        if (!normalizedCode) return;
+                        if (Number.isFinite(Number(details))) {
+                            mergedMultipliers[normalizedCode] = Number(details);
+                            return;
+                        }
+                        if (details && typeof details === 'object' && Number.isFinite(Number(details.rate))) {
+                            mergedMultipliers[normalizedCode] = Number(details.rate);
+                        }
+                    });
+                }
+
+                const defaultLimits = {
+                    'Full Professor': 36,
+                    'Associate Professor': 36,
+                    'Assistant Professor': 36,
+                    'Senior Lecturer': 45,
+                    Lecturer: 45,
+                    Adjunct: 15
+                };
+
+                return {
+                    WORKLOAD: {
+                        LIMITS: hasProfileTargets
+                            ? { ...defaultLimits, ...profileTargets }
+                            : defaultLimits,
+                        MULTIPLIERS: mergedMultipliers
+                    },
+                    BACKUP: {
+                        STORAGE_KEY_PREFIX: 'ewu_schedule_'
+                    }
+                };
+            }
+        }
+
         if (typeof CONSTANTS !== 'undefined') {
             return CONSTANTS;
         }

--- a/pages/schedule-editor.html
+++ b/pages/schedule-editor.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="../css/program-command-dashboard-theme.css">
 
     <!-- Utility Scripts -->
+    <script src="../js/profile-loader.js"></script>
     <script src="../js/config/constants.js"></script>
     <script src="../js/dom-utils.js"></script>
     <script src="../js/validators.js"></script>

--- a/pages/workload-dashboard.html
+++ b/pages/workload-dashboard.html
@@ -15,6 +15,7 @@
 
     <!-- Utility Scripts -->
     <script src="../js/department-profile.js"></script>
+    <script src="../js/profile-loader.js"></script>
     <script src="../js/config/constants.js"></script>
     <script src="../js/data-loader.js"></script>
     <script src="../js/year-filter.js"></script>

--- a/tests/profile-loader.test.js
+++ b/tests/profile-loader.test.js
@@ -1,0 +1,126 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadProfileLoader({
+    supabaseRow = null,
+    supabaseError = null,
+    authUser = null,
+    includeDepartmentProfileManager = false
+} = {}) {
+    const filePath = path.resolve(__dirname, '..', 'js/profile-loader.js');
+    const source = fs.readFileSync(filePath, 'utf8');
+
+    const query = {
+        select: jest.fn(function select() { return this; }),
+        eq: jest.fn(function eq() { return this; }),
+        maybeSingle: jest.fn().mockResolvedValue({ data: supabaseRow, error: supabaseError })
+    };
+
+    const client = {
+        from: jest.fn(() => query)
+    };
+
+    const windowObject = {
+        getSupabaseClient: jest.fn(() => client),
+        AuthService: {
+            getUser: jest.fn().mockResolvedValue(authUser)
+        }
+    };
+
+    if (includeDepartmentProfileManager) {
+        windowObject.DepartmentProfileManager = {
+            getDefaultProfile: jest.fn(() => ({
+                id: 'runtime-default',
+                workload: {
+                    defaultAnnualTargets: { 'Full Professor': 36 }
+                },
+                faculty: {
+                    ranks: {
+                        professor: { limit: 36 }
+                    }
+                }
+            }))
+        };
+    }
+
+    const sandbox = {
+        window: windowObject,
+        getSupabaseClient: jest.fn(() => client),
+        module: { exports: {} },
+        exports: {},
+        console
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: 'js/profile-loader.js' });
+
+    return {
+        ProfileLoader: sandbox.module.exports,
+        query,
+        client,
+        windowObject
+    };
+}
+
+describe('ProfileLoader', () => {
+    test('falls back to default profile and supports nested path reads', async () => {
+        const { ProfileLoader, windowObject } = loadProfileLoader({
+            supabaseRow: null,
+            supabaseError: { message: 'offline' }
+        });
+
+        windowObject.getSupabaseClient.mockReturnValue(null);
+        const snapshot = await ProfileLoader.init();
+
+        expect(snapshot.loaded).toBe(true);
+        expect(ProfileLoader.isLoaded()).toBe(true);
+        expect(ProfileLoader.get('faculty.ranks.professor.limit')).toBe(36);
+        expect(ProfileLoader.get('does.not.exist', 'fallback')).toBe('fallback');
+    });
+
+    test('loads program config from supabase and caches by program id', async () => {
+        const { ProfileLoader, query, client } = loadProfileLoader({
+            supabaseRow: {
+                id: 'program-1',
+                code: 'ewu-design',
+                config: {
+                    workload: {
+                        defaultAnnualTargets: {
+                            'Full Professor': 40
+                        }
+                    }
+                }
+            }
+        });
+
+        const first = await ProfileLoader.init('program-1');
+        const second = await ProfileLoader.init('program-1');
+
+        expect(first.source).toBe('supabase-programs');
+        expect(second.source).toBe('supabase-programs');
+        expect(ProfileLoader.get('faculty.ranks.professor.limit')).toBe(40);
+        expect(client.from).toHaveBeenCalledWith('programs');
+        expect(query.maybeSingle).toHaveBeenCalledTimes(1);
+    });
+
+    test('can resolve program id from AuthService metadata when not passed explicitly', async () => {
+        const { ProfileLoader, query, windowObject } = loadProfileLoader({
+            supabaseRow: {
+                id: 'program-auth',
+                code: 'ewu-design',
+                config: {}
+            },
+            authUser: {
+                app_metadata: {
+                    program_id: 'program-auth'
+                }
+            }
+        });
+
+        await ProfileLoader.init();
+
+        expect(windowObject.AuthService.getUser).toHaveBeenCalledTimes(1);
+        expect(query.eq).toHaveBeenCalledWith('id', 'program-auth');
+    });
+});


### PR DESCRIPTION
## Summary
- add `ProfileLoader` singleton (`js/profile-loader.js`) with API:
  - `init(programId, options)`
  - `get(path, fallback)`
  - `getAll()`
  - `isLoaded()`
- implement Supabase-backed profile loading from `programs.config` with in-memory caching
- implement fallback chain: Supabase -> DepartmentProfileManager default -> embedded EWU Design profile
- add module integration point: `js/schedule-manager.js` now consults `ProfileLoader.get(...)` for workload targets/multipliers before constants fallback
- include loader script on key pages using schedule manager
- add unit tests and rollout docs

## Validation
- `npm test -- --runInBand`
- `npm run qa:onboarding`

Closes #104
