### PR TITLE
Make scheduler patterns profile-driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ The main dashboard providing an overview of:
 - Quick access to all specialized dashboards
 - Academic year filtering
 
+Meeting patterns (day patterns and time slots) are now fully driven by the active **department profile**:
+
+- Profiles live in `department-profiles/<program>-v1.json`
+- Each profile defines `scheduler.dayPatterns` and `scheduler.timeSlots` (with `startMinutes`/`endMinutes`)
+- Both Program Command and the Schedule Builder read from this configuration, so changing meeting patterns for a program only requires editing the profile JSON.
+
+CLSS import is considered **deprecated** as a source of truth for time/meeting patterns; any remaining CLSS tooling is review-only and should not be relied on for defining patterns going forward.
+
 ### Enrollment Trends Dashboard
 **`enrollment-dashboard.html`**
 

--- a/index.html
+++ b/index.html
@@ -4855,9 +4855,10 @@
         }
 
         function getSchedulerRoomOptionList() {
+            const configuredRooms = Object.keys(schedulerRoomLabels || {}).filter(Boolean);
             const ordered = Array.isArray(CLSS_IMPORT_ROOM_PRIORITY) ? CLSS_IMPORT_ROOM_PRIORITY.slice() : [];
             const allowed = Array.from(CLSS_IMPORT_ALLOWED_ROOMS || []);
-            const merged = [...new Set([...ordered, ...allowed])].filter(Boolean);
+            const merged = [...new Set([...ordered, ...allowed, ...configuredRooms])].filter(Boolean);
             return merged.length ? merged : Object.keys(DEFAULT_SCHEDULER_ROOM_LABELS);
         }
 
@@ -12123,6 +12124,47 @@
             return false;
         }
 
+        function snapshotHasCourses(snapshot) {
+            if (!snapshot || typeof snapshot !== 'object') return false;
+            return ['fall', 'winter', 'spring'].some((quarter) => {
+                const quarterData = snapshot[quarter];
+                if (!quarterData || typeof quarterData !== 'object') return false;
+                return Object.values(quarterData).some((dayData) => {
+                    if (!dayData || typeof dayData !== 'object') return false;
+                    return Object.values(dayData).some((timeData) =>
+                        Array.isArray(timeData) && timeData.length > 0
+                    );
+                });
+            });
+        }
+
+        function findMostRecentSavedScheduleYear() {
+            const prefix = String(scheduleStorageKeyPrefix || 'designSchedulerData_').trim() || 'designSchedulerData_';
+            const years = [];
+
+            for (let i = 0; i < localStorage.length; i += 1) {
+                const key = localStorage.key(i);
+                if (!key || !key.startsWith(prefix)) continue;
+                const year = key.slice(prefix.length);
+                if (!/^\d{4}-\d{2}$/.test(year)) continue;
+
+                try {
+                    const raw = localStorage.getItem(key);
+                    if (!raw) continue;
+                    const parsed = JSON.parse(raw);
+                    if (snapshotHasCourses(parsed)) {
+                        years.push(year);
+                    }
+                } catch (error) {
+                    // ignore malformed localStorage values
+                }
+            }
+
+            if (!years.length) return '';
+            years.sort((a, b) => String(b).localeCompare(String(a)));
+            return years[0];
+        }
+
         function clearScheduleData() {
             localStorage.removeItem(getStorageKey());
             showToast('Schedule data cleared - refresh to reset');
@@ -12478,7 +12520,14 @@
             migrateOldScheduleData();
 
             // Load saved schedule data from localStorage
-            loadScheduleData();
+            const loadedCurrentYear = loadScheduleData();
+            if (!loadedCurrentYear) {
+                const fallbackYear = findMostRecentSavedScheduleYear();
+                if (fallbackYear && fallbackYear !== currentAcademicYear) {
+                    switchAcademicYear(fallbackYear);
+                    showToast(`Loaded saved schedule from ${fallbackYear}`, 'warning');
+                }
+            }
 
             // Check for imported schedule from schedule builder
             checkForImportedSchedule();

--- a/pages/schedule-builder.html
+++ b/pages/schedule-builder.html
@@ -606,6 +606,8 @@
     </div>
 
     <!-- Scripts -->
+    <!-- Department profile runtime (provides DepartmentProfileManager and scheduler config) -->
+    <script src="../js/department-profile.js"></script>
     <!-- Supabase Client Library -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="../js/supabase-config.js"></script>

--- a/pages/schedule-builder.js
+++ b/pages/schedule-builder.js
@@ -36,13 +36,28 @@ let allQuartersSchedule = {
 let activeQuarter = 'Fall';
 let courseCatalog = null; // Loaded from course-catalog.json
 
-// Time slots: 2hr 20min classes
-const TIMES = ['10:00 AM - 12:20 PM', '1:00 PM - 3:20 PM', '4:00 PM - 6:20 PM'];
-const TIME_KEYS = ['10:00-12:20', '13:00-15:20', '16:00-18:20']; // For data storage
-const DAYS = ['MW', 'TR'];
+// Scheduler pattern configuration (profile-driven with sensible defaults for Design)
+let schedulerDayPatterns = [
+    { id: 'MW', label: 'Monday / Wednesday' },
+    { id: 'TR', label: 'Tuesday / Thursday' }
+];
+let schedulerTimeSlots = [
+    { id: '10:00-12:20', label: '10:00-12:20', startMinutes: 10 * 60, endMinutes: (12 * 60) + 20 },
+    { id: '13:00-15:20', label: '13:00-15:20', startMinutes: 13 * 60, endMinutes: (15 * 60) + 20 },
+    { id: '16:00-18:20', label: '16:00-18:20', startMinutes: 16 * 60, endMinutes: (18 * 60) + 20 }
+];
 
-// Evening time slot (for safety pairing rule)
-const EVENING_TIME = '4:00 PM - 6:20 PM';
+let DAYS = schedulerDayPatterns.map((pattern) => pattern.id);
+let TIME_KEYS = schedulerTimeSlots.map((slot) => slot.id); // For data storage
+let TIMES = schedulerTimeSlots.map((slot) => slot.label);
+
+// Derived bucket helpers (updated once profile is loaded)
+let EVENING_SLOT_IDS = schedulerTimeSlots
+    .filter((slot) => Number.isFinite(slot.startMinutes) && slot.startMinutes >= 16 * 60)
+    .map((slot) => slot.id);
+
+// Program Command storage prefix (kept in sync with department profile scheduler.storageKeyPrefix)
+let PROGRAM_COMMAND_STORAGE_KEY_PREFIX = 'designSchedulerData_';
 
 // Store courses from database for constraints
 let dbCourses = [];
@@ -554,6 +569,43 @@ document.addEventListener('DOMContentLoaded', async function() {
     console.log('Initializing Schedule Builder...');
 
     try {
+        // Initialize department profile + scheduler patterns
+        if (window.DepartmentProfileManager && typeof window.DepartmentProfileManager.initialize === 'function') {
+            try {
+                const snapshot = await window.DepartmentProfileManager.initialize();
+                const profile = snapshot?.profile
+                    || (typeof window.DepartmentProfileManager.getCurrentProfile === 'function'
+                        ? window.DepartmentProfileManager.getCurrentProfile()
+                        : null)
+                    || (typeof window.DepartmentProfileManager.getDefaultProfile === 'function'
+                        ? window.DepartmentProfileManager.getDefaultProfile()
+                        : null);
+
+                const scheduler = profile && profile.scheduler ? profile.scheduler : {};
+
+                if (Array.isArray(scheduler.dayPatterns) && scheduler.dayPatterns.length > 0) {
+                    schedulerDayPatterns = scheduler.dayPatterns.slice();
+                }
+                if (Array.isArray(scheduler.timeSlots) && scheduler.timeSlots.length > 0) {
+                    schedulerTimeSlots = scheduler.timeSlots.slice();
+                }
+
+                DAYS = schedulerDayPatterns.map((pattern) => String(pattern.id || '').trim().toUpperCase()).filter(Boolean);
+                TIME_KEYS = schedulerTimeSlots.map((slot) => String(slot.id || '').trim()).filter(Boolean);
+                TIMES = schedulerTimeSlots.map((slot) => String(slot.label || slot.id || '').trim());
+
+                EVENING_SLOT_IDS = schedulerTimeSlots
+                    .filter((slot) => Number.isFinite(slot.startMinutes) && slot.startMinutes >= 16 * 60)
+                    .map((slot) => slot.id);
+
+                if (scheduler.storageKeyPrefix && typeof scheduler.storageKeyPrefix === 'string') {
+                    PROGRAM_COMMAND_STORAGE_KEY_PREFIX = scheduler.storageKeyPrefix.trim() || PROGRAM_COMMAND_STORAGE_KEY_PREFIX;
+                }
+            } catch (profileError) {
+                console.warn('Could not initialize department profile for Schedule Builder; falling back to defaults.', profileError);
+            }
+        }
+
         // Load room constraints
         const constraintsResponse = await fetch('../data/room-constraints.json');
         if (constraintsResponse.ok) {
@@ -628,7 +680,7 @@ document.addEventListener('DOMContentLoaded', async function() {
 let analysisResults = null;
 
 function getProgramCommandScheduleStorageKey(academicYear) {
-    return `designSchedulerData_${academicYear}`;
+    return `${PROGRAM_COMMAND_STORAGE_KEY_PREFIX}${academicYear}`;
 }
 
 function extractCoursesFromProgramCommandDraft(academicYear) {
@@ -1471,7 +1523,7 @@ function getValidRooms(courseCode, quarter, slotUsage = {}) {
         const cebSlots = Object.keys(slotUsage).filter(k =>
             k.includes('CEB 102') || k.includes('CEB 104')
         );
-        const cebFull = cebSlots.length >= (TIMES.length * DAYS.length * 2); // 2 CEB rooms
+        const cebFull = cebSlots.length >= (TIME_KEYS.length * DAYS.length * 2); // 2 CEB rooms
 
         if (cebFull && ROOM_212_OVERFLOW.includes(courseCode)) {
             return ['CEB 102', 'CEB 104', '212'];
@@ -1530,8 +1582,15 @@ function getFacultyCandidates(preferredFaculty, selectedFaculty = []) {
 }
 
 function getTimeBucketForKey(timeKey) {
-    if (timeKey === '10:00-12:20') return 'morning';
-    if (timeKey === '13:00-15:20') return 'afternoon';
+    const slot = schedulerTimeSlots.find((entry) => String(entry.id || '').trim() === String(timeKey || '').trim());
+    if (!slot || !Number.isFinite(slot.startMinutes) || !Number.isFinite(slot.endMinutes)) {
+        return 'unspecified';
+    }
+
+    const start = slot.startMinutes;
+
+    if (start < 12 * 60) return 'morning';
+    if (start < 16 * 60) return 'afternoon';
     return 'evening';
 }
 
@@ -3056,12 +3115,14 @@ function handleCourseSelection() {
         // Pre-populate time slot based on preferred times
         const timeSelect = document.getElementById('addCourseTime');
         if (prefs.preferredTimes && prefs.preferredTimes.length > 0) {
-            // Map time preferences to actual time keys
-            const timeMapping = {
-                'morning': '10:00-12:20',
-                'afternoon': '13:00-15:20',
-                'evening': '16:00-18:20'
-            };
+            // Map time preferences to actual time keys using current profile-driven slots
+            const timeMapping = {};
+            schedulerTimeSlots.forEach((slot) => {
+                const bucket = getTimeBucketForKey(slot.id);
+                if (!timeMapping[bucket]) {
+                    timeMapping[bucket] = slot.id;
+                }
+            });
             // Select first preferred time that's valid
             for (const timePref of prefs.preferredTimes) {
                 const timeKey = timeMapping[timePref];

--- a/tests/schedule-builder.profile-patterns.test.js
+++ b/tests/schedule-builder.profile-patterns.test.js
@@ -1,0 +1,117 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function makeStubElement() {
+    return {
+        value: '2026-27',
+        checked: false,
+        textContent: '',
+        innerHTML: '',
+        style: {},
+        dataset: {},
+        classList: {
+            add: jest.fn(),
+            remove: jest.fn(),
+            toggle: jest.fn()
+        },
+        addEventListener: jest.fn(),
+        querySelectorAll: jest.fn(() => []),
+        appendChild: jest.fn(),
+        removeChild: jest.fn()
+    };
+}
+
+function loadScheduleBuilderWindow({ profileScheduler } = {}) {
+    const filePath = path.resolve(__dirname, '..', 'pages/schedule-builder.js');
+    const source = fs.readFileSync(filePath, 'utf8');
+    const elements = new Map();
+
+    const documentObject = {
+        addEventListener: jest.fn((event, handler) => {
+            if (event === 'DOMContentLoaded') {
+                documentObject.__domReadyHandler = handler;
+            }
+        }),
+        getElementById: jest.fn((id) => {
+            if (!elements.has(id)) elements.set(id, makeStubElement());
+            return elements.get(id);
+        }),
+        querySelector: jest.fn(() => null),
+        createElement: jest.fn(() => makeStubElement())
+    };
+
+    const localStore = {};
+    const localStorageObject = {
+        getItem: jest.fn((key) => (Object.prototype.hasOwnProperty.call(localStore, key) ? localStore[key] : null)),
+        setItem: jest.fn((key, value) => {
+            localStore[key] = String(value);
+        }),
+        removeItem: jest.fn((key) => {
+            delete localStore[key];
+        })
+    };
+
+    const windowObject = {
+        document: documentObject,
+        DepartmentProfileManager: {
+            initialize: jest.fn(async () => ({
+                profile: {
+                    scheduler: profileScheduler || {
+                        storageKeyPrefix: 'designSchedulerData_',
+                        dayPatterns: [
+                            { id: 'MW', label: 'Monday / Wednesday' },
+                            { id: 'TR', label: 'Tuesday / Thursday' }
+                        ],
+                        timeSlots: [
+                            { id: '10:00-12:20', label: '10:00-12:20', startMinutes: 10 * 60, endMinutes: (12 * 60) + 20 },
+                            { id: '13:00-15:20', label: '13:00-15:20', startMinutes: 13 * 60, endMinutes: (15 * 60) + 20 },
+                            { id: '16:00-18:20', label: '16:00-18:20', startMinutes: 16 * 60, endMinutes: (18 * 60) + 20 }
+                        ]
+                    }
+                }
+            })),
+            getCurrentProfile: jest.fn(() => null),
+            getDefaultProfile: jest.fn(() => null)
+        },
+        localStorage: localStorageObject
+    };
+
+    const sandbox = {
+        window: windowObject,
+        document: documentObject,
+        localStorage: localStorageObject,
+        fetch: jest.fn(async () => ({ ok: false, json: async () => ({}) })),
+        setTimeout,
+        clearTimeout,
+        console
+    };
+
+    vm.createContext(sandbox);
+    vm.runInContext(source, sandbox, { filename: 'pages/schedule-builder.js' });
+
+    return { windowObject, documentObject, sandbox };
+}
+
+describe('Schedule Builder profile-driven patterns', () => {
+    test('uses profile storage prefix and minute-based slot buckets', async () => {
+        const profileScheduler = {
+            storageKeyPrefix: 'customPrefix_',
+            dayPatterns: [{ id: 'MW', label: 'Mon/Wed' }],
+            timeSlots: [
+                { id: '08:00-09:00', label: '8-9 AM', startMinutes: 8 * 60, endMinutes: 9 * 60 },
+                { id: '13:00-14:00', label: '1-2 PM', startMinutes: 13 * 60, endMinutes: 14 * 60 },
+                { id: '17:00-18:00', label: '5-6 PM', startMinutes: 17 * 60, endMinutes: 18 * 60 }
+            ]
+        };
+
+        const { documentObject, sandbox } = loadScheduleBuilderWindow({ profileScheduler });
+        await documentObject.__domReadyHandler();
+
+        expect(sandbox.getProgramCommandScheduleStorageKey('2026-27')).toBe('customPrefix_2026-27');
+        expect(sandbox.getTimeBucketForKey('08:00-09:00')).toBe('morning');
+        expect(sandbox.getTimeBucketForKey('13:00-14:00')).toBe('afternoon');
+        expect(sandbox.getTimeBucketForKey('17:00-18:00')).toBe('evening');
+    });
+});
+


### PR DESCRIPTION
## Summary
- use department profile scheduler day/time patterns as the source of truth in Program Command and Schedule Builder
- remove hardcoded builder day/time constants by deriving slot IDs/labels and storage key prefix from active profile config
- add year fallback loading for the most recent saved local schedule and add targeted test coverage for profile-driven slot semantics

## Test plan
- [x] `npm test -- --runTestsByPath tests/schedule-builder.profile-patterns.test.js`
- [ ] open `http://localhost:3000` and verify existing saved schedule renders for loaded year
- [ ] confirm schedule-builder grid/time preferences respect profile-defined time slots

Made with [Cursor](https://cursor.com)