### PR TITLE
Add batched screenshot onboarding intake for issue 212

### DIFF
--- a/index.html
+++ b/index.html
@@ -344,6 +344,17 @@
             font-size: 13px;
         }
 
+        .program-shell-choice-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .program-shell-choice-note {
+            font-size: 12px;
+            color: #64748b;
+        }
+
         .program-shell-choice-tag {
             display: inline-flex;
             width: fit-content;
@@ -4771,10 +4782,15 @@
                         <h3>Screenshot upload</h3>
                         <p>Capture screenshots from class search with the enrollment view and preserve the handoff context now.</p>
                         <ul>
-                            <li>Visible in the shell today so the route is explicit.</li>
+                            <li>Accept a screenshot folder when your browser can preserve nested quarter folders.</li>
+                            <li>Fall back to choosing multiple screenshot files when folder upload is not available.</li>
                             <li>Parsing and schedule seeding remain staged after the spreadsheet path.</li>
                         </ul>
-                        <button type="button" class="program-shell-button-secondary" id="programShellScreenshotButton">Choose screenshots</button>
+                        <div class="program-shell-choice-actions">
+                            <button type="button" class="program-shell-button-secondary" id="programShellScreenshotDirectoryButton">Choose screenshot folder</button>
+                            <button type="button" class="program-shell-button-secondary" id="programShellScreenshotButton">Choose screenshot files</button>
+                        </div>
+                        <p class="program-shell-choice-note" id="programShellScreenshotSupportText">Folder upload keeps nested quarter folders when the browser supports directory selection.</p>
                     </article>
                 </div>
                 <div class="program-shell-actions">
@@ -4783,7 +4799,8 @@
             </section>
         </div>
         <input id="programShellSpreadsheetInput" type="file" accept=".csv,.xlsx,.xls" hidden>
-        <input id="programShellScreenshotInput" type="file" accept="image/*" hidden>
+        <input id="programShellScreenshotDirectoryInput" type="file" accept="image/*" multiple webkitdirectory hidden>
+        <input id="programShellScreenshotInput" type="file" accept="image/*" multiple hidden>
     </div>
 
     <!-- Displaced Course Tray Sidebar -->

--- a/js/program-shell.js
+++ b/js/program-shell.js
@@ -191,6 +191,139 @@
         };
     }
 
+    const TERM_LABELS = Object.freeze({
+        fall: 'Fall',
+        winter: 'Winter',
+        spring: 'Spring',
+        summer: 'Summer'
+    });
+
+    const TERM_SORT_ORDER = Object.freeze({
+        fall: 0,
+        winter: 1,
+        spring: 2,
+        summer: 3,
+        unassigned: 99
+    });
+
+    function createArtifactMetadata(artifact) {
+        if (!artifact || typeof artifact !== 'object') return null;
+        return {
+            name: String(artifact.name || '').trim() || null,
+            size: Number(artifact.size) || 0,
+            type: String(artifact.type || '').trim() || null,
+            capturedAt: artifact.capturedAt || new Date().toISOString()
+        };
+    }
+
+    function isScreenshotFile(file) {
+        if (!file || typeof file !== 'object') return false;
+        const name = String(file.name || '').trim().toLowerCase();
+        const type = String(file.type || '').trim().toLowerCase();
+        if (type.startsWith('image/')) return true;
+        return /\.(png|jpe?g|webp|gif|bmp)$/i.test(name);
+    }
+
+    function inferScreenshotTermYear(value) {
+        const normalized = String(value || '').trim();
+        if (!normalized) return { term: null, year: null };
+
+        const byTermFirst = normalized.match(/\b(fall|winter|spring|summer)\b[^0-9]{0,12}(20\d{2})\b/i);
+        if (byTermFirst) {
+            return {
+                term: String(byTermFirst[1] || '').trim().toLowerCase() || null,
+                year: Number(byTermFirst[2]) || null
+            };
+        }
+
+        const byYearFirst = normalized.match(/\b(20\d{2})\b[^a-z0-9]{0,12}(fall|winter|spring|summer)\b/i);
+        if (byYearFirst) {
+            return {
+                term: String(byYearFirst[2] || '').trim().toLowerCase() || null,
+                year: Number(byYearFirst[1]) || null
+            };
+        }
+
+        return { term: null, year: null };
+    }
+
+    function formatScreenshotGroupLabel(term, year) {
+        if (!term || !year) return 'Unassigned';
+        return `${TERM_LABELS[term] || term} ${year}`;
+    }
+
+    function buildScreenshotArtifactBatch(files, options = {}) {
+        const normalizedFiles = Array.from(files || [])
+            .filter((file) => file && typeof file === 'object' && isScreenshotFile(file))
+            .map((file, index) => {
+                const artifact = createArtifactMetadata(file) || {};
+                const relativePath = String(file.webkitRelativePath || file.relativePath || '').trim() || null;
+                const sourcePath = relativePath || artifact.name || `screenshot-${index + 1}`;
+                const inference = inferScreenshotTermYear(sourcePath);
+                const groupKey = inference.term && inference.year
+                    ? `${inference.term}-${inference.year}`
+                    : 'unassigned';
+
+                return {
+                    name: artifact.name || `screenshot-${index + 1}`,
+                    size: artifact.size || 0,
+                    type: artifact.type || null,
+                    relativePath,
+                    sourcePath,
+                    term: inference.term,
+                    year: inference.year,
+                    groupKey
+                };
+            });
+
+        const groupsMap = new Map();
+        normalizedFiles.forEach((file) => {
+            if (!groupsMap.has(file.groupKey)) {
+                groupsMap.set(file.groupKey, {
+                    key: file.groupKey,
+                    term: file.term,
+                    year: file.year,
+                    label: formatScreenshotGroupLabel(file.term, file.year),
+                    fileCount: 0,
+                    sampleNames: []
+                });
+            }
+
+            const group = groupsMap.get(file.groupKey);
+            group.fileCount += 1;
+            if (group.sampleNames.length < 4) {
+                group.sampleNames.push(file.relativePath || file.name);
+            }
+        });
+
+        const rootFolderName = String(options.rootFolderName || '').trim() || (() => {
+            const firstRelativePath = normalizedFiles.find((file) => file.relativePath)?.relativePath || '';
+            return firstRelativePath ? firstRelativePath.split('/')[0] : null;
+        })();
+
+        const groups = Array.from(groupsMap.values()).sort((left, right) => {
+            const leftYear = Number(left.year) || Number.MAX_SAFE_INTEGER;
+            const rightYear = Number(right.year) || Number.MAX_SAFE_INTEGER;
+            if (leftYear !== rightYear) return leftYear - rightYear;
+
+            const leftOrder = TERM_SORT_ORDER[left.term || 'unassigned'] ?? TERM_SORT_ORDER.unassigned;
+            const rightOrder = TERM_SORT_ORDER[right.term || 'unassigned'] ?? TERM_SORT_ORDER.unassigned;
+            if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+
+            return String(left.label || '').localeCompare(String(right.label || ''));
+        });
+
+        return {
+            mode: String(options.mode || 'files').trim() || 'files',
+            rootFolderName: rootFolderName || null,
+            count: normalizedFiles.length,
+            totalSize: normalizedFiles.reduce((sum, file) => sum + (Number(file.size) || 0), 0),
+            groups,
+            files: normalizedFiles,
+            capturedAt: options.capturedAt || new Date().toISOString()
+        };
+    }
+
     function resolveStoredSelection(groups = DEFAULT_PROGRAM_GROUPS) {
         const storedSelection = readSelection();
         const resolvedProgram = findProgramById(storedSelection?.id, groups);
@@ -216,13 +349,9 @@
 
     function createOnboardingContext(program, options = {}) {
         const selection = createProgramSelection(program);
-        const artifact = options.artifact && typeof options.artifact === 'object'
-            ? {
-                name: String(options.artifact.name || '').trim() || null,
-                size: Number(options.artifact.size) || 0,
-                type: String(options.artifact.type || '').trim() || null,
-                capturedAt: options.artifact.capturedAt || new Date().toISOString()
-            }
+        const artifact = createArtifactMetadata(options.artifact);
+        const artifactBatch = options.artifactBatch && typeof options.artifactBatch === 'object'
+            ? buildScreenshotArtifactBatch(options.artifactBatch.files || [], options.artifactBatch)
             : null;
 
         return {
@@ -230,6 +359,7 @@
             source: String(options.source || 'manual').trim() || 'manual',
             suggestedIdentity: buildSuggestedIdentity(program),
             artifact,
+            artifactBatch,
             createdAt: new Date().toISOString()
         };
     }
@@ -465,9 +595,12 @@
             chooser: global.document.getElementById('programShellChooser'),
             manualButton: global.document.getElementById('programShellManualButton'),
             spreadsheetButton: global.document.getElementById('programShellSpreadsheetButton'),
+            screenshotDirectoryButton: global.document.getElementById('programShellScreenshotDirectoryButton'),
             screenshotButton: global.document.getElementById('programShellScreenshotButton'),
             spreadsheetInput: global.document.getElementById('programShellSpreadsheetInput'),
+            screenshotDirectoryInput: global.document.getElementById('programShellScreenshotDirectoryInput'),
             screenshotInput: global.document.getElementById('programShellScreenshotInput'),
+            screenshotSupportText: global.document.getElementById('programShellScreenshotSupportText'),
             chooserMeta: global.document.getElementById('programShellChooserMeta'),
             status: global.document.getElementById('programShellStatus')
         };
@@ -477,7 +610,8 @@
             session: null,
             previewMode: false,
             chooserVisible: false,
-            runtimeLaunched: false
+            runtimeLaunched: false,
+            directoryUploadSupported: Boolean(elements.screenshotDirectoryInput && ('webkitdirectory' in elements.screenshotDirectoryInput))
         };
 
         function authSatisfied() {
@@ -627,6 +761,20 @@
                 elements.continueButton.disabled = !state.selectedProgram || !authSatisfied();
             }
 
+            if (elements.screenshotDirectoryButton) {
+                elements.screenshotDirectoryButton.hidden = !state.directoryUploadSupported;
+            }
+            if (elements.screenshotSupportText) {
+                elements.screenshotSupportText.textContent = state.directoryUploadSupported
+                    ? 'Folder upload keeps nested quarter folders when the browser supports directory selection.'
+                    : 'This browser does not expose directory selection here, so use multiple screenshot files instead.';
+            }
+            if (elements.screenshotButton) {
+                elements.screenshotButton.textContent = state.directoryUploadSupported
+                    ? 'Choose screenshot files'
+                    : 'Choose screenshots';
+            }
+
             if (elements.chooser) {
                 elements.chooser.hidden = !state.chooserVisible || !authSatisfied();
             }
@@ -740,7 +888,7 @@
             updateUi();
         }
 
-        function navigateToOnboarding(source, file) {
+        function navigateToOnboarding(source, intake = {}) {
             if (!state.selectedProgram) {
                 setStatus('error', 'Choose a program before starting onboarding.');
                 return;
@@ -756,17 +904,24 @@
 
             const context = createOnboardingContext(state.selectedProgram, {
                 source,
-                artifact: file
-                    ? {
-                        name: file.name,
-                        size: file.size,
-                        type: file.type,
-                        capturedAt: new Date().toISOString()
-                    }
-                    : null
+                artifact: intake.artifact || null,
+                artifactBatch: intake.artifactBatch || null
             });
             persistOnboardingContext(context);
             global.location.href = `${onboardingUrl}?source=${encodeURIComponent(source)}&program=${encodeURIComponent(context.id || '')}`;
+        }
+
+        function handleScreenshotSelection(files, mode) {
+            const artifactBatch = buildScreenshotArtifactBatch(files, {
+                mode
+            });
+
+            if (!artifactBatch.count) {
+                setStatus('error', 'Choose one or more screenshot files to continue.');
+                return;
+            }
+
+            navigateToOnboarding('screenshot', { artifactBatch });
         }
 
         renderProgramList();
@@ -805,18 +960,33 @@
         elements.spreadsheetButton?.addEventListener('click', () => {
             elements.spreadsheetInput?.click();
         });
+        elements.screenshotDirectoryButton?.addEventListener('click', () => {
+            elements.screenshotDirectoryInput?.click();
+        });
         elements.screenshotButton?.addEventListener('click', () => {
             elements.screenshotInput?.click();
         });
         elements.spreadsheetInput?.addEventListener('change', (event) => {
             const file = event.target?.files?.[0];
             if (!file) return;
-            navigateToOnboarding('spreadsheet', file);
+            navigateToOnboarding('spreadsheet', {
+                artifact: {
+                    name: file.name,
+                    size: file.size,
+                    type: file.type,
+                    capturedAt: new Date().toISOString()
+                }
+            });
+        });
+        elements.screenshotDirectoryInput?.addEventListener('change', (event) => {
+            const files = Array.from(event.target?.files || []);
+            if (!files.length) return;
+            handleScreenshotSelection(files, 'directory');
         });
         elements.screenshotInput?.addEventListener('change', (event) => {
-            const file = event.target?.files?.[0];
-            if (!file) return;
-            navigateToOnboarding('screenshot', file);
+            const files = Array.from(event.target?.files || []);
+            if (!files.length) return;
+            handleScreenshotSelection(files, 'files');
         });
 
         if (authService && typeof authService.onAuthStateChange === 'function') {
@@ -845,6 +1015,7 @@
         findProgramById,
         buildSuggestedIdentity,
         createProgramSelection,
+        buildScreenshotArtifactBatch,
         createOnboardingContext,
         detectProgramData,
         readSelection,

--- a/pages/department-onboarding.html
+++ b/pages/department-onboarding.html
@@ -189,6 +189,19 @@
             letter-spacing: 0.08em;
             text-transform: uppercase;
         }
+
+        .handoff-artifact-groups {
+            display: grid;
+            gap: 8px;
+            margin-top: 6px;
+        }
+
+        .handoff-artifact-groups ul {
+            margin: 0;
+            padding-left: 18px;
+            display: grid;
+            gap: 4px;
+        }
     </style>
 </head>
 <body>
@@ -205,6 +218,7 @@
             <div class="handoff-meta">
                 <div id="handoffSummary"></div>
                 <div id="handoffArtifact"></div>
+                <div class="handoff-artifact-groups" id="handoffArtifactGroups" hidden></div>
             </div>
         </section>
 

--- a/pages/department-onboarding.js
+++ b/pages/department-onboarding.js
@@ -97,12 +97,16 @@
         const title = qs('handoffTitle');
         const summary = qs('handoffSummary');
         const artifact = qs('handoffArtifact');
+        const artifactGroups = qs('handoffArtifactGroups');
         const badge = qs('handoffBadge');
 
         const label = String(context.label || 'Selected program').trim() || 'Selected program';
         const parentLabel = String(context.parentLabel || '').trim();
         const source = String(context.source || 'manual').trim() || 'manual';
         const artifactName = String(context.artifact?.name || '').trim();
+        const artifactBatch = context.artifactBatch && typeof context.artifactBatch === 'object'
+            ? context.artifactBatch
+            : null;
         const sourceLabel = source === 'spreadsheet'
             ? 'Spreadsheet handoff'
             : source === 'screenshot'
@@ -121,11 +125,50 @@
                 : `${label} came from the Program Command start shell. Use this page to shape the first versioned profile and keep the selected program context intact.`;
         }
         if (artifact) {
-            artifact.textContent = artifactName
-                ? `Captured artifact: ${artifactName}. Parsing and seeded schedule generation continue in the follow-on import slice.`
-                : source === 'manual'
-                    ? 'No import artifact attached. Manual setup is active for this handoff.'
-                    : 'No artifact metadata was carried into this handoff.';
+            if (source === 'screenshot' && artifactBatch?.count) {
+                const rootFolderName = String(artifactBatch.rootFolderName || '').trim();
+                const groupedCount = Array.isArray(artifactBatch.groups)
+                    ? artifactBatch.groups.filter((group) => String(group.key || '') !== 'unassigned').length
+                    : 0;
+                const intro = rootFolderName
+                    ? `Captured ${artifactBatch.count} screenshot files from ${rootFolderName}.`
+                    : `Captured ${artifactBatch.count} screenshot files for this onboarding handoff.`;
+                const grouping = groupedCount
+                    ? ` The shell inferred ${groupedCount} term group${groupedCount === 1 ? '' : 's'} for downstream parsing.`
+                    : ' The shell preserved the files, but term grouping still needs manual review before parsing.';
+                artifact.textContent = `${intro}${grouping}`;
+            } else {
+                artifact.textContent = artifactName
+                    ? `Captured artifact: ${artifactName}. Parsing and seeded schedule generation continue in the follow-on import slice.`
+                    : source === 'manual'
+                        ? 'No import artifact attached. Manual setup is active for this handoff.'
+                        : 'No artifact metadata was carried into this handoff.';
+            }
+        }
+
+        if (artifactGroups) {
+            artifactGroups.innerHTML = '';
+            const groups = Array.isArray(artifactBatch?.groups) ? artifactBatch.groups : [];
+            if (source === 'screenshot' && groups.length) {
+                const heading = document.createElement('strong');
+                heading.textContent = 'Grouped screenshot batches';
+                artifactGroups.appendChild(heading);
+
+                const list = document.createElement('ul');
+                groups.forEach((group) => {
+                    const li = document.createElement('li');
+                    const labelText = String(group.label || 'Unassigned').trim() || 'Unassigned';
+                    const sampleNames = Array.isArray(group.sampleNames) && group.sampleNames.length
+                        ? ` Examples: ${group.sampleNames.slice(0, 2).join(', ')}`
+                        : '';
+                    li.textContent = `${labelText}: ${Number(group.fileCount) || 0} file${Number(group.fileCount) === 1 ? '' : 's'}.${sampleNames}`;
+                    list.appendChild(li);
+                });
+                artifactGroups.appendChild(list);
+                artifactGroups.hidden = false;
+            } else {
+                artifactGroups.hidden = true;
+            }
         }
 
         card.hidden = false;
@@ -158,7 +201,14 @@
         if (source === 'spreadsheet') {
             setStatus('info', `Spreadsheet handoff ready for ${label}. Finish the profile setup here before the import mapping slice lands.`);
         } else if (source === 'screenshot') {
-            setStatus('warn', `Screenshot handoff captured for ${label}. OCR/import parsing is staged after the spreadsheet path, but program context is preserved here.`);
+            const screenshotCount = Number(context.artifactBatch?.count) || 0;
+            const groupedCount = Array.isArray(context.artifactBatch?.groups)
+                ? context.artifactBatch.groups.filter((group) => String(group.key || '') !== 'unassigned').length
+                : 0;
+            const screenshotSummary = screenshotCount
+                ? `${screenshotCount} file${screenshotCount === 1 ? '' : 's'}${groupedCount ? ` across ${groupedCount} inferred term group${groupedCount === 1 ? '' : 's'}` : ''}`
+                : 'the captured screenshot set';
+            setStatus('warn', `Screenshot handoff ready for ${label}: ${screenshotSummary}. OCR/import parsing is staged after the spreadsheet path, but program context is preserved here.`);
         } else {
             setStatus('info', `Manual setup handoff ready for ${label}.`);
         }

--- a/tests/program-shell.test.js
+++ b/tests/program-shell.test.js
@@ -74,6 +74,98 @@ describe('ProgramCommandShell', () => {
         });
     });
 
+    test('builds a screenshot batch manifest from nested folder metadata', () => {
+        const batch = shell.buildScreenshotArtifactBatch([
+            {
+                name: 'cscd fall 2025 1.png',
+                size: 128,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/cscd fall 2025/cscd fall 2025 1.png'
+            },
+            {
+                name: 'cscd winter 2026 2.png',
+                size: 256,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/cscd winter 2026/cscd winter 2026 2.png'
+            },
+            {
+                name: 'notes.png',
+                size: 64,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/misc/notes.png'
+            },
+            {
+                name: '.DS_Store',
+                size: 32,
+                type: '',
+                webkitRelativePath: 'cscd-cyber AY2025-26/.DS_Store'
+            }
+        ], {
+            mode: 'directory',
+            capturedAt: '2026-03-26T18:30:00.000Z'
+        });
+
+        expect(batch).toMatchObject({
+            mode: 'directory',
+            rootFolderName: 'cscd-cyber AY2025-26',
+            count: 3,
+            totalSize: 448,
+            capturedAt: '2026-03-26T18:30:00.000Z'
+        });
+        expect(batch.groups).toEqual(expect.arrayContaining([
+            expect.objectContaining({ key: 'fall-2025', label: 'Fall 2025', fileCount: 1 }),
+            expect.objectContaining({ key: 'winter-2026', label: 'Winter 2026', fileCount: 1 }),
+            expect.objectContaining({ key: 'unassigned', label: 'Unassigned', fileCount: 1 })
+        ]));
+        expect(batch.files[0]).toEqual(expect.objectContaining({
+            name: 'cscd fall 2025 1.png',
+            relativePath: 'cscd-cyber AY2025-26/cscd fall 2025/cscd fall 2025 1.png',
+            term: 'fall',
+            year: 2025
+        }));
+    });
+
+    test('creates screenshot onboarding context with grouped artifact batch metadata', () => {
+        const program = shell.findProgramById('cybersecurity');
+        const artifactBatch = shell.buildScreenshotArtifactBatch([
+            {
+                name: 'cyber fall 2025 1.png',
+                size: 200,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/cyber fall 2025/cyber fall 2025 1.png'
+            },
+            {
+                name: 'cyber spring 2026 1.png',
+                size: 220,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/cyber spring 2026/cyber spring 2026 1.png'
+            }
+        ], {
+            mode: 'directory'
+        });
+
+        const context = shell.createOnboardingContext(program, {
+            source: 'screenshot',
+            artifactBatch
+        });
+
+        expect(context).toMatchObject({
+            id: 'cybersecurity',
+            label: 'Cybersecurity',
+            source: 'screenshot',
+            artifactBatch: expect.objectContaining({
+                mode: 'directory',
+                rootFolderName: 'cscd-cyber AY2025-26',
+                count: 2
+            })
+        });
+        expect(context.artifact).toBeNull();
+        expect(context.artifactBatch.groups).toEqual(expect.arrayContaining([
+            expect.objectContaining({ key: 'fall-2025', label: 'Fall 2025', fileCount: 1 }),
+            expect.objectContaining({ key: 'spring-2026', label: 'Spring 2026', fileCount: 1 })
+        ]));
+    });
+
     test('detects a previously onboarded custom profile for a non-seeded program', async () => {
         const biology = shell.findProgramById('biology');
         const manager = {


### PR DESCRIPTION
## Summary
- add folder and multi-file screenshot intake paths in the Program Command onboarding shell
- build and persist a normalized screenshot batch manifest with inferred term/year groups
- render grouped screenshot handoff details on the onboarding page for downstream parsing work
- ignore non-image files during directory intake so Finder metadata like `.DS_Store` does not pollute the batch

Closes #212.

## Validation
- `npm test -- --runInBand`
- Live browser verification at `http://127.0.0.1:8123/`
  - multi-file screenshot upload carried Cybersecurity context into onboarding
  - directory upload using `/Users/tmasingale/Downloads/cscd-cyber AY2025-26` preserved the folder root and grouped 12 screenshots into Fall 2025 / Winter 2026 / Spring 2026
  - non-image `.DS_Store` content was excluded from the stored batch manifest