### PR TITLE
feat(auth): enforce login in prod, bypass on localhost dev

### DIFF
--- a/docs/auth-contract.md
+++ b/docs/auth-contract.md
@@ -119,3 +119,10 @@ This spec is normative input for:
 - implementing program multi-tenancy claims (`program_id`) end-to-end
 
 Those are handled in subsequent A/T issues.
+
+## 9) Environment Auth Enforcement
+- Production/staging hosts enforce auth guard by default.
+- Local development hosts (`localhost`, `127.0.0.1`, `::1`) bypass auth guard by default.
+- Optional override controls:
+  - query param: `?auth=required` or `?auth=disabled`
+  - global flag before `auth-guard.js`: `window.PROGRAM_COMMAND_AUTH_MODE = 'required' | 'disabled'`

--- a/js/auth-guard.js
+++ b/js/auth-guard.js
@@ -20,6 +20,39 @@
         return /\/login\.html$/i.test(window.location.pathname);
     }
 
+    function isLocalDevHost() {
+        const hostname = String(window.location.hostname || '').toLowerCase();
+        if (!hostname) return false;
+        return (
+            hostname === 'localhost' ||
+            hostname === '127.0.0.1' ||
+            hostname === '::1'
+        );
+    }
+
+    function readAuthModeOverride() {
+        const params = new URLSearchParams(window.location.search);
+        const queryMode = String(params.get('auth') || '').trim().toLowerCase();
+        if (queryMode === 'on' || queryMode === 'required') return 'required';
+        if (queryMode === 'off' || queryMode === 'disabled') return 'disabled';
+
+        const globalMode = String(
+            window.PROGRAM_COMMAND_AUTH_MODE ||
+            window.__PROGRAM_COMMAND_AUTH_MODE ||
+            ''
+        ).trim().toLowerCase();
+        if (globalMode === 'required') return 'required';
+        if (globalMode === 'disabled') return 'disabled';
+        return null;
+    }
+
+    function shouldEnforceAuth() {
+        const mode = readAuthModeOverride();
+        if (mode === 'required') return true;
+        if (mode === 'disabled') return false;
+        return !isLocalDevHost();
+    }
+
     function loginUrl() {
         return window.location.pathname.includes('/pages/')
             ? '../login.html'
@@ -583,6 +616,13 @@
     }
 
     async function initGuard() {
+        if (!shouldEnforceAuth()) {
+            if (isLoginPage()) {
+                window.location.replace(getNextPath());
+            }
+            return;
+        }
+
         if (typeof window.AuthService === 'undefined') {
             console.warn('Auth guard skipped: AuthService is not available.');
             return;

--- a/tests/auth-editstate.integration.test.js
+++ b/tests/auth-editstate.integration.test.js
@@ -12,6 +12,7 @@ function createLocation(url) {
     const parsed = new URL(url);
     return {
         pathname: parsed.pathname,
+        hostname: parsed.hostname,
         search: parsed.search,
         hash: parsed.hash,
         replace: jest.fn()
@@ -259,6 +260,23 @@ describe('Auth + Edit State Integration', () => {
 
         presenceCallback([]);
         expect(document.getElementById('editAction').disabled).toBe(false);
+
+        harness.cleanup();
+    });
+
+    test('skips auth enforcement on localhost by default for dev flow', async () => {
+        const harness = loadAuthGuardHarness({
+            url: 'http://localhost:3000/pages/schedule-builder.html',
+            session: null,
+            user: null,
+            canResult: false,
+            presenceService: null
+        });
+
+        await harness.triggerDomReady();
+
+        expect(harness.authService.getSession).not.toHaveBeenCalled();
+        expect(harness.location.replace).not.toHaveBeenCalled();
 
         harness.cleanup();
     });


### PR DESCRIPTION
## Summary
- enforce auth guard by default on non-local hosts (production/staging behavior)
- bypass auth guard by default on local dev hosts (`localhost`, `127.0.0.1`, `::1`)
- add explicit override switches:
  - query param `?auth=required|disabled`
  - global `window.PROGRAM_COMMAND_AUTH_MODE = 'required'|'disabled'`
- add integration test coverage for localhost bypass behavior
- document environment auth enforcement in auth contract

## Validation
- `npm test -- --runInBand`
- `npm run qa:onboarding`
