### PR TITLE
Issue #210: import EagleNET spreadsheets into seeded schedule review

### DIFF
--- a/index.html
+++ b/index.html
@@ -4687,6 +4687,8 @@
     <script src="js/department-profile.js"></script>
     <script type="module" src="js/supabase-config.js"></script>
     <script src="js/auth-service.js"></script>
+    <script src="js/eaglenet-compare.js"></script>
+    <script src="js/eaglenet-import.js"></script>
     <script src="js/program-shell.js"></script>
     <script src="js/auth-guard.js"></script>
     <script src="js/dirty-state-tracker.js"></script>
@@ -6400,6 +6402,40 @@
 
             // Auto-remove after 5 seconds
             setTimeout(() => notification.remove(), 5000);
+        }
+
+        async function resumePendingOnboardingImport() {
+            const importApi = window.ProgramCommandImport;
+            if (!importApi || typeof importApi.readPendingOnboardingImport !== 'function') {
+                return false;
+            }
+
+            const pendingImport = importApi.readPendingOnboardingImport();
+            if (!pendingImport || pendingImport.source !== 'spreadsheet') {
+                return false;
+            }
+
+            const currentProfileId = window.DepartmentProfileManager?.getStoredProfileId?.();
+            if (pendingImport.profileId && currentProfileId && String(pendingImport.profileId) !== String(currentProfileId)) {
+                return false;
+            }
+
+            try {
+                openClssImportModal();
+                applyClssSpreadsheetPayload(pendingImport, { announce: false });
+                if (typeof importApi.clearPendingOnboardingImport === 'function') {
+                    importApi.clearPendingOnboardingImport();
+                }
+                const fileName = String(pendingImport?.artifact?.name || '').trim();
+                showToast(fileName
+                    ? `Resumed onboarding spreadsheet import from ${fileName}`
+                    : 'Resumed onboarding spreadsheet import');
+                return true;
+            } catch (error) {
+                console.error('Could not resume onboarding import handoff:', error);
+                showToast(error?.message || 'Could not resume the onboarding spreadsheet import.', 'error');
+                return false;
+            }
         }
 
         function renderSchedule(quarter) {
@@ -9371,9 +9407,128 @@
         let clssImportOcrLibraryPromise = null;
         let clssImportPriorYearPlacementIndexCache = new Map();
         let clssImportLastApplyReport = null;
+        let clssImportSpreadsheetPayload = null;
 
         function getClssImportRoomOptionList() {
             return getSchedulerRoomOptionList();
+        }
+
+        function setClssImportSpreadsheetSummary(message) {
+            const summaryEl = document.getElementById('clssImportSpreadsheetSummary');
+            if (!summaryEl) return;
+            summaryEl.textContent = String(message || 'No spreadsheet selected.');
+        }
+
+        function clearClssImportSpreadsheetPayload(options = {}) {
+            clssImportSpreadsheetPayload = null;
+            setClssImportSpreadsheetSummary('No spreadsheet selected.');
+            if (options?.clearInput) {
+                const input = document.getElementById('clssImportSpreadsheetInput');
+                if (input) input.value = '';
+            }
+        }
+
+        function primeClssImportScopeFromRows(rows) {
+            const quarters = [...new Set((Array.isArray(rows) ? rows : [])
+                .map((row) => String(row?.targetQuarter || row?.reviewQuarter || '').trim().toLowerCase())
+                .filter((value) => CLSS_IMPORT_QUARTERS.includes(value)))];
+
+            const scopeSelect = document.getElementById('clssImportScope');
+            const quarterSelect = document.getElementById('clssImportQuarter');
+            if (scopeSelect) {
+                scopeSelect.value = quarters.length > 1 ? 'all' : 'single';
+            }
+            if (quarterSelect && quarters.length === 1) {
+                quarterSelect.value = quarters[0];
+            }
+            toggleClssImportInputMode();
+        }
+
+        function applyClssSpreadsheetPayload(payload, options = {}) {
+            const importApi = window.ProgramCommandImport;
+            if (!importApi || typeof importApi.buildClssPreviewRowsFromTabularRows !== 'function') {
+                throw new Error('Spreadsheet import runtime is unavailable.');
+            }
+
+            const spreadsheetImport = payload?.spreadsheetImport && typeof payload.spreadsheetImport === 'object'
+                ? payload.spreadsheetImport
+                : payload;
+            const rows = Array.isArray(spreadsheetImport?.rows) ? spreadsheetImport.rows : [];
+            if (!rows.length) {
+                throw new Error('Spreadsheet import did not contain any rows.');
+            }
+
+            const preview = importApi.buildClssPreviewRowsFromTabularRows(rows, {
+                fileName: String(spreadsheetImport?.meta?.fileName || payload?.artifact?.name || '').trim() || null,
+                defaultQuarter: (window.StateManager?.get('currentQuarter')) || 'spring',
+                dayPatterns: getSchedulerDayPatterns(),
+                timeSlots: getSchedulerTimeSlots(),
+                roomOptions: getClssImportRoomOptionList(),
+                resolveCourseCode: resolveClssImportCourseCode,
+                resolveFacultyName: getCanonicalFacultyName
+            });
+
+            clssImportSpreadsheetPayload = {
+                artifact: payload?.artifact || null,
+                spreadsheetImport,
+                meta: preview.meta
+            };
+            primeClssImportScopeFromRows(preview.rows);
+            applyClssPriorYearAutoSuggestionsToRows(preview.rows, getClssImportTargetAcademicYear());
+            clssImportPreviewRows = preview.rows;
+            renderClssImportReview(clssImportPreviewRows, preview.meta);
+
+            const fileName = String(spreadsheetImport?.meta?.fileName || payload?.artifact?.name || '').trim();
+            const quarterCounts = preview.meta?.quarterCounts && typeof preview.meta.quarterCounts === 'object'
+                ? Object.entries(preview.meta.quarterCounts)
+                    .filter(([, count]) => Number(count) > 0)
+                    .map(([quarter, count]) => `${quarter.charAt(0).toUpperCase() + quarter.slice(1)} ${count}`)
+                    .join(', ')
+                : '';
+            setClssImportSpreadsheetSummary(
+                fileName
+                    ? `${fileName}: ${preview.rows.length} parsed row${preview.rows.length === 1 ? '' : 's'}${quarterCounts ? ` (${quarterCounts})` : ''}.`
+                    : `${preview.rows.length} parsed spreadsheet row${preview.rows.length === 1 ? '' : 's'}${quarterCounts ? ` (${quarterCounts})` : ''}.`
+            );
+
+            if (options?.announce !== false) {
+                showToast(`Loaded ${preview.rows.length} spreadsheet row${preview.rows.length === 1 ? '' : 's'} for CLSS review`);
+            }
+
+            return preview;
+        }
+
+        async function handleClssImportSpreadsheetSelection(event) {
+            const file = event?.target?.files?.[0];
+            if (!file) {
+                clearClssImportSpreadsheetPayload();
+                return;
+            }
+
+            const importApi = window.ProgramCommandImport;
+            if (!importApi || typeof importApi.readTabularRowsFromFile !== 'function') {
+                setClssImportSpreadsheetSummary('Spreadsheet import runtime is unavailable.');
+                showToast('Spreadsheet import runtime is unavailable.', 'error');
+                return;
+            }
+
+            setClssImportSpreadsheetSummary(`Parsing ${file.name}...`);
+            try {
+                const spreadsheetImport = await importApi.readTabularRowsFromFile(file);
+                applyClssSpreadsheetPayload({
+                    artifact: {
+                        name: file.name,
+                        size: file.size,
+                        type: file.type,
+                        capturedAt: new Date().toISOString()
+                    },
+                    spreadsheetImport
+                });
+            } catch (error) {
+                clearClssImportSpreadsheetPayload();
+                setClssImportSpreadsheetSummary(error?.message || 'Could not parse the selected spreadsheet.');
+                showToast(error?.message || 'Could not parse the selected spreadsheet.', 'error');
+            }
         }
 
         function openClssImportModal() {
@@ -9386,6 +9541,9 @@
             refreshClssImportModeUi();
             toggleClssImportInputMode();
             handleClssImportPngSelection();
+            if (!clssImportSpreadsheetPayload) {
+                setClssImportSpreadsheetSummary('No spreadsheet selected.');
+            }
             renderClssImportResultsPanel(readClssImportLastReport());
             modal?.classList.add('active');
         }
@@ -9637,6 +9795,23 @@
             const pngCount = (document.getElementById('clssImportPngInput')?.files || []).length;
             let parseSources = getClssImportParseSources();
             let hasAnyText = parseSources.some((source) => source.text);
+            const hasSpreadsheetRows = Array.isArray(clssImportSpreadsheetPayload?.spreadsheetImport?.rows)
+                && clssImportSpreadsheetPayload.spreadsheetImport.rows.length > 0;
+
+            if (!hasAnyText && pngCount === 0 && hasSpreadsheetRows) {
+                const preview = applyClssSpreadsheetPayload(clssImportSpreadsheetPayload, { announce: false });
+                if (!preview.rows.length) {
+                    renderClssImportReview([]);
+                    showToast('Spreadsheet import did not yield any review rows.', 'error');
+                    return;
+                }
+
+                const effectiveRows = clssImportPreviewRows.map((row) => getClssImportRowEffectiveState(row));
+                const readyCount = effectiveRows.filter((row) => row.effectiveStatus === 'ready').length;
+                const needsReviewCount = effectiveRows.filter((row) => row.effectiveStatus === 'needs-review').length;
+                showToast(`Loaded ${clssImportPreviewRows.length} spreadsheet row${clssImportPreviewRows.length === 1 ? '' : 's'} (${readyCount} ready${needsReviewCount ? `, ${needsReviewCount} needs review` : ''})`);
+                return;
+            }
 
             if (!hasAnyText && pngCount > 0) {
                 const ocrResult = await populateClssImportTextFromPngs();
@@ -12948,6 +13123,7 @@
             renderConflictSolver(initialQuarter);
             renderRecommendations(initialQuarter);
             updateStats(initialQuarter);
+            await resumePendingOnboardingImport();
         }
 
         // Bridge module-scoped state/functions for legacy inline handlers and
@@ -12976,6 +13152,7 @@
             openClssImportModal,
             closeClssImportModal,
             handleClssImportPngSelection,
+            handleClssImportSpreadsheetSelection,
             invalidateClssImportPreview,
             invalidateClssImportPriorYearPlacementCache,
             refreshClssImportPreviewReview,
@@ -13224,6 +13401,11 @@
                                 <label for="clssImportPngInput">Upload CLSS screenshots (PNG, optional, multiple)</label>
                                 <input type="file" id="clssImportPngInput" accept=".png,image/png" multiple onchange="handleClssImportPngSelection()">
                                 <div class="clss-import-file-list" id="clssImportPngSummary">No screenshots selected.</div>
+                            </div>
+                            <div class="clss-import-field">
+                                <label for="clssImportSpreadsheetInput">Upload EagleNET spreadsheet (.csv, .xlsx, .xls)</label>
+                                <input type="file" id="clssImportSpreadsheetInput" accept=".csv,.xlsx,.xls" onchange="handleClssImportSpreadsheetSelection(event)">
+                                <div class="clss-import-file-list" id="clssImportSpreadsheetSummary">No spreadsheet selected.</div>
                             </div>
                             <div class="clss-import-field" id="clssImportSingleTextField">
                                 <label for="clssImportText">Paste copied CLSS text (optional)</label>

--- a/js/eaglenet-import.js
+++ b/js/eaglenet-import.js
@@ -1,0 +1,756 @@
+(function programCommandImportModule(globalScope) {
+    'use strict';
+
+    const PENDING_ONBOARDING_IMPORT_STORAGE_KEY = 'programCommandOnboardingImportV1';
+    const EXCELJS_CDN_URL = 'https://cdn.jsdelivr.net/npm/exceljs@4.4.0/dist/exceljs.min.js';
+    const ENROLLMENT_FIELD_ALIASES = [
+        'enrollment',
+        'enrolled',
+        'registered',
+        'registeredCount',
+        'studentCount',
+        'actualEnrollment',
+        'enrollmentActual',
+        'currentEnrollment',
+        'censusEnrollment',
+        'headcount'
+    ];
+
+    let excelJsLoadPromise = null;
+
+    function getCompareApi() {
+        if (globalScope.EagleNetCompare) {
+            return globalScope.EagleNetCompare;
+        }
+        if (typeof require === 'function') {
+            try {
+                return require('./eaglenet-compare.js');
+            } catch (error) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    function safeLocalStorage() {
+        try {
+            return globalScope.localStorage || null;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function readJsonStorage(key) {
+        const storage = safeLocalStorage();
+        if (!storage) return null;
+        try {
+            const raw = storage.getItem(key);
+            return raw ? JSON.parse(raw) : null;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function writeJsonStorage(key, value) {
+        const storage = safeLocalStorage();
+        if (!storage) return;
+        try {
+            storage.setItem(key, JSON.stringify(value));
+        } catch (error) {
+            // Ignore storage failures.
+        }
+    }
+
+    function clearStorageKey(key) {
+        const storage = safeLocalStorage();
+        if (!storage) return;
+        try {
+            storage.removeItem(key);
+        } catch (error) {
+            // Ignore storage failures.
+        }
+    }
+
+    function normalizeHeaderKey(value) {
+        const raw = String(value || '')
+            .replace(/^\uFEFF/, '')
+            .trim();
+        if (!raw) return '';
+
+        const cleaned = raw
+            .replace(/[_-]+/g, ' ')
+            .replace(/[^A-Za-z0-9 ]+/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim()
+            .toLowerCase();
+        if (!cleaned) return '';
+
+        const parts = cleaned.split(' ');
+        return parts[0] + parts.slice(1).map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join('');
+    }
+
+    function parseCsvRows(text) {
+        const input = String(text || '').replace(/\r\n?/g, '\n');
+        const records = [];
+        let row = [];
+        let cell = '';
+        let inQuotes = false;
+
+        for (let index = 0; index < input.length; index += 1) {
+            const char = input[index];
+            const next = input[index + 1];
+
+            if (char === '"') {
+                if (inQuotes && next === '"') {
+                    cell += '"';
+                    index += 1;
+                } else {
+                    inQuotes = !inQuotes;
+                }
+                continue;
+            }
+
+            if (char === ',' && !inQuotes) {
+                row.push(cell);
+                cell = '';
+                continue;
+            }
+
+            if (char === '\n' && !inQuotes) {
+                row.push(cell);
+                records.push(row);
+                row = [];
+                cell = '';
+                continue;
+            }
+
+            cell += char;
+        }
+
+        if (cell !== '' || row.length > 0) {
+            row.push(cell);
+            records.push(row);
+        }
+
+        if (!records.length) return [];
+
+        const headers = records[0].map((value) => normalizeHeaderKey(value));
+        return records.slice(1)
+            .filter((values) => values.some((value) => String(value || '').trim() !== ''))
+            .map((values) => {
+                const rowObject = {};
+                headers.forEach((header, index) => {
+                    if (!header) return;
+                    rowObject[header] = String(values[index] == null ? '' : values[index]).trim();
+                });
+                return rowObject;
+            });
+    }
+
+    function dedupe(values) {
+        return [...new Set((Array.isArray(values) ? values : []).filter(Boolean))];
+    }
+
+    function buildRecognizedHeaderKeySet(compareApi) {
+        const aliases = compareApi?.DEFAULT_FIELD_ALIASES || {};
+        const keys = new Set();
+        Object.values(aliases).forEach((list) => {
+            (Array.isArray(list) ? list : []).forEach((value) => {
+                const normalized = normalizeHeaderKey(value);
+                if (normalized) keys.add(normalized);
+            });
+        });
+        ENROLLMENT_FIELD_ALIASES.forEach((value) => {
+            const normalized = normalizeHeaderKey(value);
+            if (normalized) keys.add(normalized);
+        });
+        return keys;
+    }
+
+    function normalizeWorksheetCellValue(cell) {
+        if (!cell) return '';
+
+        const value = cell.value;
+        if (value == null) return '';
+        if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+            return String(value).trim();
+        }
+        if (value instanceof Date) {
+            return value.toISOString();
+        }
+        if (typeof value === 'object') {
+            if (Array.isArray(value.richText)) {
+                return value.richText.map((entry) => String(entry?.text || '')).join('').trim();
+            }
+            if (typeof value.text === 'string' && value.text.trim()) {
+                return value.text.trim();
+            }
+            if (typeof value.result !== 'undefined' && value.result != null) {
+                return String(value.result).trim();
+            }
+            if (typeof value.formula === 'string' && typeof cell.text === 'string' && cell.text.trim()) {
+                return cell.text.trim();
+            }
+        }
+        if (typeof cell.text === 'string' && cell.text.trim()) {
+            return cell.text.trim();
+        }
+        return String(value).trim();
+    }
+
+    function selectWorksheetHeaderRow(matrix, recognizedHeaders) {
+        let firstNonEmpty = null;
+
+        for (let index = 0; index < matrix.length; index += 1) {
+            const row = matrix[index];
+            const values = row.values.filter(Boolean);
+            if (!values.length) continue;
+            if (firstNonEmpty == null) {
+                firstNonEmpty = index;
+            }
+
+            const normalized = values.map((value) => normalizeHeaderKey(value)).filter(Boolean);
+            const recognizedCount = normalized.filter((value) => recognizedHeaders.has(value)).length;
+            if (recognizedCount >= 2) {
+                return index;
+            }
+        }
+
+        return firstNonEmpty;
+    }
+
+    async function ensureExcelJsLoaded(options = {}) {
+        if (options.ExcelJS) {
+            return options.ExcelJS;
+        }
+        if (globalScope.ExcelJS) {
+            return globalScope.ExcelJS;
+        }
+        if (!globalScope.document) {
+            throw new Error('ExcelJS is required to parse .xlsx files in this environment.');
+        }
+
+        if (!excelJsLoadPromise) {
+            excelJsLoadPromise = new Promise((resolve, reject) => {
+                const existing = globalScope.document.querySelector('script[data-program-command-exceljs="import"]');
+                if (existing) {
+                    existing.addEventListener('load', () => resolve(globalScope.ExcelJS), { once: true });
+                    existing.addEventListener('error', () => reject(new Error('Failed to load ExcelJS library.')), { once: true });
+                    return;
+                }
+
+                const script = globalScope.document.createElement('script');
+                script.src = EXCELJS_CDN_URL;
+                script.async = true;
+                script.dataset.programCommandExceljs = 'import';
+                script.onload = () => {
+                    if (globalScope.ExcelJS) {
+                        resolve(globalScope.ExcelJS);
+                        return;
+                    }
+                    reject(new Error('ExcelJS loaded without a global runtime.'));
+                };
+                script.onerror = () => reject(new Error('Failed to load ExcelJS library from CDN.'));
+                globalScope.document.head.appendChild(script);
+            }).catch((error) => {
+                excelJsLoadPromise = null;
+                throw error;
+            });
+        }
+
+        return excelJsLoadPromise;
+    }
+
+    function extractWorkbookRows(workbook, options = {}) {
+        const compareApi = getCompareApi();
+        const recognizedHeaders = buildRecognizedHeaderKeySet(compareApi);
+        const rows = [];
+        const warnings = [];
+        const sheetSummaries = [];
+
+        (Array.isArray(workbook?.worksheets) ? workbook.worksheets : []).forEach((worksheet) => {
+            const matrix = [];
+            worksheet.eachRow({ includeEmpty: false }, (row) => {
+                const values = [];
+                row.eachCell({ includeEmpty: true }, (cell, colNumber) => {
+                    values[colNumber - 1] = normalizeWorksheetCellValue(cell);
+                });
+                matrix.push({
+                    rowNumber: row.number,
+                    values
+                });
+            });
+
+            const headerIndex = selectWorksheetHeaderRow(matrix, recognizedHeaders);
+            if (headerIndex == null) {
+                return;
+            }
+
+            const headerRow = matrix[headerIndex];
+            const headers = headerRow.values.map((value) => normalizeHeaderKey(value));
+            const recognizedCount = headers.filter((value) => recognizedHeaders.has(value)).length;
+            if (recognizedCount < 2) {
+                warnings.push(`${worksheet.name}: skipped worksheet without recognizable EagleNET headers.`);
+                return;
+            }
+
+            let sheetRowCount = 0;
+            matrix.slice(headerIndex + 1).forEach((entry) => {
+                const hasContent = entry.values.some((value) => String(value || '').trim() !== '');
+                if (!hasContent) return;
+
+                const rowObject = {};
+                headers.forEach((header, index) => {
+                    if (!header) return;
+                    const value = entry.values[index];
+                    rowObject[header] = String(value == null ? '' : value).trim();
+                });
+                rowObject.__sheetName = worksheet.name;
+                rowObject.__rowNumber = entry.rowNumber;
+                rows.push(rowObject);
+                sheetRowCount += 1;
+            });
+
+            sheetSummaries.push({
+                sheetName: worksheet.name,
+                rowCount: sheetRowCount
+            });
+        });
+
+        if (!rows.length && !warnings.length) {
+            warnings.push('No spreadsheet rows matched the EagleNET header pattern.');
+        }
+
+        return {
+            rows,
+            meta: {
+                format: String(options.format || 'xlsx'),
+                sheetSummaries,
+                warnings
+            }
+        };
+    }
+
+    async function readTabularRowsFromFile(file, options = {}) {
+        if (!file) {
+            throw new Error('Choose a spreadsheet file first.');
+        }
+
+        const name = String(file.name || '').trim() || 'import';
+        const extension = name.includes('.') ? name.split('.').pop().toLowerCase() : '';
+        const format = extension || (String(file.type || '').toLowerCase().includes('csv') ? 'csv' : 'xlsx');
+
+        if (format === 'csv' || format === 'tsv' || String(file.type || '').toLowerCase().includes('csv')) {
+            const text = typeof file.text === 'function'
+                ? await file.text()
+                : '';
+            const rows = parseCsvRows(text);
+            return {
+                rows,
+                meta: {
+                    format: 'csv',
+                    fileName: name,
+                    rowCount: rows.length,
+                    sheetSummaries: [],
+                    warnings: rows.length ? [] : ['CSV file did not contain any data rows.']
+                }
+            };
+        }
+
+        if (format === 'xls') {
+            throw new Error('Legacy .xls files are not supported in this MVP yet. Save the export as .xlsx or .csv and try again.');
+        }
+
+        const ExcelJS = await ensureExcelJsLoaded(options);
+        const workbook = new ExcelJS.Workbook();
+        const buffer = typeof file.arrayBuffer === 'function'
+            ? await file.arrayBuffer()
+            : null;
+        if (!buffer) {
+            throw new Error('Could not read spreadsheet data from the selected file.');
+        }
+
+        await workbook.xlsx.load(buffer.slice(0));
+        const extracted = extractWorkbookRows(workbook, { format: 'xlsx' });
+        return {
+            rows: extracted.rows,
+            meta: {
+                ...extracted.meta,
+                fileName: name,
+                rowCount: extracted.rows.length
+            }
+        };
+    }
+
+    function normalizeLookupKey(value) {
+        return String(value || '')
+            .trim()
+            .toUpperCase()
+            .replace(/[^A-Z0-9]/g, '');
+    }
+
+    function inferQuarterKey(...values) {
+        const compareApi = getCompareApi();
+        for (const value of values) {
+            const normalized = compareApi?.normalizeQuarter
+                ? compareApi.normalizeQuarter(value)
+                : String(value || '').trim();
+            const lookup = String(normalized || '').trim().toLowerCase();
+            if (lookup === 'fall') return 'fall';
+            if (lookup === 'winter') return 'winter';
+            if (lookup === 'spring') return 'spring';
+            if (lookup === 'summer') return 'summer';
+        }
+        return '';
+    }
+
+    function pickFirstPresentValue(row, keys) {
+        const source = row && typeof row === 'object' ? row : {};
+        for (const key of Array.isArray(keys) ? keys : []) {
+            if (Object.prototype.hasOwnProperty.call(source, key) && source[key] != null && String(source[key]).trim() !== '') {
+                return source[key];
+            }
+        }
+        return '';
+    }
+
+    function resolveDayPattern(days, dayPatterns) {
+        const lookup = normalizeLookupKey(days);
+        if (!lookup) {
+            return { dayPattern: '', singleDay: false, note: 'Meeting pattern not found' };
+        }
+
+        const patterns = Array.isArray(dayPatterns) ? dayPatterns : [];
+        const matched = patterns.find((pattern) => {
+            const aliases = [pattern?.id, ...(Array.isArray(pattern?.aliases) ? pattern.aliases : [])];
+            return aliases.some((alias) => normalizeLookupKey(alias) === lookup);
+        });
+        if (matched?.id) {
+            return { dayPattern: String(matched.id).trim(), singleDay: false, note: '' };
+        }
+
+        if (lookup.length === 1 && 'MTWRFSU'.includes(lookup)) {
+            return { dayPattern: '', singleDay: true, note: `Single-day pattern (${lookup})` };
+        }
+
+        return { dayPattern: '', singleDay: false, note: `Unsupported day pattern (${days})` };
+    }
+
+    function parseClockToMinutes(value) {
+        const compareApi = getCompareApi();
+        const normalized = compareApi?.normalizeTimeRange
+            ? compareApi.normalizeTimeRange('', '', value)
+            : String(value || '').trim();
+
+        const rangeMatch = String(normalized || '').match(/^(\d{2}:\d{2})-(\d{2}:\d{2})$/);
+        if (rangeMatch) {
+            return {
+                startMinutes: parseClockTokenToMinutes(rangeMatch[1]),
+                endMinutes: parseClockTokenToMinutes(rangeMatch[2])
+            };
+        }
+
+        return {
+            startMinutes: parseClockTokenToMinutes(value),
+            endMinutes: null
+        };
+    }
+
+    function parseClockTokenToMinutes(value) {
+        const raw = String(value || '').trim();
+        if (!raw) return null;
+        const match = raw.match(/^(\d{1,2}):(\d{2})$/);
+        if (!match) return null;
+        const hours = Number(match[1]);
+        const minutes = Number(match[2]);
+        if (!Number.isFinite(hours) || !Number.isFinite(minutes) || hours < 0 || hours > 23 || minutes < 0 || minutes > 59) {
+            return null;
+        }
+        return (hours * 60) + minutes;
+    }
+
+    function resolveTimeSlot(timeRange, timeSlots) {
+        const raw = String(timeRange || '').trim();
+        if (!raw) {
+            return { timeSlot: '', note: 'Meeting time not found' };
+        }
+
+        const slots = Array.isArray(timeSlots) ? timeSlots : [];
+        const lookup = normalizeLookupKey(raw);
+        const aliasMatch = slots.find((slot) => {
+            const aliases = [slot?.id, ...(Array.isArray(slot?.aliases) ? slot.aliases : [])];
+            return aliases.some((alias) => normalizeLookupKey(alias) === lookup);
+        });
+        if (aliasMatch?.id) {
+            return { timeSlot: String(aliasMatch.id).trim(), note: '' };
+        }
+
+        const range = parseClockToMinutes(raw);
+        const exact = slots.find((slot) =>
+            Number.isFinite(slot?.startMinutes)
+            && Number.isFinite(slot?.endMinutes)
+            && slot.startMinutes === range.startMinutes
+            && slot.endMinutes === range.endMinutes
+        );
+        if (exact?.id) {
+            return { timeSlot: String(exact.id).trim(), note: '' };
+        }
+
+        const startMatch = slots.find((slot) =>
+            Number.isFinite(slot?.startMinutes)
+            && slot.startMinutes === range.startMinutes
+        );
+        if (startMatch?.id) {
+            return { timeSlot: String(startMatch.id).trim(), note: '' };
+        }
+
+        return { timeSlot: '', note: `Unsupported time (${raw})` };
+    }
+
+    function resolveRoom(roomValue, roomOptions) {
+        const source = String(roomValue || '').trim();
+        if (!source) {
+            return { raw: '', mappedRoom: '', note: '' };
+        }
+
+        const rooms = dedupe(roomOptions);
+        const lookup = normalizeLookupKey(source);
+        const matched = rooms.find((room) => {
+            const normalizedRoom = normalizeLookupKey(room);
+            return normalizedRoom && (normalizedRoom === lookup || lookup.includes(normalizedRoom));
+        });
+
+        return {
+            raw: source,
+            mappedRoom: matched || '',
+            note: matched ? '' : 'Room not detected; import will auto-assign an open room'
+        };
+    }
+
+    function buildRawRowSummary(rawRow) {
+        const entries = Object.entries(rawRow || {})
+            .filter(([key, value]) => !String(key || '').startsWith('__') && String(value || '').trim() !== '')
+            .slice(0, 12)
+            .map(([key, value]) => `${key}: ${value}`);
+        return entries.join(' | ');
+    }
+
+    function buildMeetingLabel(normalized, rawRow) {
+        const pieces = [];
+        if (normalized.days) pieces.push(normalized.days);
+        if (normalized.timeRange) pieces.push(normalized.timeRange);
+        if (pieces.length) return pieces.join(' ');
+
+        const rawMeeting = pickFirstPresentValue(rawRow, ['meetingTime', 'meetingPattern', 'time']);
+        return String(rawMeeting || '').trim() || '—';
+    }
+
+    function buildClssPreviewRowsFromTabularRows(rows, options = {}) {
+        const compareApi = getCompareApi();
+        if (!compareApi || typeof compareApi.createNormalizedScheduleRecord !== 'function') {
+            throw new Error('EagleNet compare helpers are unavailable.');
+        }
+
+        const dayPatterns = Array.isArray(options.dayPatterns) ? options.dayPatterns : [];
+        const timeSlots = Array.isArray(options.timeSlots) ? options.timeSlots : [];
+        const roomOptions = Array.isArray(options.roomOptions) ? options.roomOptions : [];
+        const resolveCourseCode = typeof options.resolveCourseCode === 'function'
+            ? options.resolveCourseCode
+            : (value) => String(value || '').trim();
+        const resolveFacultyName = typeof options.resolveFacultyName === 'function'
+            ? options.resolveFacultyName
+            : (value) => String(value || '').trim() || 'TBD';
+        const defaultQuarter = inferQuarterKey(options.defaultQuarter) || 'spring';
+
+        const warnings = [];
+        const quarterCounts = {
+            fall: 0,
+            winter: 0,
+            spring: 0,
+            summer: 0
+        };
+
+        const previewRows = (Array.isArray(rows) ? rows : []).map((rawRow, index) => {
+            const record = compareApi.createNormalizedScheduleRecord(rawRow, index, { source: 'spreadsheet' });
+            const normalized = record.normalized || {};
+            const notes = [];
+
+            const inferredQuarter = inferQuarterKey(
+                normalized.quarter,
+                rawRow?.quarter,
+                rawRow?.term,
+                rawRow?.session,
+                rawRow?.__sheetName
+            ) || defaultQuarter;
+            quarterCounts[inferredQuarter] = (quarterCounts[inferredQuarter] || 0) + 1;
+
+            if (!inferQuarterKey(normalized.quarter, rawRow?.quarter, rawRow?.term, rawRow?.session, rawRow?.__sheetName)) {
+                notes.push(`Quarter not detected; defaulted to ${inferredQuarter}`);
+            }
+
+            const sourceText = buildRawRowSummary(rawRow);
+            const courseCode = resolveCourseCode(normalized.courseCode || '');
+            const title = String(normalized.title || pickFirstPresentValue(rawRow, ['title', 'courseTitle', 'classTitle']) || '').trim();
+            const section = String(normalized.section || '').trim();
+            const credits = Number.isFinite(normalized.credits) ? normalized.credits : 5;
+            const instructor = resolveFacultyName(normalized.instructor || 'TBD');
+            const meetingLabel = buildMeetingLabel(normalized, rawRow);
+            const roomValue = String(normalized.room || pickFirstPresentValue(rawRow, ['room', 'location', 'buildingRoom']) || '').trim();
+            const roomInfo = resolveRoom(roomValue, roomOptions);
+            if (roomInfo.note) {
+                notes.push(roomInfo.note);
+            }
+
+            const dayInfo = resolveDayPattern(normalized.days, dayPatterns);
+            if (dayInfo.note) {
+                notes.push(dayInfo.note);
+            }
+
+            const timeInfo = resolveTimeSlot(normalized.timeRange, timeSlots);
+            if (timeInfo.note) {
+                notes.push(timeInfo.note);
+            }
+
+            const enrollmentRaw = pickFirstPresentValue(rawRow, ENROLLMENT_FIELD_ALIASES);
+            const enrollment = enrollmentRaw === '' ? null : Number(enrollmentRaw);
+            if (Number.isFinite(enrollment)) {
+                notes.push(`Enrollment ${enrollment}`);
+            }
+
+            const keywordSource = [
+                normalized.modality,
+                normalized.room,
+                normalized.timeRange,
+                rawRow?.meetingTime,
+                rawRow?.meetingPattern,
+                rawRow?.comments,
+                rawRow?.instructionMode
+            ].map((value) => String(value || '')).join(' ');
+
+            const onlineHint = normalized.modalityKey === 'online'
+                || /\bonline|web|async|asynch|asynchronous\b/i.test(keywordSource);
+            const arrangedHint = /\barranged|does not meet|independent\b/i.test(keywordSource);
+
+            let status = 'needs-review';
+            let schedulerDay = '';
+            let schedulerTime = '';
+            let schedulerRoom = '';
+            let schedulerSlotLabel = '';
+            let requiresAutoRoomAssignment = false;
+
+            if (onlineHint && !normalized.days) {
+                status = 'online';
+                schedulerRoom = 'ONLINE';
+                schedulerSlotLabel = 'ONLINE / async';
+            } else if (arrangedHint && !normalized.days) {
+                status = 'arranged';
+                schedulerRoom = 'ARRANGED';
+                schedulerSlotLabel = 'ARRANGED';
+            } else if (dayInfo.dayPattern) {
+                schedulerDay = dayInfo.dayPattern;
+                schedulerTime = timeInfo.timeSlot || '';
+                if (roomInfo.mappedRoom) {
+                    schedulerRoom = roomInfo.mappedRoom;
+                } else {
+                    requiresAutoRoomAssignment = true;
+                }
+
+                if (schedulerDay && schedulerTime) {
+                    status = 'ready';
+                    schedulerSlotLabel = `${schedulerDay} ${schedulerTime} • ${schedulerRoom || 'Auto room'}`;
+                }
+            }
+
+            if (dayInfo.singleDay) {
+                status = 'needs-review';
+                schedulerDay = '';
+                schedulerTime = '';
+                schedulerRoom = '';
+                schedulerSlotLabel = '';
+            }
+
+            if (!courseCode || !title) {
+                status = 'error';
+                if (!courseCode) notes.push('Course code missing');
+                if (!title) notes.push('Course title missing');
+            }
+
+            if (String(rawRow?.__sheetName || '').trim()) {
+                notes.push(`Sheet: ${String(rawRow.__sheetName).trim()}`);
+            }
+
+            return {
+                status,
+                code: courseCode,
+                title,
+                section,
+                credits,
+                instructor,
+                meetingLabel,
+                roomLabel: roomInfo.raw || roomValue || '—',
+                schedulerDay,
+                schedulerTime,
+                schedulerRoom,
+                requiresAutoRoomAssignment,
+                schedulerSlotLabel,
+                targetQuarter: inferredQuarter,
+                reviewQuarter: inferredQuarter,
+                reviewPlacement: '',
+                reviewDay: schedulerDay || '',
+                reviewTime: schedulerTime || '',
+                reviewRoom: status === 'online' || status === 'arranged'
+                    ? ''
+                    : (schedulerRoom || (requiresAutoRoomAssignment ? 'AUTO' : '')),
+                notes: dedupe(notes),
+                rawText: sourceText || `Spreadsheet row ${index + 1}`,
+                enrollment: Number.isFinite(enrollment) ? enrollment : null,
+                sourceSheet: String(rawRow?.__sheetName || '').trim() || null
+            };
+        });
+
+        if (!previewRows.length) {
+            warnings.push('No importable rows were found in the spreadsheet.');
+        }
+
+        return {
+            rows: previewRows,
+            meta: {
+                source: 'spreadsheet',
+                fileName: String(options.fileName || '').trim() || null,
+                rowCount: previewRows.length,
+                quarterCounts,
+                warnings
+            }
+        };
+    }
+
+    function writePendingOnboardingImport(payload) {
+        writeJsonStorage(PENDING_ONBOARDING_IMPORT_STORAGE_KEY, payload);
+    }
+
+    function readPendingOnboardingImport() {
+        return readJsonStorage(PENDING_ONBOARDING_IMPORT_STORAGE_KEY);
+    }
+
+    function clearPendingOnboardingImport() {
+        clearStorageKey(PENDING_ONBOARDING_IMPORT_STORAGE_KEY);
+    }
+
+    const api = {
+        PENDING_ONBOARDING_IMPORT_STORAGE_KEY,
+        normalizeHeaderKey,
+        parseCsvRows,
+        ensureExcelJsLoaded,
+        readTabularRowsFromFile,
+        buildClssPreviewRowsFromTabularRows,
+        writePendingOnboardingImport,
+        readPendingOnboardingImport,
+        clearPendingOnboardingImport
+    };
+
+    globalScope.ProgramCommandImport = api;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : null));

--- a/js/program-shell.js
+++ b/js/program-shell.js
@@ -427,6 +427,9 @@
         const artifactBatch = options.artifactBatch && typeof options.artifactBatch === 'object'
             ? buildScreenshotArtifactBatch(options.artifactBatch.files || [], options.artifactBatch)
             : null;
+        const spreadsheetImport = options.spreadsheetImport && typeof options.spreadsheetImport === 'object'
+            ? JSON.parse(JSON.stringify(options.spreadsheetImport))
+            : null;
 
         return {
             ...(selection || {}),
@@ -434,6 +437,7 @@
             suggestedIdentity: buildSuggestedIdentity(program),
             artifact,
             artifactBatch,
+            spreadsheetImport,
             createdAt: new Date().toISOString()
         };
     }
@@ -652,6 +656,11 @@
         const manager = options.profileManager || global.DepartmentProfileManager || null;
         const onboardingUrl = String(options.onboardingUrl || 'pages/department-onboarding.html').trim() || 'pages/department-onboarding.html';
         const groups = Array.isArray(options.programGroups) ? options.programGroups : DEFAULT_PROGRAM_GROUPS;
+        const importApi = global.ProgramCommandImport || null;
+        const pendingOnboardingImport = importApi && typeof importApi.readPendingOnboardingImport === 'function'
+            ? importApi.readPendingOnboardingImport()
+            : null;
+        const pendingProgram = findProgramById(pendingOnboardingImport?.programId, groups);
 
         const elements = {
             overlay,
@@ -680,13 +689,21 @@
         };
 
         const state = {
-            selectedProgram: resolveStoredSelection(groups),
+            selectedProgram: pendingProgram || resolveStoredSelection(groups),
             session: null,
             previewMode: false,
             chooserVisible: false,
             runtimeLaunched: false,
+            pendingOnboardingImport,
             directoryUploadSupported: Boolean(elements.screenshotDirectoryInput && ('webkitdirectory' in elements.screenshotDirectoryInput))
         };
+
+        if (pendingProgram && pendingOnboardingImport?.profileId) {
+            persistSelection(createProgramSelection({
+                ...pendingProgram,
+                profileId: String(pendingOnboardingImport.profileId || '').trim() || null
+            }));
+        }
 
         function authSatisfied() {
             return Boolean(state.session || state.previewMode);
@@ -984,10 +1001,38 @@
 
             state.chooserVisible = true;
             if (elements.chooserMeta) {
-                elements.chooserMeta.textContent = `${formatProgramLabel(state.selectedProgram)} does not have seeded data yet. Start with manual setup or capture the import artifacts for the follow-on import slice.`;
+                elements.chooserMeta.textContent = `${formatProgramLabel(state.selectedProgram)} does not have seeded data yet. Start with manual setup or capture the import artifacts to continue into onboarding and CLSS review.`;
             }
             setStatus('info', `${formatProgramLabel(state.selectedProgram)} is empty. Choose how you want to start onboarding.`);
             updateUi();
+        }
+
+        async function maybeResumePendingOnboardingImport() {
+            if (!state.pendingOnboardingImport || state.runtimeLaunched) {
+                return false;
+            }
+
+            const resumedProgram = findProgramById(state.pendingOnboardingImport.programId, groups);
+            if (!resumedProgram) {
+                return false;
+            }
+
+            persistSelectedProgram(resumedProgram, {
+                profileId: String(state.pendingOnboardingImport.profileId || resumedProgram.profileId || '').trim() || null
+            });
+
+            if (!authSatisfied()) {
+                if (isLocalPreviewHost()) {
+                    activatePreviewMode();
+                } else {
+                    setStatus('info', `${formatProgramLabel(resumedProgram)} is ready. Sign in to resume the pending import handoff.`);
+                    return false;
+                }
+            }
+
+            setStatus('info', `Resuming ${formatProgramLabel(resumedProgram)} import handoff...`);
+            await handleContinue();
+            return true;
         }
 
         function navigateToOnboarding(source, intake = {}) {
@@ -1007,7 +1052,8 @@
             const context = createOnboardingContext(state.selectedProgram, {
                 source,
                 artifact: intake.artifact || null,
-                artifactBatch: intake.artifactBatch || null
+                artifactBatch: intake.artifactBatch || null,
+                spreadsheetImport: intake.spreadsheetImport || null
             });
             persistOnboardingContext(context);
             global.location.href = `${onboardingUrl}?source=${encodeURIComponent(source)}&program=${encodeURIComponent(context.id || '')}`;
@@ -1071,14 +1117,42 @@
         elements.spreadsheetInput?.addEventListener('change', (event) => {
             const file = event.target?.files?.[0];
             if (!file) return;
-            navigateToOnboarding('spreadsheet', {
-                artifact: {
-                    name: file.name,
-                    size: file.size,
-                    type: file.type,
-                    capturedAt: new Date().toISOString()
-                }
-            });
+            const artifact = {
+                name: file.name,
+                size: file.size,
+                type: file.type,
+                capturedAt: new Date().toISOString()
+            };
+
+            const importApi = global.ProgramCommandImport;
+            if (!importApi || typeof importApi.readTabularRowsFromFile !== 'function') {
+                setStatus('error', 'Spreadsheet import runtime is unavailable on this page.');
+                event.target.value = '';
+                return;
+            }
+
+            setStatus('info', `Parsing ${file.name} before onboarding...`);
+            importApi.readTabularRowsFromFile(file)
+                .then((spreadsheetImport) => {
+                    if (!spreadsheetImport?.rows?.length) {
+                        const warning = Array.isArray(spreadsheetImport?.meta?.warnings) && spreadsheetImport.meta.warnings.length
+                            ? spreadsheetImport.meta.warnings[0]
+                            : 'Spreadsheet did not contain any importable rows.';
+                        setStatus('error', warning);
+                        return;
+                    }
+
+                    navigateToOnboarding('spreadsheet', {
+                        artifact,
+                        spreadsheetImport
+                    });
+                })
+                .catch((error) => {
+                    setStatus('error', error?.message || 'Could not parse the selected spreadsheet.');
+                })
+                .finally(() => {
+                    event.target.value = '';
+                });
         });
         elements.screenshotDirectoryInput?.addEventListener('change', (event) => {
             const files = Array.from(event.target?.files || []);
@@ -1106,7 +1180,7 @@
             ? `${formatProgramLabel(state.selectedProgram)} selected. Authenticate to continue.`
             : 'Welcome to Program Command. Choose a program to begin.');
 
-        return refreshSessionFromAuth();
+        return refreshSessionFromAuth().then(() => maybeResumePendingOnboardingImport());
     }
 
     const api = {

--- a/pages/department-onboarding.html
+++ b/pages/department-onboarding.html
@@ -291,6 +291,8 @@
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="../js/supabase-config.js"></script>
     <script src="../js/auth-service.js"></script>
+    <script src="../js/eaglenet-compare.js"></script>
+    <script src="../js/eaglenet-import.js"></script>
     <script src="../js/program-shell.js"></script>
     <script src="../js/auth-guard.js"></script>
     <script src="department-onboarding.js"></script>

--- a/pages/department-onboarding.js
+++ b/pages/department-onboarding.js
@@ -109,6 +109,13 @@
         const artifactBatch = context.artifactBatch && typeof context.artifactBatch === 'object'
             ? context.artifactBatch
             : null;
+        const spreadsheetImport = context.spreadsheetImport && typeof context.spreadsheetImport === 'object'
+            ? context.spreadsheetImport
+            : null;
+        const spreadsheetRowCount = Number(spreadsheetImport?.meta?.rowCount) || Number(Array.isArray(spreadsheetImport?.rows) ? spreadsheetImport.rows.length : 0) || 0;
+        const spreadsheetQuarterCounts = spreadsheetImport?.meta?.quarterCounts && typeof spreadsheetImport.meta.quarterCounts === 'object'
+            ? spreadsheetImport.meta.quarterCounts
+            : null;
         const sourceLabel = source === 'spreadsheet'
             ? 'Spreadsheet handoff'
             : source === 'screenshot'
@@ -133,7 +140,20 @@
             }
         }
         if (artifact) {
-            if (source === 'screenshot' && artifactBatch?.count) {
+            if (source === 'spreadsheet' && spreadsheetRowCount) {
+                const quarterSummary = spreadsheetQuarterCounts
+                    ? Object.entries(spreadsheetQuarterCounts)
+                        .filter(([, count]) => Number(count) > 0)
+                        .map(([quarter, count]) => `${quarter.charAt(0).toUpperCase() + quarter.slice(1)} ${count}`)
+                        .join(', ')
+                    : '';
+                const intro = artifactName
+                    ? `Captured spreadsheet: ${artifactName}. Parsed ${spreadsheetRowCount} import row${spreadsheetRowCount === 1 ? '' : 's'}.`
+                    : `Parsed ${spreadsheetRowCount} import row${spreadsheetRowCount === 1 ? '' : 's'} from the spreadsheet handoff.`;
+                artifact.textContent = quarterSummary
+                    ? `${intro} Quarter detection: ${quarterSummary}.`
+                    : `${intro} Quarter detection will stay editable during CLSS review after activation.`;
+            } else if (source === 'screenshot' && artifactBatch?.count) {
                 const rootFolderName = String(artifactBatch.rootFolderName || '').trim();
                 const groupedCount = Array.isArray(artifactBatch.groups)
                     ? artifactBatch.groups.filter((group) => String(group.key || '') !== 'unassigned').length
@@ -207,7 +227,8 @@
         const label = String(context.label || 'selected program').trim() || 'selected program';
         const source = String(context.source || 'manual').trim() || 'manual';
         if (source === 'spreadsheet') {
-            setStatus('info', `Spreadsheet handoff ready for ${label}. Finish the profile setup here before the import mapping slice lands.`);
+            const parsedRows = Number(context.spreadsheetImport?.meta?.rowCount) || Number(Array.isArray(context.spreadsheetImport?.rows) ? context.spreadsheetImport.rows.length : 0) || 0;
+            setStatus('info', `Spreadsheet handoff ready for ${label}${parsedRows ? ` with ${parsedRows} parsed row${parsedRows === 1 ? '' : 's'}` : ''}. Save + activate this profile to continue into CLSS review.`);
         } else if (source === 'screenshot') {
             const screenshotCount = Number(context.artifactBatch?.count) || 0;
             const groupedCount = Array.isArray(context.artifactBatch?.groups)
@@ -610,11 +631,66 @@
                     activate: true
                 });
 
+                const handoffContext = state.handoffContext && typeof state.handoffContext === 'object'
+                    ? state.handoffContext
+                    : null;
+                const importApi = window.ProgramCommandImport;
+                const shellApi = window.ProgramCommandShell;
+                const shouldResumeSpreadsheetImport = Boolean(
+                    handoffContext
+                    && handoffContext.source === 'spreadsheet'
+                    && Array.isArray(handoffContext.spreadsheetImport?.rows)
+                    && handoffContext.spreadsheetImport.rows.length
+                    && importApi
+                    && typeof importApi.writePendingOnboardingImport === 'function'
+                );
+
+                if (shellApi && typeof shellApi.persistSelection === 'function') {
+                    const nextSelection = shellApi.readSelection && typeof shellApi.readSelection === 'function'
+                        ? shellApi.readSelection()
+                        : {};
+                    shellApi.persistSelection({
+                        ...nextSelection,
+                        id: String(handoffContext?.id || nextSelection?.id || '').trim() || nextSelection?.id || null,
+                        label: String(handoffContext?.label || nextSelection?.label || '').trim() || nextSelection?.label || null,
+                        parentLabel: handoffContext?.parentLabel || nextSelection?.parentLabel || null,
+                        departmentId: handoffContext?.departmentId || nextSelection?.departmentId || null,
+                        departmentLabel: handoffContext?.departmentLabel || nextSelection?.departmentLabel || null,
+                        baseProfileId: String(handoffContext?.baseProfileId || nextSelection?.baseProfileId || saved.profileId || '').trim() || saved.profileId,
+                        profileId: saved.profileId,
+                        suggestedCode: String(handoffContext?.suggestedCode || nextSelection?.suggestedCode || result.draft.profile.identity?.code || '').trim() || null,
+                        workspaceKind: String(handoffContext?.workspaceKind || nextSelection?.workspaceKind || 'program').trim() || 'program',
+                        workspaceSummary: handoffContext?.workspaceSummary || nextSelection?.workspaceSummary || null,
+                        memberProgramIds: Array.isArray(handoffContext?.memberProgramIds)
+                            ? handoffContext.memberProgramIds
+                            : (Array.isArray(nextSelection?.memberProgramIds) ? nextSelection.memberProgramIds : []),
+                        seededDefault: false,
+                        selectedAt: new Date().toISOString()
+                    });
+                }
+
+                if (shouldResumeSpreadsheetImport) {
+                    importApi.writePendingOnboardingImport({
+                        source: 'spreadsheet',
+                        programId: String(handoffContext.id || '').trim() || null,
+                        label: String(handoffContext.label || '').trim() || null,
+                        profileId: saved.profileId,
+                        artifact: handoffContext.artifact || null,
+                        spreadsheetImport: handoffContext.spreadsheetImport,
+                        createdAt: new Date().toISOString()
+                    });
+                }
+
                 clearHandoffContext();
                 qs('activationResult').textContent = `Activated profile ${saved.profileId}.`;
                 setStatus('ok', `Profile ${saved.profileId} saved and activated.`);
                 await populateProfileSelect();
                 qs('baseProfileSelect').value = saved.profileId;
+
+                if (shouldResumeSpreadsheetImport) {
+                    setStatus('info', `Profile ${saved.profileId} activated. Opening the spreadsheet import review...`);
+                    window.location.href = '../index.html?onboardingImport=spreadsheet';
+                }
             } catch (error) {
                 setStatus('error', error?.message || 'Could not save profile.');
             } finally {

--- a/tests/eaglenet-import.test.js
+++ b/tests/eaglenet-import.test.js
@@ -1,0 +1,139 @@
+const ProgramCommandImport = require('../js/eaglenet-import.js');
+
+describe('ProgramCommandImport', () => {
+    beforeEach(() => {
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    test('parses CSV headers into normalized row objects', () => {
+        const csv = [
+            'Academic Year,Term,Subject,Catalog Number,Section,Course Title,Faculty,Meeting Days,Start Time,End Time,Location,Credits,Registered',
+            '2025-26,Fall,CSCD,101,1,Intro to CS,"Doe, Jane",TuTh,1300,1500,CEB 210,5,24'
+        ].join('\n');
+
+        const rows = ProgramCommandImport.parseCsvRows(csv);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({
+            academicYear: '2025-26',
+            term: 'Fall',
+            subject: 'CSCD',
+            catalogNumber: '101',
+            courseTitle: 'Intro to CS',
+            faculty: 'Doe, Jane',
+            meetingDays: 'TuTh',
+            startTime: '1300',
+            endTime: '1500',
+            location: 'CEB 210',
+            registered: '24'
+        });
+    });
+
+    test('builds CLSS preview rows from EagleNET-style tabular rows', () => {
+        const result = ProgramCommandImport.buildClssPreviewRowsFromTabularRows([
+            {
+                academicYear: '2025-26',
+                term: 'Fall',
+                subject: 'CSCD',
+                catalogNumber: '101',
+                section: '1',
+                courseTitle: 'Intro to CS',
+                faculty: 'Doe, Jane',
+                meetingDays: 'TuTh',
+                startTime: '1300',
+                endTime: '1500',
+                location: 'CEB 210',
+                credits: '5',
+                registered: '24',
+                __sheetName: 'Fall export'
+            }
+        ], {
+            dayPatterns: [
+                { id: 'MW', aliases: ['MW'] },
+                { id: 'TR', aliases: ['TR', 'TTH'] }
+            ],
+            timeSlots: [
+                { id: '10:00-12:20', aliases: ['10:00-12:00'], startMinutes: 600, endMinutes: 740 },
+                { id: '13:00-15:20', aliases: ['13:00-15:00'], startMinutes: 780, endMinutes: 920 }
+            ],
+            roomOptions: ['CEB 210', 'CEB 215'],
+            resolveCourseCode: (value) => value,
+            resolveFacultyName: (value) => value
+        });
+
+        expect(result.rows).toHaveLength(1);
+        expect(result.meta.quarterCounts).toMatchObject({ fall: 1 });
+        expect(result.rows[0]).toMatchObject({
+            status: 'ready',
+            code: 'CSCD 101',
+            title: 'Intro to CS',
+            section: '001',
+            instructor: 'Jane Doe',
+            meetingLabel: 'TR 13:00-15:00',
+            roomLabel: 'CEB 210',
+            schedulerDay: 'TR',
+            schedulerTime: '13:00-15:20',
+            schedulerRoom: 'CEB 210',
+            targetQuarter: 'fall',
+            reviewQuarter: 'fall',
+            enrollment: 24
+        });
+        expect(result.rows[0].notes).toEqual(expect.arrayContaining([
+            'Enrollment 24',
+            'Sheet: Fall export'
+        ]));
+    });
+
+    test('infers quarter from worksheet names and detects online rows', () => {
+        const result = ProgramCommandImport.buildClssPreviewRowsFromTabularRows([
+            {
+                subject: 'CYBR',
+                catalogNumber: '310',
+                section: '2',
+                title: 'Cyber Operations',
+                faculty: 'Staff',
+                modality: 'Online async',
+                __sheetName: 'Spring 2026 export'
+            }
+        ], {
+            dayPatterns: [
+                { id: 'MW', aliases: ['MW'] },
+                { id: 'TR', aliases: ['TR', 'TTH'] }
+            ],
+            timeSlots: [],
+            roomOptions: [],
+            resolveCourseCode: (value) => value,
+            resolveFacultyName: (value) => value,
+            defaultQuarter: 'winter'
+        });
+
+        expect(result.rows).toHaveLength(1);
+        expect(result.rows[0]).toMatchObject({
+            status: 'online',
+            code: 'CYBR 310',
+            targetQuarter: 'spring',
+            reviewQuarter: 'spring',
+            schedulerRoom: 'ONLINE',
+            schedulerSlotLabel: 'ONLINE / async',
+            reviewRoom: ''
+        });
+    });
+
+    test('persists pending onboarding import handoff state', () => {
+        const payload = {
+            source: 'spreadsheet',
+            programId: 'biology',
+            profileId: 'biology-v01'
+        };
+
+        ProgramCommandImport.writePendingOnboardingImport(payload);
+        expect(ProgramCommandImport.readPendingOnboardingImport()).toEqual(payload);
+
+        ProgramCommandImport.clearPendingOnboardingImport();
+        expect(ProgramCommandImport.readPendingOnboardingImport()).toBeNull();
+    });
+});

--- a/tests/program-shell.test.js
+++ b/tests/program-shell.test.js
@@ -96,6 +96,40 @@ describe('ProgramCommandShell', () => {
         });
     });
 
+    test('stores parsed spreadsheet import rows in onboarding context', () => {
+        const program = shell.findProgramById('biology');
+        const context = shell.createOnboardingContext(program, {
+            source: 'spreadsheet',
+            artifact: {
+                name: 'biology-seed.csv',
+                size: 512,
+                type: 'text/csv',
+                capturedAt: '2026-03-26T18:00:00.000Z'
+            },
+            spreadsheetImport: {
+                rows: [
+                    { term: 'Fall', subject: 'BIOL', catalogNumber: '101', title: 'Intro Biology' }
+                ],
+                meta: {
+                    format: 'csv',
+                    fileName: 'biology-seed.csv',
+                    rowCount: 1
+                }
+            }
+        });
+
+        expect(context.spreadsheetImport).toEqual({
+            rows: [
+                { term: 'Fall', subject: 'BIOL', catalogNumber: '101', title: 'Intro Biology' }
+            ],
+            meta: {
+                format: 'csv',
+                fileName: 'biology-seed.csv',
+                rowCount: 1
+            }
+        });
+    });
+
     test('creates department-aware onboarding context for combined workspaces', () => {
         const program = shell.findProgramById('computer-science-cybersecurity');
         const context = shell.createOnboardingContext(program, {


### PR DESCRIPTION
Closes #210

## Summary
- parse EagleNET CSV/XLS/XLSX uploads into CLSS review rows via a shared import module
- carry spreadsheet imports through the onboarding shell into department onboarding and auto-resume them in the Program Command runtime
- add regression coverage for spreadsheet handoff state and online-row classification

## Testing
- npm test -- --runInBand
- verified live at http://127.0.0.1:8123/