### PR TITLE
feat(conflicts): define CE-01 conflict severity taxonomy

### DIFF
--- a/docs/conflict-engine-pluggable-architecture-ce02.md
+++ b/docs/conflict-engine-pluggable-architecture-ce02.md
@@ -1,0 +1,59 @@
+# Conflict Engine Pluggable Architecture (CE-02)
+
+Issue: [#142](https://github.com/sicxz/program-command/issues/142)
+
+## Overview
+Conflict Engine now operates as an orchestrator over registered rule plugins.
+
+Core runtime flow:
+1. resolve enabled constraints
+2. resolve plugin by normalized `constraint_type`
+3. run `plugin.detect(schedule, ruleDetails, constraint, context)`
+4. apply CE-01 tier normalization + scoring
+5. bucket into `conflicts`, `warnings`, `suggestions`
+
+## RulePlugin Interface
+```ts
+interface RulePlugin {
+  id: string;
+  name: string;
+  tier?: 'hard_block' | 'warning' | 'suggestion' | 'optimization';
+  enabled?: boolean;
+  weight?: number;
+  detect(schedule: any[], ruleDetails: Record<string, any>, constraint: any, context: Record<string, any>): any[];
+}
+```
+
+## Registry API
+- `registerRule(plugin)`
+- `enableRule(id)`
+- `disableRule(id)`
+- `setWeight(id, weight)`
+- `listRules()`
+
+## Backward Compatibility
+- Existing `evaluate(schedule, constraints, context)` API remains unchanged.
+- Added alias: `findIssues(schedule, constraints, context)`.
+- Existing checker functions are still available via `ConflictEngine.checkers`.
+- Existing conflict rules are pre-registered as built-in plugins during engine initialization.
+
+## Per-Program Overrides
+`evaluate(..., context)` supports optional rule overrides:
+```js
+{
+  ruleOverrides: {
+    student_conflict: { enabled: false },
+    faculty_double_book: { weight: 1.5 }
+  }
+}
+```
+
+## Built-in Rules Registered as Plugins
+- `room_restriction`
+- `student_conflict`
+- `faculty_double_book`
+- `room_double_book`
+- `evening_safety`
+- `ay_setup_alignment`
+- `enrollment_threshold`
+- `campus_transition`

--- a/docs/conflict-severity-taxonomy-ce01.md
+++ b/docs/conflict-severity-taxonomy-ce01.md
@@ -1,0 +1,83 @@
+# Conflict Severity Taxonomy (CE-01)
+
+Issue: [#141](https://github.com/sicxz/program-command/issues/141)
+
+## Purpose
+Define the canonical 4-tier severity model for Conflict Engine v2 while preserving legacy `critical|warning|info` compatibility in current UI/test flows.
+
+## Canonical Tiers
+| Tier | Score Range | Meaning | UX Treatment | Save Behavior |
+|---|---:|---|---|---|
+| `hard_block` | 90-100 | Non-negotiable constraint violation | Red blocking banner/card | Save blocked |
+| `warning` | 50-89 | Real problem that should be fixed | Yellow warning card with acknowledge path | Save allowed with acknowledgment |
+| `suggestion` | 20-49 | Actionable improvement opportunity | Blue info card, dismissible | Save allowed |
+| `optimization` | 1-19 | Nice-to-have quality optimization | Green tip, collapsible by default | Save allowed |
+
+## Legacy Compatibility
+`critical -> hard_block`, `warning -> warning`, `info -> suggestion`.
+
+For existing rendering/tests, engine still emits `severity` as legacy values (`critical|warning|info`) and adds canonical `severityTier`/`tier`.
+
+## Current Conflict-Type Mapping (8 Existing Types)
+| Constraint Type | Default Tier | Rationale |
+|---|---|---|
+| `faculty_double_book` | `hard_block` | Instructor cannot teach two rooms at once |
+| `room_double_book` | `hard_block` | Physical room collision is unschedulable |
+| `student_conflict` | `warning` | Pathway conflict is serious but often resolvable |
+| `room_restriction` | `warning` | Usually fixable by room/time adjustment |
+| `evening_safety` | `warning` | Operational risk, requires review |
+| `ay_setup_alignment` | `warning` | Planning drift should be corrected before finalization |
+| `enrollment_threshold` | `suggestion` | Forecast/quality signal, not hard invalidity |
+| `campus_transition` | `suggestion` | Scheduling quality concern by default |
+
+## Escalation / Demotion Rules
+1. Student pathway conflict promotion:
+- If `daysUntilGraduation <= 45` and tier is `suggestion`, promote to `warning`.
+- If `daysUntilGraduation <= 14`, issue is upper-division/graduation-critical, and tier is `warning`, promote to `hard_block`.
+
+2. Student pathway conflict demotion:
+- If `daysUntilGraduation >= 120`, tier is `warning`, and `pathwayImpactScore <= 8`, demote to `suggestion`.
+
+3. Room restriction escalation:
+- If room-fit result is `blocked`, force tier to `hard_block`.
+
+## Type Definitions (Documentation-Only)
+```ts
+export type ConflictSeverityTier =
+  | 'hard_block'
+  | 'warning'
+  | 'suggestion'
+  | 'optimization';
+
+export type LegacySeverity = 'critical' | 'warning' | 'info';
+
+export interface ConflictIssue {
+  constraintId?: string;
+  constraintType?: string;
+  severity: LegacySeverity;        // backward compatibility
+  severityTier: ConflictSeverityTier; // canonical CE-01 tier
+  tier: ConflictSeverityTier;      // alias of severityTier
+  blocksSave: boolean;
+  title: string;
+  description: string;
+  score?: number;
+  priority?: 'critical' | 'high' | 'medium' | 'low';
+  courses?: Array<Record<string, unknown>>;
+  suggestion?: string;
+}
+
+export interface ConflictSummary {
+  totalIssues: number;            // backward-compatible actionable count
+  totalActionableIssues: number;  // hard_block + warning
+  totalTieredIssues: number;      // all tiers
+  criticalCount: number;          // hard_block count (legacy name)
+  warningCount: number;
+  tierCounts: Record<ConflictSeverityTier, number>;
+  weightedScore: number;
+  weightedByConstraintType: Record<string, number>;
+}
+```
+
+## Code Touchpoints
+- `js/config/constants.js` (`CONFLICTS` section)
+- `js/conflict-engine.js` (tier normalization, scoring, and result bucketing)

--- a/js/config/constants.js
+++ b/js/config/constants.js
@@ -196,6 +196,88 @@ const CONSTANTS = {
     },
 
     // ===========================================
+    // CONFLICT ENGINE TAXONOMY (CE-01)
+    // ===========================================
+    CONFLICTS: {
+        /**
+         * Canonical severity tiers used by Conflict Engine v2
+         */
+        TIERS: {
+            HARD_BLOCK: {
+                id: 'hard_block',
+                label: 'Hard Block',
+                scoreMin: 90,
+                scoreMax: 100,
+                blocksSave: true,
+                uiTreatment: 'red-banner-blocking'
+            },
+            WARNING: {
+                id: 'warning',
+                label: 'Warning',
+                scoreMin: 50,
+                scoreMax: 89,
+                blocksSave: false,
+                uiTreatment: 'yellow-card-acknowledge'
+            },
+            SUGGESTION: {
+                id: 'suggestion',
+                label: 'Suggestion',
+                scoreMin: 20,
+                scoreMax: 49,
+                blocksSave: false,
+                uiTreatment: 'blue-info-dismissible'
+            },
+            OPTIMIZATION: {
+                id: 'optimization',
+                label: 'Optimization',
+                scoreMin: 1,
+                scoreMax: 19,
+                blocksSave: false,
+                uiTreatment: 'green-tip-collapsible'
+            }
+        },
+
+        /**
+         * Legacy compatibility for current engine outputs/UI
+         */
+        LEGACY_SEVERITY_TO_TIER: {
+            critical: 'hard_block',
+            warning: 'warning',
+            info: 'suggestion'
+        },
+        TIER_TO_LEGACY_SEVERITY: {
+            hard_block: 'critical',
+            warning: 'warning',
+            suggestion: 'info',
+            optimization: 'info'
+        },
+
+        /**
+         * Default tier assignment for current checker set (8 conflict types)
+         */
+        DEFAULT_TIER_BY_CONSTRAINT: {
+            room_restriction: 'warning',
+            student_conflict: 'warning',
+            faculty_double_book: 'hard_block',
+            room_double_book: 'hard_block',
+            evening_safety: 'warning',
+            ay_setup_alignment: 'warning',
+            enrollment_threshold: 'suggestion',
+            campus_transition: 'suggestion'
+        },
+
+        /**
+         * Escalation and demotion guardrails
+         */
+        ESCALATION: {
+            STUDENT_CONFLICT_PROMOTE_WARNING_DAYS: 45,
+            STUDENT_CONFLICT_PROMOTE_HARD_BLOCK_DAYS: 14,
+            STUDENT_CONFLICT_DEMOTE_SUGGESTION_DAYS: 120,
+            LOW_IMPACT_PATHWAY_SCORE_MAX: 8
+        }
+    },
+
+    // ===========================================
     // DATA LOADING CONFIGURATION
     // ===========================================
     DATA: {
@@ -340,6 +422,16 @@ if (typeof Object.freeze === 'function') {
     Object.freeze(CONSTANTS.CHART);
     Object.freeze(CONSTANTS.CHART.COLORS);
     Object.freeze(CONSTANTS.UI);
+    Object.freeze(CONSTANTS.CONFLICTS);
+    Object.freeze(CONSTANTS.CONFLICTS.TIERS);
+    Object.freeze(CONSTANTS.CONFLICTS.TIERS.HARD_BLOCK);
+    Object.freeze(CONSTANTS.CONFLICTS.TIERS.WARNING);
+    Object.freeze(CONSTANTS.CONFLICTS.TIERS.SUGGESTION);
+    Object.freeze(CONSTANTS.CONFLICTS.TIERS.OPTIMIZATION);
+    Object.freeze(CONSTANTS.CONFLICTS.LEGACY_SEVERITY_TO_TIER);
+    Object.freeze(CONSTANTS.CONFLICTS.TIER_TO_LEGACY_SEVERITY);
+    Object.freeze(CONSTANTS.CONFLICTS.DEFAULT_TIER_BY_CONSTRAINT);
+    Object.freeze(CONSTANTS.CONFLICTS.ESCALATION);
     Object.freeze(CONSTANTS.DATA);
     Object.freeze(CONSTANTS.NOTIFICATIONS);
     Object.freeze(CONSTANTS.EXPORT);

--- a/js/conflict-engine.js
+++ b/js/conflict-engine.js
@@ -93,10 +93,95 @@ const ConflictEngine = (function() {
         student_scheduling_conflict: 'student_conflict'
     };
 
+    const FALLBACK_CONFLICT_TAXONOMY = {
+        tiers: {
+            hard_block: { label: 'Hard Block', scoreMin: 90, scoreMax: 100, blocksSave: true },
+            warning: { label: 'Warning', scoreMin: 50, scoreMax: 89, blocksSave: false },
+            suggestion: { label: 'Suggestion', scoreMin: 20, scoreMax: 49, blocksSave: false },
+            optimization: { label: 'Optimization', scoreMin: 1, scoreMax: 19, blocksSave: false }
+        },
+        legacyToTier: {
+            critical: 'hard_block',
+            warning: 'warning',
+            info: 'suggestion'
+        },
+        tierToLegacy: {
+            hard_block: 'critical',
+            warning: 'warning',
+            suggestion: 'info',
+            optimization: 'info'
+        },
+        defaultTierByConstraint: {
+            room_restriction: 'warning',
+            student_conflict: 'warning',
+            faculty_double_book: 'hard_block',
+            room_double_book: 'hard_block',
+            evening_safety: 'warning',
+            ay_setup_alignment: 'warning',
+            enrollment_threshold: 'suggestion',
+            campus_transition: 'suggestion'
+        },
+        escalation: {
+            STUDENT_CONFLICT_PROMOTE_WARNING_DAYS: 45,
+            STUDENT_CONFLICT_PROMOTE_HARD_BLOCK_DAYS: 14,
+            STUDENT_CONFLICT_DEMOTE_SUGGESTION_DAYS: 120,
+            LOW_IMPACT_PATHWAY_SCORE_MAX: 8
+        }
+    };
+
+    const externalConflictConstants = (
+        typeof CONSTANTS !== 'undefined'
+        && CONSTANTS
+        && typeof CONSTANTS === 'object'
+        && CONSTANTS.CONFLICTS
+    ) ? CONSTANTS.CONFLICTS : null;
+
+    const CONFLICT_TIER_DEFINITIONS = {
+        ...FALLBACK_CONFLICT_TAXONOMY.tiers,
+        ...(externalConflictConstants?.TIERS
+            ? {
+                hard_block: externalConflictConstants.TIERS.HARD_BLOCK || FALLBACK_CONFLICT_TAXONOMY.tiers.hard_block,
+                warning: externalConflictConstants.TIERS.WARNING || FALLBACK_CONFLICT_TAXONOMY.tiers.warning,
+                suggestion: externalConflictConstants.TIERS.SUGGESTION || FALLBACK_CONFLICT_TAXONOMY.tiers.suggestion,
+                optimization: externalConflictConstants.TIERS.OPTIMIZATION || FALLBACK_CONFLICT_TAXONOMY.tiers.optimization
+            }
+            : {})
+    };
+
+    const LEGACY_SEVERITY_TO_TIER = {
+        ...FALLBACK_CONFLICT_TAXONOMY.legacyToTier,
+        ...(externalConflictConstants?.LEGACY_SEVERITY_TO_TIER || {})
+    };
+
+    const TIER_TO_LEGACY_SEVERITY = {
+        ...FALLBACK_CONFLICT_TAXONOMY.tierToLegacy,
+        ...(externalConflictConstants?.TIER_TO_LEGACY_SEVERITY || {})
+    };
+
+    const DEFAULT_TIER_BY_CONSTRAINT = {
+        ...FALLBACK_CONFLICT_TAXONOMY.defaultTierByConstraint,
+        ...(externalConflictConstants?.DEFAULT_TIER_BY_CONSTRAINT || {})
+    };
+
+    const TIER_ESCALATION = {
+        ...FALLBACK_CONFLICT_TAXONOMY.escalation,
+        ...(externalConflictConstants?.ESCALATION || {})
+    };
+
+    function resolveTierScore(tier) {
+        const def = CONFLICT_TIER_DEFINITIONS[tier];
+        if (!def) return 20;
+        const min = Number(def.scoreMin);
+        const max = Number(def.scoreMax);
+        if (!Number.isFinite(min) || !Number.isFinite(max)) return 20;
+        return Math.round((min + max) / 2);
+    }
+
     const ISSUE_SEVERITY_SCORE = {
-        critical: 100,
-        warning: 60,
-        info: 25
+        hard_block: resolveTierScore('hard_block'),
+        warning: resolveTierScore('warning'),
+        suggestion: resolveTierScore('suggestion'),
+        optimization: resolveTierScore('optimization')
     };
 
     const ISSUE_PRIORITY_SCORE = {
@@ -169,6 +254,90 @@ const ConflictEngine = (function() {
     function normalizeConstraintType(type) {
         const normalized = String(type || '').trim().toLowerCase();
         return CONSTRAINT_TYPE_ALIASES[normalized] || normalized;
+    }
+
+    function toTierName(rawValue) {
+        const normalized = String(rawValue || '').trim().toLowerCase().replace(/\s+/g, '_');
+        if (!normalized) return '';
+        if (CONFLICT_TIER_DEFINITIONS[normalized]) return normalized;
+        return LEGACY_SEVERITY_TO_TIER[normalized] || '';
+    }
+
+    function clampIssueTier(baseTier, normalizedConstraintType) {
+        if (CONFLICT_TIER_DEFINITIONS[baseTier]) return baseTier;
+        const fallback = DEFAULT_TIER_BY_CONSTRAINT[normalizedConstraintType];
+        if (CONFLICT_TIER_DEFINITIONS[fallback]) return fallback;
+        return 'suggestion';
+    }
+
+    function isUpperDivisionPathwayIssue(issue) {
+        const courses = Array.isArray(issue?.courses) ? issue.courses : [];
+        const has400LevelCourse = courses.some((course) => {
+            const code = normalizeCourseCode(course?.code || course);
+            const match = code.match(/(\d{3})/);
+            return match ? Number(match[1]) >= 400 : false;
+        });
+        return has400LevelCourse || String(issue?.pathwayImpact || '').includes('graduation');
+    }
+
+    function promoteTier(tier) {
+        if (tier === 'optimization') return 'suggestion';
+        if (tier === 'suggestion') return 'warning';
+        if (tier === 'warning') return 'hard_block';
+        return 'hard_block';
+    }
+
+    function demoteTier(tier) {
+        if (tier === 'hard_block') return 'warning';
+        if (tier === 'warning') return 'suggestion';
+        if (tier === 'suggestion') return 'optimization';
+        return 'optimization';
+    }
+
+    function applyTierEscalationRules(tier, normalizedConstraintType, issue, context = {}) {
+        let nextTier = clampIssueTier(tier, normalizedConstraintType);
+        const daysUntilGraduation = Number(
+            context.daysUntilGraduation ?? context.graduationDeadlineDays
+        );
+        const pathwayImpactScore = Number(issue?.pathwayImpactScore || 0);
+
+        if (normalizedConstraintType === 'student_conflict' && Number.isFinite(daysUntilGraduation)) {
+            if (daysUntilGraduation <= TIER_ESCALATION.STUDENT_CONFLICT_PROMOTE_WARNING_DAYS && nextTier === 'suggestion') {
+                nextTier = promoteTier(nextTier);
+            }
+
+            if (
+                daysUntilGraduation <= TIER_ESCALATION.STUDENT_CONFLICT_PROMOTE_HARD_BLOCK_DAYS
+                && nextTier === 'warning'
+                && isUpperDivisionPathwayIssue(issue)
+            ) {
+                nextTier = promoteTier(nextTier);
+            }
+
+            if (
+                daysUntilGraduation >= TIER_ESCALATION.STUDENT_CONFLICT_DEMOTE_SUGGESTION_DAYS
+                && nextTier === 'warning'
+                && pathwayImpactScore <= TIER_ESCALATION.LOW_IMPACT_PATHWAY_SCORE_MAX
+            ) {
+                nextTier = demoteTier(nextTier);
+            }
+        }
+
+        if (normalizedConstraintType === 'room_restriction' && issue?.roomFitStatus === 'blocked') {
+            nextTier = 'hard_block';
+        }
+
+        return clampIssueTier(nextTier, normalizedConstraintType);
+    }
+
+    function resolveIssueTier(issue, normalizedConstraintType, context = {}) {
+        const raw = issue?.severityTier || issue?.tier || issue?.severity;
+        const baseTier = clampIssueTier(toTierName(raw), normalizedConstraintType);
+        return applyTierEscalationRules(baseTier, normalizedConstraintType, issue, context);
+    }
+
+    function resolveLegacySeverityFromTier(tier) {
+        return TIER_TO_LEGACY_SEVERITY[tier] || 'info';
     }
 
     function normalizeTimeSlotLabel(timeSlot) {
@@ -371,11 +540,14 @@ const ConflictEngine = (function() {
 
     function calculateWeightedIssueScore(issue, normalizedConstraintType, ruleDetails = {}) {
         const registry = getRuleRegistryEntry(normalizedConstraintType);
-        const severity = String(issue?.severity || 'info').toLowerCase();
+        const tier = clampIssueTier(
+            toTierName(issue?.severityTier || issue?.tier || issue?.severity),
+            normalizedConstraintType
+        );
         const priority = String(issue?.priority || '').toLowerCase();
         const ruleWeightOverride = Number(ruleDetails?.weight);
         const ruleWeight = Number.isFinite(ruleWeightOverride) ? ruleWeightOverride : 1;
-        const severityWeight = ISSUE_SEVERITY_SCORE[severity] || ISSUE_SEVERITY_SCORE.info;
+        const severityWeight = ISSUE_SEVERITY_SCORE[tier] || ISSUE_SEVERITY_SCORE.suggestion;
         const priorityWeight = ISSUE_PRIORITY_SCORE[priority] || 0;
         const hardnessMultiplier = registry.hardness === 'hard' ? 1.15 : 0.85;
         const impactCourseCount = Array.isArray(issue?.courses) ? issue.courses.length : 0;
@@ -386,7 +558,7 @@ const ConflictEngine = (function() {
             : 0;
 
         const contributions = [
-            { source: 'severity', value: severityWeight, detail: severity },
+            { source: 'severity', value: severityWeight, detail: tier },
             { source: 'registry-base', value: baseWeight, detail: registry.id },
             { source: 'priority', value: priorityWeight, detail: priority || 'none' },
             { source: 'affected-courses', value: impactWeight, detail: impactCourseCount }
@@ -411,7 +583,7 @@ const ConflictEngine = (function() {
             total,
             explanation: [
                 `${registry.label} (${registry.hardness})`,
-                `severity=${severity}`,
+                `tier=${tier}`,
                 priority ? `priority=${priority}` : null,
                 issue?.pathwayImpact ? `pathway=${issue.pathwayImpact}` : null,
                 `courses=${impactCourseCount}`,
@@ -432,9 +604,11 @@ const ConflictEngine = (function() {
         };
     }
 
-    function getIssueSeverityRank(severity) {
-        if (severity === 'critical') return 2;
-        if (severity === 'warning') return 1;
+    function getIssueSeverityRank(severityOrTier) {
+        const tier = toTierName(severityOrTier) || 'suggestion';
+        if (tier === 'hard_block') return 3;
+        if (tier === 'warning') return 2;
+        if (tier === 'suggestion') return 1;
         return 0;
     }
 
@@ -799,14 +973,23 @@ const ConflictEngine = (function() {
             suggestions: [],
             summary: {
                 totalIssues: 0,
+                totalActionableIssues: 0,
+                totalTieredIssues: 0,
                 criticalCount: 0,
                 warningCount: 0,
+                tierCounts: {
+                    hard_block: 0,
+                    warning: 0,
+                    suggestion: 0,
+                    optimization: 0
+                },
                 weightedScore: 0,
                 weightedByConstraintType: {}
             },
             scoringModel: {
                 version: 'v2',
-                registry: CONFLICT_RULE_REGISTRY
+                registry: CONFLICT_RULE_REGISTRY,
+                taxonomy: CONFLICT_TIER_DEFINITIONS
             }
         };
 
@@ -831,6 +1014,10 @@ const ConflictEngine = (function() {
                     issue.constraintType = normalizedConstraintType;
                     issue.constraintTypeOriginal = constraint.constraint_type;
                     issue.constraintRule = getRuleRegistryEntry(normalizedConstraintType);
+                    issue.severityTier = resolveIssueTier(issue, normalizedConstraintType, evaluationContext);
+                    issue.tier = issue.severityTier;
+                    issue.severity = resolveLegacySeverityFromTier(issue.severityTier);
+                    issue.blocksSave = Boolean(CONFLICT_TIER_DEFINITIONS[issue.severityTier]?.blocksSave);
 
                     const weighted = calculateWeightedIssueScore(
                         issue,
@@ -845,11 +1032,13 @@ const ConflictEngine = (function() {
                     results.summary.weightedScore += issue.score;
                     results.summary.weightedByConstraintType[normalizedConstraintType] =
                         (results.summary.weightedByConstraintType[normalizedConstraintType] || 0) + issue.score;
+                    results.summary.tierCounts[issue.severityTier] =
+                        (results.summary.tierCounts[issue.severityTier] || 0) + 1;
 
-                    if (issue.severity === 'critical') {
+                    if (issue.severityTier === 'hard_block') {
                         results.conflicts.push(issue);
                         results.summary.criticalCount++;
-                    } else if (issue.severity === 'warning') {
+                    } else if (issue.severityTier === 'warning') {
                         results.warnings.push(issue);
                         results.summary.warningCount++;
                     } else {
@@ -859,7 +1048,10 @@ const ConflictEngine = (function() {
             }
         });
 
-        results.summary.totalIssues = results.conflicts.length + results.warnings.length;
+        results.summary.totalActionableIssues = results.conflicts.length + results.warnings.length;
+        results.summary.totalTieredIssues = results.conflicts.length + results.warnings.length + results.suggestions.length;
+        // Backward-compatible field used by existing UI sections.
+        results.summary.totalIssues = results.summary.totalActionableIssues;
         return results;
     }
 

--- a/js/conflict-engine.js
+++ b/js/conflict-engine.js
@@ -251,6 +251,19 @@ const ConflictEngine = (function() {
         }
     };
 
+    const DEFAULT_RULE_PLUGIN_METADATA = {
+        room_restriction: { name: 'Room Restriction Rule', tier: 'warning' },
+        student_conflict: { name: 'Student Pathway Rule', tier: 'warning' },
+        faculty_double_book: { name: 'Faculty Double Book Rule', tier: 'hard_block' },
+        room_double_book: { name: 'Room Double Book Rule', tier: 'hard_block' },
+        evening_safety: { name: 'Evening Safety Rule', tier: 'warning' },
+        ay_setup_alignment: { name: 'AY Setup Alignment Rule', tier: 'warning' },
+        enrollment_threshold: { name: 'Enrollment Threshold Rule', tier: 'suggestion' },
+        campus_transition: { name: 'Campus Transition Rule', tier: 'suggestion' }
+    };
+
+    const rulePlugins = new Map();
+
     function normalizeConstraintType(type) {
         const normalized = String(type || '').trim().toLowerCase();
         return CONSTRAINT_TYPE_ALIASES[normalized] || normalized;
@@ -536,6 +549,117 @@ const ConflictEngine = (function() {
 
     function getRuleRegistryEntry(normalizedConstraintType) {
         return CONFLICT_RULE_REGISTRY[normalizedConstraintType] || CONFLICT_RULE_REGISTRY._default;
+    }
+
+    /**
+     * @typedef {Object} RulePlugin
+     * @property {string} id
+     * @property {string} name
+     * @property {'hard_block'|'warning'|'suggestion'|'optimization'} [tier]
+     * @property {boolean} [enabled]
+     * @property {number} [weight]
+     * @property {(schedule: Array, ruleDetails: Object, constraint: Object, context: Object) => Array} detect
+     */
+
+    function normalizeRulePlugin(plugin = {}) {
+        const id = normalizeConstraintType(plugin.id);
+        if (!id) {
+            throw new Error('Rule plugin requires a non-empty id');
+        }
+        if (typeof plugin.detect !== 'function') {
+            throw new Error(`Rule plugin "${id}" requires a detect(schedule, context) function`);
+        }
+
+        const metadata = DEFAULT_RULE_PLUGIN_METADATA[id] || {};
+        const tier = clampIssueTier(toTierName(plugin.tier || metadata.tier), id);
+        const weight = Number(plugin.weight);
+
+        return {
+            id,
+            name: String(plugin.name || metadata.name || id),
+            tier,
+            enabled: plugin.enabled !== false,
+            detect: plugin.detect,
+            weight: Number.isFinite(weight) ? weight : 1
+        };
+    }
+
+    function registerRule(plugin, options = {}) {
+        const normalized = normalizeRulePlugin(plugin);
+        const replace = options.replace === true;
+        if (!replace && rulePlugins.has(normalized.id)) {
+            throw new Error(`Rule plugin "${normalized.id}" is already registered`);
+        }
+        rulePlugins.set(normalized.id, normalized);
+        return normalized;
+    }
+
+    function getRulePlugin(id) {
+        const normalized = normalizeConstraintType(id);
+        return rulePlugins.get(normalized) || null;
+    }
+
+    function enableRule(id) {
+        const plugin = getRulePlugin(id);
+        if (!plugin) return false;
+        plugin.enabled = true;
+        return true;
+    }
+
+    function disableRule(id) {
+        const plugin = getRulePlugin(id);
+        if (!plugin) return false;
+        plugin.enabled = false;
+        return true;
+    }
+
+    function setWeight(id, weight) {
+        const plugin = getRulePlugin(id);
+        const numericWeight = Number(weight);
+        if (!plugin || !Number.isFinite(numericWeight)) return false;
+        plugin.weight = numericWeight;
+        return true;
+    }
+
+    function getProgramRuleOverride(context, id) {
+        const overrides = context?.ruleOverrides;
+        if (!overrides || typeof overrides !== 'object') return null;
+        const override = overrides[id];
+        return override && typeof override === 'object' ? override : null;
+    }
+
+    function isRuleEnabledForEvaluation(plugin, context = {}) {
+        if (!plugin || plugin.enabled === false) return false;
+        const override = getProgramRuleOverride(context, plugin.id);
+        if (override && typeof override.enabled === 'boolean') {
+            return override.enabled;
+        }
+        return true;
+    }
+
+    function getEffectiveRuleDetails(plugin, ruleDetails = {}, context = {}) {
+        const rawRule = (ruleDetails && typeof ruleDetails === 'object') ? { ...ruleDetails } : {};
+        const override = getProgramRuleOverride(context, plugin.id);
+
+        if (!Number.isFinite(Number(rawRule.weight))) {
+            if (override && Number.isFinite(Number(override.weight))) {
+                rawRule.weight = Number(override.weight);
+            } else if (Number.isFinite(Number(plugin.weight))) {
+                rawRule.weight = Number(plugin.weight);
+            }
+        }
+
+        return rawRule;
+    }
+
+    function listRegisteredRules() {
+        return Array.from(rulePlugins.values()).map((plugin) => ({
+            id: plugin.id,
+            name: plugin.name,
+            tier: plugin.tier,
+            enabled: plugin.enabled !== false,
+            weight: Number(plugin.weight)
+        }));
     }
 
     function calculateWeightedIssueScore(issue, normalizedConstraintType, ruleDetails = {}) {
@@ -989,7 +1113,8 @@ const ConflictEngine = (function() {
             scoringModel: {
                 version: 'v2',
                 registry: CONFLICT_RULE_REGISTRY,
-                taxonomy: CONFLICT_TIER_DEFINITIONS
+                taxonomy: CONFLICT_TIER_DEFINITIONS,
+                registeredRules: listRegisteredRules()
             }
         };
 
@@ -1003,49 +1128,53 @@ const ConflictEngine = (function() {
             enabledConstraints
         };
 
-        // Run each enabled constraint checker
+        // Run each enabled constraint rule plugin
         enabledConstraints.forEach(constraint => {
             const normalizedConstraintType = normalizeConstraintType(constraint.constraint_type);
-            const checker = checkers[normalizedConstraintType];
-            if (checker) {
-                const issues = checker(schedule, constraint.rule_details, constraint, evaluationContext);
-                issues.forEach(issue => {
-                    issue.constraintId = constraint.id;
-                    issue.constraintType = normalizedConstraintType;
-                    issue.constraintTypeOriginal = constraint.constraint_type;
-                    issue.constraintRule = getRuleRegistryEntry(normalizedConstraintType);
-                    issue.severityTier = resolveIssueTier(issue, normalizedConstraintType, evaluationContext);
-                    issue.tier = issue.severityTier;
-                    issue.severity = resolveLegacySeverityFromTier(issue.severityTier);
-                    issue.blocksSave = Boolean(CONFLICT_TIER_DEFINITIONS[issue.severityTier]?.blocksSave);
+            const plugin = getRulePlugin(normalizedConstraintType);
+            if (!plugin || !isRuleEnabledForEvaluation(plugin, evaluationContext)) return;
 
-                    const weighted = calculateWeightedIssueScore(
-                        issue,
-                        normalizedConstraintType,
-                        constraint.rule_details
-                    );
-                    issue.score = weighted.total;
-                    issue.scoreExplanation = weighted.explanation;
-                    issue.scoreBreakdown = weighted.breakdown;
-                    issue.scoreRuleMeta = weighted.rule;
+            const effectiveRuleDetails = getEffectiveRuleDetails(plugin, constraint.rule_details, evaluationContext);
+            const issues = plugin.detect(schedule, effectiveRuleDetails, constraint, evaluationContext);
 
-                    results.summary.weightedScore += issue.score;
-                    results.summary.weightedByConstraintType[normalizedConstraintType] =
-                        (results.summary.weightedByConstraintType[normalizedConstraintType] || 0) + issue.score;
-                    results.summary.tierCounts[issue.severityTier] =
-                        (results.summary.tierCounts[issue.severityTier] || 0) + 1;
+            (Array.isArray(issues) ? issues : []).forEach(issue => {
+                issue.constraintId = constraint.id;
+                issue.constraintType = normalizedConstraintType;
+                issue.constraintTypeOriginal = constraint.constraint_type;
+                issue.constraintRule = getRuleRegistryEntry(normalizedConstraintType);
+                issue.rulePluginId = plugin.id;
+                issue.rulePluginName = plugin.name;
+                issue.severityTier = resolveIssueTier(issue, normalizedConstraintType, evaluationContext);
+                issue.tier = issue.severityTier;
+                issue.severity = resolveLegacySeverityFromTier(issue.severityTier);
+                issue.blocksSave = Boolean(CONFLICT_TIER_DEFINITIONS[issue.severityTier]?.blocksSave);
 
-                    if (issue.severityTier === 'hard_block') {
-                        results.conflicts.push(issue);
-                        results.summary.criticalCount++;
-                    } else if (issue.severityTier === 'warning') {
-                        results.warnings.push(issue);
-                        results.summary.warningCount++;
-                    } else {
-                        results.suggestions.push(issue);
-                    }
-                });
-            }
+                const weighted = calculateWeightedIssueScore(
+                    issue,
+                    normalizedConstraintType,
+                    effectiveRuleDetails
+                );
+                issue.score = weighted.total;
+                issue.scoreExplanation = weighted.explanation;
+                issue.scoreBreakdown = weighted.breakdown;
+                issue.scoreRuleMeta = weighted.rule;
+
+                results.summary.weightedScore += issue.score;
+                results.summary.weightedByConstraintType[normalizedConstraintType] =
+                    (results.summary.weightedByConstraintType[normalizedConstraintType] || 0) + issue.score;
+                results.summary.tierCounts[issue.severityTier] =
+                    (results.summary.tierCounts[issue.severityTier] || 0) + 1;
+
+                if (issue.severityTier === 'hard_block') {
+                    results.conflicts.push(issue);
+                    results.summary.criticalCount++;
+                } else if (issue.severityTier === 'warning') {
+                    results.warnings.push(issue);
+                    results.summary.warningCount++;
+                } else {
+                    results.suggestions.push(issue);
+                }
+            });
         });
 
         results.summary.totalActionableIssues = results.conflicts.length + results.warnings.length;
@@ -1053,6 +1182,11 @@ const ConflictEngine = (function() {
         // Backward-compatible field used by existing UI sections.
         results.summary.totalIssues = results.summary.totalActionableIssues;
         return results;
+    }
+
+    // Backward-compatible API alias
+    function findIssues(schedule, constraints, context = {}) {
+        return evaluate(schedule, constraints, context);
     }
 
     /**
@@ -1340,6 +1474,16 @@ const ConflictEngine = (function() {
         }
     };
 
+    Object.entries(checkers).forEach(([id, detect]) => {
+        const metadata = DEFAULT_RULE_PLUGIN_METADATA[id] || {};
+        registerRule({
+            id,
+            name: metadata.name || id,
+            tier: metadata.tier || 'suggestion',
+            detect
+        });
+    });
+
     /**
      * Calculate available room resolutions for a course
      */
@@ -1495,10 +1639,16 @@ const ConflictEngine = (function() {
     // Public API
     return {
         evaluate,
+        findIssues,
         checkers,
         COMMON_PAIRINGS,
         evaluateAySetup,
-        ruleRegistry: CONFLICT_RULE_REGISTRY
+        ruleRegistry: CONFLICT_RULE_REGISTRY,
+        registerRule,
+        enableRule,
+        disableRule,
+        setWeight,
+        listRules: listRegisteredRules
     };
 })();
 

--- a/tests/conflict-engine.plugins.test.js
+++ b/tests/conflict-engine.plugins.test.js
@@ -1,0 +1,117 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadScriptModule(relativePath) {
+    const filePath = path.resolve(__dirname, '..', relativePath);
+    const source = fs.readFileSync(filePath, 'utf8');
+
+    const sandbox = {
+        console,
+        module: { exports: {} },
+        exports: {}
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: relativePath });
+    return sandbox.module.exports;
+}
+
+describe('ConflictEngine pluggable rule registry (CE-02)', () => {
+    const ConflictEngine = loadScriptModule('js/conflict-engine.js');
+
+    function buildFacultyConflictSchedule() {
+        return [
+            { code: 'DESN 301', day: 'MW', time: '10:00-12:20', room: '206', instructor: 'S.Mills' },
+            { code: 'DESN 401', day: 'MW', time: '10:00-12:20', room: '209', instructor: 'S.Mills' }
+        ];
+    }
+
+    function buildFacultyConstraint() {
+        return [
+            {
+                id: 'faculty-double-book',
+                enabled: true,
+                constraint_type: 'faculty_double_book',
+                rule_details: { severity: 'critical' }
+            }
+        ];
+    }
+
+    test('exposes registry APIs and keeps findIssues backward-compatible with evaluate', () => {
+        expect(typeof ConflictEngine.registerRule).toBe('function');
+        expect(typeof ConflictEngine.enableRule).toBe('function');
+        expect(typeof ConflictEngine.disableRule).toBe('function');
+        expect(typeof ConflictEngine.setWeight).toBe('function');
+        expect(typeof ConflictEngine.listRules).toBe('function');
+        expect(typeof ConflictEngine.findIssues).toBe('function');
+
+        const schedule = buildFacultyConflictSchedule();
+        const constraints = buildFacultyConstraint();
+
+        const evaluateResult = ConflictEngine.evaluate(schedule, constraints);
+        const findIssuesResult = ConflictEngine.findIssues(schedule, constraints);
+
+        expect(JSON.stringify(findIssuesResult)).toBe(JSON.stringify(evaluateResult));
+    });
+
+    test('supports enable/disable toggles for registered rules', () => {
+        const schedule = buildFacultyConflictSchedule();
+        const constraints = buildFacultyConstraint();
+
+        expect(ConflictEngine.disableRule('faculty_double_book')).toBe(true);
+        const disabledResult = ConflictEngine.evaluate(schedule, constraints);
+        expect(disabledResult.conflicts).toHaveLength(0);
+
+        expect(ConflictEngine.enableRule('faculty_double_book')).toBe(true);
+        const enabledResult = ConflictEngine.evaluate(schedule, constraints);
+        expect(enabledResult.conflicts.length).toBeGreaterThan(0);
+    });
+
+    test('supports program-level rule enable overrides and plugin weights', () => {
+        const schedule = buildFacultyConflictSchedule();
+        const constraints = buildFacultyConstraint();
+
+        const disabledByOverride = ConflictEngine.evaluate(schedule, constraints, {
+            ruleOverrides: {
+                faculty_double_book: { enabled: false }
+            }
+        });
+        expect(disabledByOverride.conflicts).toHaveLength(0);
+
+        ConflictEngine.setWeight('faculty_double_book', 1);
+        const base = ConflictEngine.evaluate(schedule, constraints);
+        ConflictEngine.setWeight('faculty_double_book', 1.6);
+        const weighted = ConflictEngine.evaluate(schedule, constraints);
+
+        expect(weighted.conflicts[0].score).toBeGreaterThan(base.conflicts[0].score);
+
+        // Reset shared plugin weight for deterministic suite behavior.
+        ConflictEngine.setWeight('faculty_double_book', 1);
+    });
+
+    test('registerRule allows new plugins without core engine changes', () => {
+        const customId = 'custom_test_rule';
+        ConflictEngine.registerRule({
+            id: customId,
+            name: 'Custom Test Rule',
+            tier: 'suggestion',
+            detect: (schedule) => ([
+                {
+                    severity: 'info',
+                    title: 'Custom Test Issue',
+                    description: `Schedule size: ${schedule.length}`
+                }
+            ])
+        });
+
+        const result = ConflictEngine.evaluate(
+            [{ code: 'DESN 100', day: 'MW', time: '10:00-12:20', room: '206', instructor: 'A.User' }],
+            [{ id: customId, enabled: true, constraint_type: customId, rule_details: {} }]
+        );
+
+        expect(result.suggestions).toHaveLength(1);
+        expect(result.suggestions[0].rulePluginId).toBe(customId);
+        expect(result.suggestions[0].rulePluginName).toBe('Custom Test Rule');
+    });
+});

--- a/tests/conflict-engine.severity-taxonomy.test.js
+++ b/tests/conflict-engine.severity-taxonomy.test.js
@@ -1,0 +1,98 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadScriptModule(relativePath) {
+    const filePath = path.resolve(__dirname, '..', relativePath);
+    const source = fs.readFileSync(filePath, 'utf8');
+
+    const sandbox = {
+        console,
+        module: { exports: {} },
+        exports: {}
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: relativePath });
+    return sandbox.module.exports;
+}
+
+describe('ConflictEngine severity taxonomy (CE-01)', () => {
+    const ConflictEngine = loadScriptModule('js/conflict-engine.js');
+
+    test('maps legacy critical severity to hard_block tier while keeping backward-compatible severity field', () => {
+        const schedule = [
+            { code: 'DESN 301', day: 'MW', time: '10:00-12:20', room: '206', instructor: 'S.Mills' },
+            { code: 'DESN 401', day: 'MW', time: '10:00-12:20', room: '209', instructor: 'S.Mills' }
+        ];
+
+        const constraints = [
+            {
+                id: 'faculty-double-book',
+                enabled: true,
+                constraint_type: 'faculty_double_book',
+                rule_details: { severity: 'critical' }
+            }
+        ];
+
+        const result = ConflictEngine.evaluate(schedule, constraints);
+        const issue = result.conflicts[0];
+
+        expect(issue.severityTier).toBe('hard_block');
+        expect(issue.tier).toBe('hard_block');
+        expect(issue.severity).toBe('critical');
+        expect(issue.blocksSave).toBe(true);
+        expect(result.summary.tierCounts.hard_block).toBe(1);
+    });
+
+    test('maps info-level issues to suggestion tier', () => {
+        const schedule = [
+            { code: 'DESN 301', day: 'MW', time: '10:00-12:20', room: '206', instructor: 'S.Mills' }
+        ];
+
+        const constraints = [
+            {
+                id: 'room-preference',
+                enabled: true,
+                constraint_type: 'room_restriction',
+                rule_details: {
+                    room: '206',
+                    preferred_courses: ['DESN 355']
+                }
+            }
+        ];
+
+        const result = ConflictEngine.evaluate(schedule, constraints);
+        expect(result.suggestions.length).toBeGreaterThan(0);
+
+        const issue = result.suggestions[0];
+        expect(issue.severity).toBe('info');
+        expect(issue.severityTier).toBe('suggestion');
+        expect(issue.blocksSave).toBe(false);
+    });
+
+    test('promotes low-tier student conflicts near graduation deadlines', () => {
+        const schedule = [
+            { code: 'DESN 338', day: 'MW', time: '10:00-12:20', room: '206', instructor: 'A.One' },
+            { code: 'DESN 355', day: 'MW', time: '10:00-12:20', room: '209', instructor: 'B.Two' }
+        ];
+
+        const constraints = [
+            {
+                id: 'student-pathway',
+                enabled: true,
+                constraint_type: 'student_conflict',
+                rule_details: { severity: 'info' }
+            }
+        ];
+
+        const result = ConflictEngine.evaluate(schedule, constraints, {
+            daysUntilGraduation: 30
+        });
+
+        expect(result.warnings.length).toBeGreaterThan(0);
+        const issue = result.warnings[0];
+        expect(issue.severityTier).toBe('warning');
+        expect(issue.severity).toBe('warning');
+    });
+});


### PR DESCRIPTION
## Summary
- add canonical CE-01 severity taxonomy constants (`hard_block`, `warning`, `suggestion`, `optimization`)
- keep backward compatibility by preserving legacy `severity` while adding canonical `severityTier`/`tier` on issues
- apply tier normalization + escalation/demotion guardrails (graduation-window student conflict promotion, room restriction hard block)
- add CE-01 taxonomy specification doc with full 8-type mapping and TS-style type definitions
- add regression tests for tier mapping and promotion behavior

## Validation
- `npm test -- --runInBand`
- `npm run qa:onboarding`

Closes #141
