### PR TITLE
feat(conflicts): refactor ConflictEngine to pluggable rule registry (CE-02)

### DIFF
--- a/docs/conflict-engine-pluggable-architecture-ce02.md
+++ b/docs/conflict-engine-pluggable-architecture-ce02.md
@@ -1,0 +1,59 @@
+# Conflict Engine Pluggable Architecture (CE-02)
+
+Issue: [#142](https://github.com/sicxz/program-command/issues/142)
+
+## Overview
+Conflict Engine now operates as an orchestrator over registered rule plugins.
+
+Core runtime flow:
+1. resolve enabled constraints
+2. resolve plugin by normalized `constraint_type`
+3. run `plugin.detect(schedule, ruleDetails, constraint, context)`
+4. apply CE-01 tier normalization + scoring
+5. bucket into `conflicts`, `warnings`, `suggestions`
+
+## RulePlugin Interface
+```ts
+interface RulePlugin {
+  id: string;
+  name: string;
+  tier?: 'hard_block' | 'warning' | 'suggestion' | 'optimization';
+  enabled?: boolean;
+  weight?: number;
+  detect(schedule: any[], ruleDetails: Record<string, any>, constraint: any, context: Record<string, any>): any[];
+}
+```
+
+## Registry API
+- `registerRule(plugin)`
+- `enableRule(id)`
+- `disableRule(id)`
+- `setWeight(id, weight)`
+- `listRules()`
+
+## Backward Compatibility
+- Existing `evaluate(schedule, constraints, context)` API remains unchanged.
+- Added alias: `findIssues(schedule, constraints, context)`.
+- Existing checker functions are still available via `ConflictEngine.checkers`.
+- Existing conflict rules are pre-registered as built-in plugins during engine initialization.
+
+## Per-Program Overrides
+`evaluate(..., context)` supports optional rule overrides:
+```js
+{
+  ruleOverrides: {
+    student_conflict: { enabled: false },
+    faculty_double_book: { weight: 1.5 }
+  }
+}
+```
+
+## Built-in Rules Registered as Plugins
+- `room_restriction`
+- `student_conflict`
+- `faculty_double_book`
+- `room_double_book`
+- `evening_safety`
+- `ay_setup_alignment`
+- `enrollment_threshold`
+- `campus_transition`

--- a/js/conflict-engine.js
+++ b/js/conflict-engine.js
@@ -251,6 +251,19 @@ const ConflictEngine = (function() {
         }
     };
 
+    const DEFAULT_RULE_PLUGIN_METADATA = {
+        room_restriction: { name: 'Room Restriction Rule', tier: 'warning' },
+        student_conflict: { name: 'Student Pathway Rule', tier: 'warning' },
+        faculty_double_book: { name: 'Faculty Double Book Rule', tier: 'hard_block' },
+        room_double_book: { name: 'Room Double Book Rule', tier: 'hard_block' },
+        evening_safety: { name: 'Evening Safety Rule', tier: 'warning' },
+        ay_setup_alignment: { name: 'AY Setup Alignment Rule', tier: 'warning' },
+        enrollment_threshold: { name: 'Enrollment Threshold Rule', tier: 'suggestion' },
+        campus_transition: { name: 'Campus Transition Rule', tier: 'suggestion' }
+    };
+
+    const rulePlugins = new Map();
+
     function normalizeConstraintType(type) {
         const normalized = String(type || '').trim().toLowerCase();
         return CONSTRAINT_TYPE_ALIASES[normalized] || normalized;
@@ -536,6 +549,117 @@ const ConflictEngine = (function() {
 
     function getRuleRegistryEntry(normalizedConstraintType) {
         return CONFLICT_RULE_REGISTRY[normalizedConstraintType] || CONFLICT_RULE_REGISTRY._default;
+    }
+
+    /**
+     * @typedef {Object} RulePlugin
+     * @property {string} id
+     * @property {string} name
+     * @property {'hard_block'|'warning'|'suggestion'|'optimization'} [tier]
+     * @property {boolean} [enabled]
+     * @property {number} [weight]
+     * @property {(schedule: Array, ruleDetails: Object, constraint: Object, context: Object) => Array} detect
+     */
+
+    function normalizeRulePlugin(plugin = {}) {
+        const id = normalizeConstraintType(plugin.id);
+        if (!id) {
+            throw new Error('Rule plugin requires a non-empty id');
+        }
+        if (typeof plugin.detect !== 'function') {
+            throw new Error(`Rule plugin "${id}" requires a detect(schedule, context) function`);
+        }
+
+        const metadata = DEFAULT_RULE_PLUGIN_METADATA[id] || {};
+        const tier = clampIssueTier(toTierName(plugin.tier || metadata.tier), id);
+        const weight = Number(plugin.weight);
+
+        return {
+            id,
+            name: String(plugin.name || metadata.name || id),
+            tier,
+            enabled: plugin.enabled !== false,
+            detect: plugin.detect,
+            weight: Number.isFinite(weight) ? weight : 1
+        };
+    }
+
+    function registerRule(plugin, options = {}) {
+        const normalized = normalizeRulePlugin(plugin);
+        const replace = options.replace === true;
+        if (!replace && rulePlugins.has(normalized.id)) {
+            throw new Error(`Rule plugin "${normalized.id}" is already registered`);
+        }
+        rulePlugins.set(normalized.id, normalized);
+        return normalized;
+    }
+
+    function getRulePlugin(id) {
+        const normalized = normalizeConstraintType(id);
+        return rulePlugins.get(normalized) || null;
+    }
+
+    function enableRule(id) {
+        const plugin = getRulePlugin(id);
+        if (!plugin) return false;
+        plugin.enabled = true;
+        return true;
+    }
+
+    function disableRule(id) {
+        const plugin = getRulePlugin(id);
+        if (!plugin) return false;
+        plugin.enabled = false;
+        return true;
+    }
+
+    function setWeight(id, weight) {
+        const plugin = getRulePlugin(id);
+        const numericWeight = Number(weight);
+        if (!plugin || !Number.isFinite(numericWeight)) return false;
+        plugin.weight = numericWeight;
+        return true;
+    }
+
+    function getProgramRuleOverride(context, id) {
+        const overrides = context?.ruleOverrides;
+        if (!overrides || typeof overrides !== 'object') return null;
+        const override = overrides[id];
+        return override && typeof override === 'object' ? override : null;
+    }
+
+    function isRuleEnabledForEvaluation(plugin, context = {}) {
+        if (!plugin || plugin.enabled === false) return false;
+        const override = getProgramRuleOverride(context, plugin.id);
+        if (override && typeof override.enabled === 'boolean') {
+            return override.enabled;
+        }
+        return true;
+    }
+
+    function getEffectiveRuleDetails(plugin, ruleDetails = {}, context = {}) {
+        const rawRule = (ruleDetails && typeof ruleDetails === 'object') ? { ...ruleDetails } : {};
+        const override = getProgramRuleOverride(context, plugin.id);
+
+        if (!Number.isFinite(Number(rawRule.weight))) {
+            if (override && Number.isFinite(Number(override.weight))) {
+                rawRule.weight = Number(override.weight);
+            } else if (Number.isFinite(Number(plugin.weight))) {
+                rawRule.weight = Number(plugin.weight);
+            }
+        }
+
+        return rawRule;
+    }
+
+    function listRegisteredRules() {
+        return Array.from(rulePlugins.values()).map((plugin) => ({
+            id: plugin.id,
+            name: plugin.name,
+            tier: plugin.tier,
+            enabled: plugin.enabled !== false,
+            weight: Number(plugin.weight)
+        }));
     }
 
     function calculateWeightedIssueScore(issue, normalizedConstraintType, ruleDetails = {}) {
@@ -989,7 +1113,8 @@ const ConflictEngine = (function() {
             scoringModel: {
                 version: 'v2',
                 registry: CONFLICT_RULE_REGISTRY,
-                taxonomy: CONFLICT_TIER_DEFINITIONS
+                taxonomy: CONFLICT_TIER_DEFINITIONS,
+                registeredRules: listRegisteredRules()
             }
         };
 
@@ -1003,49 +1128,53 @@ const ConflictEngine = (function() {
             enabledConstraints
         };
 
-        // Run each enabled constraint checker
+        // Run each enabled constraint rule plugin
         enabledConstraints.forEach(constraint => {
             const normalizedConstraintType = normalizeConstraintType(constraint.constraint_type);
-            const checker = checkers[normalizedConstraintType];
-            if (checker) {
-                const issues = checker(schedule, constraint.rule_details, constraint, evaluationContext);
-                issues.forEach(issue => {
-                    issue.constraintId = constraint.id;
-                    issue.constraintType = normalizedConstraintType;
-                    issue.constraintTypeOriginal = constraint.constraint_type;
-                    issue.constraintRule = getRuleRegistryEntry(normalizedConstraintType);
-                    issue.severityTier = resolveIssueTier(issue, normalizedConstraintType, evaluationContext);
-                    issue.tier = issue.severityTier;
-                    issue.severity = resolveLegacySeverityFromTier(issue.severityTier);
-                    issue.blocksSave = Boolean(CONFLICT_TIER_DEFINITIONS[issue.severityTier]?.blocksSave);
+            const plugin = getRulePlugin(normalizedConstraintType);
+            if (!plugin || !isRuleEnabledForEvaluation(plugin, evaluationContext)) return;
 
-                    const weighted = calculateWeightedIssueScore(
-                        issue,
-                        normalizedConstraintType,
-                        constraint.rule_details
-                    );
-                    issue.score = weighted.total;
-                    issue.scoreExplanation = weighted.explanation;
-                    issue.scoreBreakdown = weighted.breakdown;
-                    issue.scoreRuleMeta = weighted.rule;
+            const effectiveRuleDetails = getEffectiveRuleDetails(plugin, constraint.rule_details, evaluationContext);
+            const issues = plugin.detect(schedule, effectiveRuleDetails, constraint, evaluationContext);
 
-                    results.summary.weightedScore += issue.score;
-                    results.summary.weightedByConstraintType[normalizedConstraintType] =
-                        (results.summary.weightedByConstraintType[normalizedConstraintType] || 0) + issue.score;
-                    results.summary.tierCounts[issue.severityTier] =
-                        (results.summary.tierCounts[issue.severityTier] || 0) + 1;
+            (Array.isArray(issues) ? issues : []).forEach(issue => {
+                issue.constraintId = constraint.id;
+                issue.constraintType = normalizedConstraintType;
+                issue.constraintTypeOriginal = constraint.constraint_type;
+                issue.constraintRule = getRuleRegistryEntry(normalizedConstraintType);
+                issue.rulePluginId = plugin.id;
+                issue.rulePluginName = plugin.name;
+                issue.severityTier = resolveIssueTier(issue, normalizedConstraintType, evaluationContext);
+                issue.tier = issue.severityTier;
+                issue.severity = resolveLegacySeverityFromTier(issue.severityTier);
+                issue.blocksSave = Boolean(CONFLICT_TIER_DEFINITIONS[issue.severityTier]?.blocksSave);
 
-                    if (issue.severityTier === 'hard_block') {
-                        results.conflicts.push(issue);
-                        results.summary.criticalCount++;
-                    } else if (issue.severityTier === 'warning') {
-                        results.warnings.push(issue);
-                        results.summary.warningCount++;
-                    } else {
-                        results.suggestions.push(issue);
-                    }
-                });
-            }
+                const weighted = calculateWeightedIssueScore(
+                    issue,
+                    normalizedConstraintType,
+                    effectiveRuleDetails
+                );
+                issue.score = weighted.total;
+                issue.scoreExplanation = weighted.explanation;
+                issue.scoreBreakdown = weighted.breakdown;
+                issue.scoreRuleMeta = weighted.rule;
+
+                results.summary.weightedScore += issue.score;
+                results.summary.weightedByConstraintType[normalizedConstraintType] =
+                    (results.summary.weightedByConstraintType[normalizedConstraintType] || 0) + issue.score;
+                results.summary.tierCounts[issue.severityTier] =
+                    (results.summary.tierCounts[issue.severityTier] || 0) + 1;
+
+                if (issue.severityTier === 'hard_block') {
+                    results.conflicts.push(issue);
+                    results.summary.criticalCount++;
+                } else if (issue.severityTier === 'warning') {
+                    results.warnings.push(issue);
+                    results.summary.warningCount++;
+                } else {
+                    results.suggestions.push(issue);
+                }
+            });
         });
 
         results.summary.totalActionableIssues = results.conflicts.length + results.warnings.length;
@@ -1053,6 +1182,11 @@ const ConflictEngine = (function() {
         // Backward-compatible field used by existing UI sections.
         results.summary.totalIssues = results.summary.totalActionableIssues;
         return results;
+    }
+
+    // Backward-compatible API alias
+    function findIssues(schedule, constraints, context = {}) {
+        return evaluate(schedule, constraints, context);
     }
 
     /**
@@ -1340,6 +1474,16 @@ const ConflictEngine = (function() {
         }
     };
 
+    Object.entries(checkers).forEach(([id, detect]) => {
+        const metadata = DEFAULT_RULE_PLUGIN_METADATA[id] || {};
+        registerRule({
+            id,
+            name: metadata.name || id,
+            tier: metadata.tier || 'suggestion',
+            detect
+        });
+    });
+
     /**
      * Calculate available room resolutions for a course
      */
@@ -1495,10 +1639,16 @@ const ConflictEngine = (function() {
     // Public API
     return {
         evaluate,
+        findIssues,
         checkers,
         COMMON_PAIRINGS,
         evaluateAySetup,
-        ruleRegistry: CONFLICT_RULE_REGISTRY
+        ruleRegistry: CONFLICT_RULE_REGISTRY,
+        registerRule,
+        enableRule,
+        disableRule,
+        setWeight,
+        listRules: listRegisteredRules
     };
 })();
 

--- a/tests/conflict-engine.plugins.test.js
+++ b/tests/conflict-engine.plugins.test.js
@@ -1,0 +1,117 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadScriptModule(relativePath) {
+    const filePath = path.resolve(__dirname, '..', relativePath);
+    const source = fs.readFileSync(filePath, 'utf8');
+
+    const sandbox = {
+        console,
+        module: { exports: {} },
+        exports: {}
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: relativePath });
+    return sandbox.module.exports;
+}
+
+describe('ConflictEngine pluggable rule registry (CE-02)', () => {
+    const ConflictEngine = loadScriptModule('js/conflict-engine.js');
+
+    function buildFacultyConflictSchedule() {
+        return [
+            { code: 'DESN 301', day: 'MW', time: '10:00-12:20', room: '206', instructor: 'S.Mills' },
+            { code: 'DESN 401', day: 'MW', time: '10:00-12:20', room: '209', instructor: 'S.Mills' }
+        ];
+    }
+
+    function buildFacultyConstraint() {
+        return [
+            {
+                id: 'faculty-double-book',
+                enabled: true,
+                constraint_type: 'faculty_double_book',
+                rule_details: { severity: 'critical' }
+            }
+        ];
+    }
+
+    test('exposes registry APIs and keeps findIssues backward-compatible with evaluate', () => {
+        expect(typeof ConflictEngine.registerRule).toBe('function');
+        expect(typeof ConflictEngine.enableRule).toBe('function');
+        expect(typeof ConflictEngine.disableRule).toBe('function');
+        expect(typeof ConflictEngine.setWeight).toBe('function');
+        expect(typeof ConflictEngine.listRules).toBe('function');
+        expect(typeof ConflictEngine.findIssues).toBe('function');
+
+        const schedule = buildFacultyConflictSchedule();
+        const constraints = buildFacultyConstraint();
+
+        const evaluateResult = ConflictEngine.evaluate(schedule, constraints);
+        const findIssuesResult = ConflictEngine.findIssues(schedule, constraints);
+
+        expect(JSON.stringify(findIssuesResult)).toBe(JSON.stringify(evaluateResult));
+    });
+
+    test('supports enable/disable toggles for registered rules', () => {
+        const schedule = buildFacultyConflictSchedule();
+        const constraints = buildFacultyConstraint();
+
+        expect(ConflictEngine.disableRule('faculty_double_book')).toBe(true);
+        const disabledResult = ConflictEngine.evaluate(schedule, constraints);
+        expect(disabledResult.conflicts).toHaveLength(0);
+
+        expect(ConflictEngine.enableRule('faculty_double_book')).toBe(true);
+        const enabledResult = ConflictEngine.evaluate(schedule, constraints);
+        expect(enabledResult.conflicts.length).toBeGreaterThan(0);
+    });
+
+    test('supports program-level rule enable overrides and plugin weights', () => {
+        const schedule = buildFacultyConflictSchedule();
+        const constraints = buildFacultyConstraint();
+
+        const disabledByOverride = ConflictEngine.evaluate(schedule, constraints, {
+            ruleOverrides: {
+                faculty_double_book: { enabled: false }
+            }
+        });
+        expect(disabledByOverride.conflicts).toHaveLength(0);
+
+        ConflictEngine.setWeight('faculty_double_book', 1);
+        const base = ConflictEngine.evaluate(schedule, constraints);
+        ConflictEngine.setWeight('faculty_double_book', 1.6);
+        const weighted = ConflictEngine.evaluate(schedule, constraints);
+
+        expect(weighted.conflicts[0].score).toBeGreaterThan(base.conflicts[0].score);
+
+        // Reset shared plugin weight for deterministic suite behavior.
+        ConflictEngine.setWeight('faculty_double_book', 1);
+    });
+
+    test('registerRule allows new plugins without core engine changes', () => {
+        const customId = 'custom_test_rule';
+        ConflictEngine.registerRule({
+            id: customId,
+            name: 'Custom Test Rule',
+            tier: 'suggestion',
+            detect: (schedule) => ([
+                {
+                    severity: 'info',
+                    title: 'Custom Test Issue',
+                    description: `Schedule size: ${schedule.length}`
+                }
+            ])
+        });
+
+        const result = ConflictEngine.evaluate(
+            [{ code: 'DESN 100', day: 'MW', time: '10:00-12:20', room: '206', instructor: 'A.User' }],
+            [{ id: customId, enabled: true, constraint_type: customId, rule_details: {} }]
+        );
+
+        expect(result.suggestions).toHaveLength(1);
+        expect(result.suggestions[0].rulePluginId).toBe(customId);
+        expect(result.suggestions[0].rulePluginName).toBe('Custom Test Rule');
+    });
+});


### PR DESCRIPTION
## Summary
- refactor ConflictEngine into plugin-driven orchestration while preserving existing behavior
- add RulePlugin registry APIs: `registerRule`, `enableRule`, `disableRule`, `setWeight`, `listRules`
- register all current built-in conflict rules as plugins at startup
- route `evaluate()` through rule plugins with support for per-program rule overrides (`context.ruleOverrides`)
- add backward-compatible `findIssues()` alias
- add CE-02 architecture doc and plugin-registry tests

## Validation
- `npm test -- --runInBand`
- `npm run qa:onboarding`

## Notes
- This PR is stacked on `codex/tree-ce01-conflict-severity-taxonomy` (CE-01 dependency).
- Existing test behavior remains unchanged.

Refs #142
