### PR TITLE
Simplify scheduler row labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -4003,6 +4003,22 @@
             box-shadow: 0 4px 12px rgba(31, 35, 40, 0.12);
         }
 
+        .schedule-cell.single-course-cell {
+            display: flex;
+            padding: 0;
+        }
+
+        .single-course-cell .course-block.single-course-block {
+            flex: 1;
+            min-height: 100%;
+            margin-bottom: 0;
+            border-radius: 0;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-start;
+            padding: 12px 14px;
+        }
+
         .btn-ewu-accent {
             border-radius: 8px !important;
             box-shadow: 0 1px 0 rgba(27, 31, 36, 0.08) !important;
@@ -6339,6 +6355,9 @@
 
                         const cell = document.createElement('div');
                         cell.className = 'schedule-cell drop-zone';
+                        if (courses.length === 1) {
+                            cell.classList.add('single-course-cell');
+                        }
                         cell.dataset.day = day;
                         cell.dataset.time = time;
                         cell.dataset.room = room;
@@ -6389,6 +6408,9 @@
 
                             const block = document.createElement('div');
                             block.className = 'course-block conflict-' + conflictLevel + ' ' + facultyClass + ' ' + trendClass;
+                            if (courses.length === 1) {
+                                block.classList.add('single-course-block');
+                            }
                             block.dataset.courseId = courseId;
                             block.dataset.quarter = quarter;
                             block.dataset.courseCode = course.code;

--- a/tests/index.scheduler-time-formatting.test.js
+++ b/tests/index.scheduler-time-formatting.test.js
@@ -92,4 +92,11 @@ describe('index scheduler time formatting', () => {
         expect(source).toContain("timeSlot.textContent = timeLabel;");
         expect(source).toContain("timeSlot.setAttribute('aria-label', `${getSchedulerDayLabel(day)} ${timeLabel}`);");
     });
+
+    test('single-course scheduler cells render as full slot blocks', () => {
+        const { source } = loadSchedulerTimeHelpers();
+
+        expect(source).toContain("cell.classList.add('single-course-cell');");
+        expect(source).toContain("block.classList.add('single-course-block');");
+    });
 });

--- a/update-2026-03-18.md
+++ b/update-2026-03-18.md
@@ -119,3 +119,20 @@
   - none
 - Next step:
   - commit, push, and open the PR for the row-label cleanup
+
+## 2026-03-18 15:51:08 PDT
+
+- Current issue or branch: scheduler slot-fill follow-up on `codex/fix-schedule-row-labels`
+- Changes made:
+  - updated single-course scheduler cells so course cards fill the slot visually instead of rendering as small tags inside large empty cells
+  - kept stacked behavior unchanged for multi-course conflict cells so overlap review still works
+  - extended `tests/index.scheduler-time-formatting.test.js` to guard the single-course full-slot rendering hook
+  - verified in a real browser that the Fall 2025 grid now shows full-height course blocks; saved evidence to `output/playwright/schedule-single-course-slot-fill.png`
+- Tests run:
+  - `npm test -- --runInBand tests/index.scheduler-time-formatting.test.js`
+  - `npm run qa:onboarding`
+  - real-browser verification on `http://127.0.0.1:8081/index.html?cb=1773874472`
+- Blockers:
+  - none
+- Next step:
+  - commit and push this visual fill adjustment so PR `#208` reflects the approved grid style


### PR DESCRIPTION
## Summary
- remove the repeated day label from each left-side schedule row
- keep day context in the section divider while preserving an accessible day+time aria label
- extend scheduler time formatting coverage for the time-only row labels

## Verification
- npm test -- --runInBand tests/index.scheduler-time-formatting.test.js
- npm run qa:onboarding
- browser check on http://127.0.0.1:8081/index.html?cb=1773874130 confirming the left column shows time only
