### PR TITLE
Fix scheduler time display formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -5063,6 +5063,86 @@
             return startMatch ? startMatch.id : '';
         }
 
+        function formatSchedulerClockTime(value) {
+            const match = String(value || '').trim().match(/^(\d{1,2}):(\d{2})$/);
+            if (!match) return String(value || '').trim();
+
+            let hours = Number(match[1]);
+            const minutes = match[2];
+            const meridiem = hours >= 12 ? 'PM' : 'AM';
+
+            if (hours === 0) {
+                hours = 12;
+            } else if (hours > 12) {
+                hours -= 12;
+            }
+
+            return `${hours}:${minutes} ${meridiem}`;
+        }
+
+        function formatSchedulerTimeRange(value) {
+            const text = String(value || '').trim();
+            if (!text) return '';
+            if (!text.includes('-')) {
+                return formatSchedulerClockTime(text);
+            }
+
+            const [start, end] = text.split('-').map((part) => String(part || '').trim());
+            if (!start || !end) return text;
+            return `${formatSchedulerClockTime(start)} - ${formatSchedulerClockTime(end)}`;
+        }
+
+        function getSchedulerTimeSlotDisplayText(value) {
+            const slot = getSchedulerTimeSlotByAlias(value);
+            const rawLabel = String(slot?.label || slot?.id || value || '').trim();
+            return formatSchedulerTimeRange(rawLabel) || rawLabel;
+        }
+
+        function parseSchedulerClockValueToMinutes(value) {
+            const match = String(value || '').trim().match(/^(\d{1,2}):(\d{2})$/);
+            if (!match) return null;
+
+            const hours = Number(match[1]);
+            const minutes = Number(match[2]);
+            if (!Number.isFinite(hours) || !Number.isFinite(minutes) || minutes > 59) {
+                return null;
+            }
+            return (hours * 60) + minutes;
+        }
+
+        function getSchedulerTimeSlotForClockInputs(startValue, endValue) {
+            const startMinutes = parseSchedulerClockValueToMinutes(startValue);
+            const endMinutes = parseSchedulerClockValueToMinutes(endValue);
+
+            if (startMinutes == null) return null;
+
+            const exact = getSchedulerTimeSlots().find((slot) =>
+                Number.isFinite(slot.startMinutes)
+                && slot.startMinutes === startMinutes
+                && (endMinutes == null || slot.endMinutes === endMinutes)
+            );
+            if (exact) return exact;
+
+            return getSchedulerTimeSlots().find((slot) =>
+                Number.isFinite(slot.startMinutes)
+                && slot.startMinutes === startMinutes
+            ) || null;
+        }
+
+        function syncSchedulerEndTimeInput(startInputId, endInputId) {
+            const startInput = document.getElementById(startInputId);
+            const endInput = document.getElementById(endInputId);
+            if (!startInput || !endInput) return;
+
+            const slot = getSchedulerTimeSlotForClockInputs(startInput.value, endInput.value)
+                || getSchedulerTimeSlotForClockInputs(startInput.value, null);
+            if (!slot || !Number.isFinite(slot.endMinutes)) return;
+
+            const hours = Math.floor(slot.endMinutes / 60);
+            const minutes = slot.endMinutes % 60;
+            endInput.value = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+        }
+
         function getSchedulerRoomOptionList(options = {}) {
             const {
                 year = currentAcademicYear,
@@ -6248,9 +6328,9 @@
                 times.forEach(time => {
                     const timeSlot = document.createElement('div');
                     timeSlot.className = 'time-slot';
-                    timeSlot.textContent = day;
+                    timeSlot.textContent = getSchedulerDayLabel(day);
                     timeSlot.appendChild(document.createElement('br'));
-                    timeSlot.appendChild(document.createTextNode(time));
+                    timeSlot.appendChild(document.createTextNode(getSchedulerTimeSlotDisplayText(time)));
                     grid.appendChild(timeSlot);
 
                     rooms.forEach(room => {
@@ -6458,7 +6538,7 @@
                 const time = this.dataset.time;
                 const room = this.dataset.room;
                 document.getElementById('dropIndicatorText').textContent =
-                    'Drop to move to ' + day + ' ' + time + ' in Room ' + room;
+                    'Drop to move to ' + getSchedulerDayLabel(day) + ' ' + getSchedulerTimeSlotDisplayText(time) + ' in Room ' + room;
             }
         }
 
@@ -6630,7 +6710,7 @@
                     renderConflictSolver(quarter);
                     updateStats(quarter);
 
-                    let toastMsg = 'Moved ' + course.courseCode + ' to ' + newDay + ' ' + newTime + ' Room ' + newRoom;
+                    let toastMsg = 'Moved ' + course.courseCode + ' to ' + getSchedulerDayLabel(newDay) + ' ' + getSchedulerTimeSlotDisplayText(newTime) + ' Room ' + newRoom;
                     if (hasExisting) {
                         if (swapMode && swappedCourse) {
                             toastMsg += ' (swapped with ' + swappedCourse.code + ')';
@@ -7145,7 +7225,7 @@
 
         function formatConflictSlot(day, time) {
             const dayLabel = getSchedulerDayLabel(day) || day;
-            return `${dayLabel}, ${formatTime(time)}`;
+            return `${dayLabel}, ${getSchedulerTimeSlotDisplayText(time)}`;
         }
 
         function createConflictEntry({
@@ -8270,8 +8350,10 @@
             currentCourseData = { code, name, instructor, credits, room, courseId, quarter, day, time };
 
             // Format day/time for display
-            const dayDisplay = day || 'TBD';
-            const timeDisplay = time || 'TBD';
+            const dayDisplay = isSchedulableDay(day) ? getSchedulerDayLabel(day) : (day || 'TBD');
+            const timeDisplay = String(day || '').toUpperCase() === 'ONLINE' || String(time || '').toLowerCase() === 'async'
+                ? 'Online / Async'
+                : (time ? getSchedulerTimeSlotDisplayText(time) : 'TBD');
 
             // Build details content
             const content = document.getElementById('courseDetailsContent');
@@ -8341,6 +8423,7 @@
             }
             document.getElementById('editStartTime').value = startTime;
             document.getElementById('editEndTime').value = endTime;
+            syncSchedulerEndTimeInput('editStartTime', 'editEndTime');
 
             // Clear day checkboxes first
             ['M', 'T', 'W', 'Th', 'F'].forEach(day => {
@@ -8565,12 +8648,12 @@
                     if (!isOnlineEdit) {
                         const selectedDays = getEditSelectedDays();
                         const startTimeValue = document.getElementById('editStartTime').value;
+                        const endTimeValue = document.getElementById('editEndTime').value;
                         targetDay = (selectedDays.includes('M') || selectedDays.includes('W')) ? 'MW' : 'TR';
-                        targetTime = startTimeValue.replace(':', '') === '1000'
-                            ? '10:00-12:20'
-                            : startTimeValue.replace(':', '') === '1300'
-                                ? '13:00-15:20'
-                                : '16:00-18:20';
+                        targetTime = getSchedulerTimeSlotForClockInputs(startTimeValue, endTimeValue)?.id
+                            || getSchedulerTimeSlotForClockInputs(startTimeValue, null)?.id
+                            || sourceTime
+                            || '10:00-12:20';
                     }
 
                     if (!destinationQuarterData[targetDay]) destinationQuarterData[targetDay] = {};
@@ -12437,6 +12520,7 @@
             document.getElementById('addDayW').checked = true;
             document.getElementById('addOnlineSection').checked = false;
             toggleOnlineMode(false);
+            syncSchedulerEndTimeInput('addStartTime', 'addEndTime');
             populateAddRoomDropdown();
             document.getElementById('addCourseModal').classList.add('active');
 
@@ -12598,9 +12682,11 @@
             } else {
                 const days = getAddSelectedDays();
                 const startTime = document.getElementById('addStartTime').value;
+                const endTime = document.getElementById('addEndTime').value;
                 dayPattern = (days.includes('M') || days.includes('W')) ? 'MW' : 'TR';
-                timeSlot = startTime.replace(':', '') === '1000' ? '10:00-12:20' :
-                    startTime.replace(':', '') === '1300' ? '13:00-15:20' : '16:00-18:20';
+                timeSlot = getSchedulerTimeSlotForClockInputs(startTime, endTime)?.id
+                    || getSchedulerTimeSlotForClockInputs(startTime, null)?.id
+                    || '10:00-12:20';
             }
 
             // Ensure structure exists
@@ -13492,10 +13578,10 @@
                         </div>
                     </div>
 
-                    <div class="form-input-group">
-                        <div class="form-group">
-                            <label for="editStartTime" class="form-label">Start Time</label>
-                            <input type="time" id="editStartTime" class="form-input">
+                        <div class="form-input-group">
+                            <div class="form-group">
+                                <label for="editStartTime" class="form-label">Start Time</label>
+                            <input type="time" id="editStartTime" class="form-input" onchange="syncSchedulerEndTimeInput('editStartTime', 'editEndTime')">
                         </div>
 
                         <div class="form-group">
@@ -13831,7 +13917,7 @@
                         <div class="form-input-group">
                             <div class="form-group">
                                 <label for="addStartTime" class="form-label">Start Time</label>
-                                <select id="addStartTime" class="form-select" required>
+                                <select id="addStartTime" class="form-select" onchange="syncSchedulerEndTimeInput('addStartTime', 'addEndTime')" required>
                                     <option value="10:00">10:00 AM</option>
                                     <option value="13:00">1:00 PM</option>
                                     <option value="16:00">4:00 PM</option>
@@ -13841,9 +13927,9 @@
                             <div class="form-group">
                                 <label for="addEndTime" class="form-label">End Time</label>
                                 <select id="addEndTime" class="form-select" required>
-                                    <option value="12:00">12:00 PM</option>
-                                    <option value="15:00">3:00 PM</option>
-                                    <option value="18:00">6:00 PM</option>
+                                    <option value="12:20">12:20 PM</option>
+                                    <option value="15:20">3:20 PM</option>
+                                    <option value="18:20">6:20 PM</option>
                                 </select>
                             </div>
                         </div>
@@ -15052,7 +15138,7 @@
                                             <h5 style="color: #10b981; margin: 0 0 12px 0;">Resolution Options</h5>
                                             <p style="color: #94a3b8; font-size: 0.85em; margin-bottom: 12px;">Move one course to reduce the conflict:</p>
                                             ${c.resolutions.map((r, i) => {
-                                const timeDisplay = r.time ? r.time.replace('10:00-12:20', '10:00 AM - 12:20 PM').replace('13:00-15:20', '1:00 - 3:20 PM').replace('16:00-18:20', '4:00 - 6:20 PM') : (r.target_slot || 'alternate time');
+                                const timeDisplay = r.time ? getSchedulerTimeSlotDisplayText(r.time) : (r.target_slot || 'alternate time');
                                 const dayDisplay = r.dayName || (r.target_slot ? (r.target_slot.startsWith('MW') ? 'Monday/Wednesday' : 'Tuesday/Thursday') : '');
                                 return `
                                                 <div style="background: #1e293b; padding: 10px 12px; border-radius: 6px; margin-bottom: 8px; border-left: 3px solid ${i < 2 ? '#10b981' : '#3b82f6'};">

--- a/tests/index.scheduler-time-formatting.test.js
+++ b/tests/index.scheduler-time-formatting.test.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function extractFunction(source, name) {
+    const signature = `function ${name}(`;
+    const start = source.indexOf(signature);
+    if (start === -1) {
+        throw new Error(`Could not find function ${name}`);
+    }
+
+    const braceStart = source.indexOf('{', start);
+    let depth = 0;
+    for (let index = braceStart; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') {
+            depth -= 1;
+            if (depth === 0) {
+                return source.slice(start, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Could not extract function ${name}`);
+}
+
+function loadSchedulerTimeHelpers() {
+    const source = fs.readFileSync(path.resolve(__dirname, '..', 'index.html'), 'utf8');
+    const sandbox = {
+        getSchedulerTimeSlotByAlias: jest.fn(() => null),
+        getSchedulerTimeSlots: jest.fn(() => []),
+        document: {
+            getElementById: jest.fn(() => null)
+        }
+    };
+
+    vm.createContext(sandbox);
+    [
+        'formatSchedulerClockTime',
+        'formatSchedulerTimeRange',
+        'getSchedulerTimeSlotDisplayText',
+        'parseSchedulerClockValueToMinutes',
+        'getSchedulerTimeSlotForClockInputs'
+    ].forEach((name) => {
+        const fnSource = extractFunction(source, name);
+        vm.runInContext(fnSource, sandbox, { filename: `index.html#${name}` });
+    });
+
+    return { sandbox, source };
+}
+
+describe('index scheduler time formatting', () => {
+    test('formats canonical scheduler ranges in 12-hour time', () => {
+        const { sandbox } = loadSchedulerTimeHelpers();
+
+        expect(sandbox.formatSchedulerTimeRange('10:00-12:20')).toBe('10:00 AM - 12:20 PM');
+        expect(sandbox.formatSchedulerTimeRange('13:00-15:20')).toBe('1:00 PM - 3:20 PM');
+        expect(sandbox.formatSchedulerTimeRange('16:00-18:20')).toBe('4:00 PM - 6:20 PM');
+    });
+
+    test('uses configured slot labels when building display text', () => {
+        const { sandbox } = loadSchedulerTimeHelpers();
+        sandbox.getSchedulerTimeSlotByAlias.mockReturnValue({ label: '13:00-15:20' });
+
+        expect(sandbox.getSchedulerTimeSlotDisplayText('13:00-15:20')).toBe('1:00 PM - 3:20 PM');
+    });
+
+    test('maps start and end clock inputs to the configured 2h20 scheduler slot', () => {
+        const { sandbox } = loadSchedulerTimeHelpers();
+        sandbox.getSchedulerTimeSlots.mockReturnValue([
+            { id: '10:00-12:20', startMinutes: 600, endMinutes: 740 },
+            { id: '13:00-15:20', startMinutes: 780, endMinutes: 920 },
+            { id: '16:00-18:20', startMinutes: 960, endMinutes: 1100 }
+        ]);
+
+        const slot = sandbox.getSchedulerTimeSlotForClockInputs('10:00', '12:20');
+        expect(slot && slot.id).toBe('10:00-12:20');
+    });
+
+    test('add-course form offers 2h20 end times', () => {
+        const { source } = loadSchedulerTimeHelpers();
+
+        expect(source).toContain('<option value="12:20">12:20 PM</option>');
+        expect(source).toContain('<option value="15:20">3:20 PM</option>');
+        expect(source).toContain('<option value="18:20">6:20 PM</option>');
+    });
+});

--- a/update-2026-03-18.md
+++ b/update-2026-03-18.md
@@ -84,3 +84,21 @@
   - none
 - Next step:
   - commit and push the branch so GitHub matches the verified 2025-26 schedule pattern
+
+## 2026-03-18 15:41:39 PDT
+
+- Current issue or branch: scheduler time formatting on `codex/fix-scheduler-time-display`
+- Changes made:
+  - updated scheduler time labels, drag/drop messaging, conflict text, and course detail modal text to use 12-hour clock formatting instead of raw 24-hour slot ids
+  - fixed add/edit course time handling so the scheduler resolves slots from the configured start/end pair and syncs end times to the 2h20 schedule blocks
+  - corrected the add-course end-time options to `12:20 PM`, `3:20 PM`, and `6:20 PM`
+  - added `tests/index.scheduler-time-formatting.test.js` to cover 12-hour display formatting and 2h20 slot resolution
+  - verified in a real browser that Fall 2025 `ITGS 110` shows `Tuesday / Thursday` and `10:00 AM - 12:20 PM`; saved evidence to `output/playwright/itgs-110-time-display-fall-2025.png`
+- Tests run:
+  - `npm test -- --runInBand tests/index.scheduler-time-formatting.test.js`
+  - `npm run qa:onboarding`
+  - real-browser verification on `http://127.0.0.1:8081/index.html?cb=1773873379`
+- Blockers:
+  - none
+- Next step:
+  - commit, push, and open the PR for the time-display and 2h20 scheduler fix


### PR DESCRIPTION
## Summary
- render scheduler grid and course detail times in 12-hour clock format
- keep add/edit course time inputs aligned with the configured 2h20 scheduler slots
- add regression coverage for scheduler time formatting and slot resolution

## Verification
- npm test -- --runInBand tests/index.scheduler-time-formatting.test.js
- npm test -- --runInBand
- npm run qa:onboarding
- browser check on http://127.0.0.1:8081/index.html?cb=1773873379 confirming ITGS 110 shows Tuesday / Thursday and 10:00 AM - 12:20 PM
