### PR TITLE
Fix async course sidebar rendering from legacy online buckets

### DIFF
--- a/index.html
+++ b/index.html
@@ -4633,8 +4633,25 @@
         </div>
     </div>
 
+    <script src="js/schedule-data-utils.js"></script>
     <script type="module">
         console.log(">>>>>>>> MAIN SCRIPT STARTING <<<<<<<<");
+        const scheduleDataUtils = window.ScheduleDataUtils || {};
+        const normalizeOnlineQuarterBucket = typeof scheduleDataUtils.ensureOnlineCourseBucketForQuarter === 'function'
+            ? scheduleDataUtils.ensureOnlineCourseBucketForQuarter
+            : function(quarterData) {
+                if (!quarterData || typeof quarterData !== 'object') return [];
+                if (!quarterData.ONLINE || typeof quarterData.ONLINE !== 'object' || Array.isArray(quarterData.ONLINE)) {
+                    quarterData.ONLINE = {};
+                }
+                if (!Array.isArray(quarterData.ONLINE.async)) {
+                    quarterData.ONLINE.async = [];
+                }
+                return quarterData.ONLINE.async;
+            };
+        const readOnlineCoursesFromQuarter = typeof scheduleDataUtils.getOnlineCoursesForQuarter === 'function'
+            ? scheduleDataUtils.getOnlineCoursesForQuarter
+            : normalizeOnlineQuarterBucket;
         // Faculty color mapping
         const facultyColors = {
             'T.Masingale': { class: 'faculty-masingale', color: '#667eea', name: 'T.Masingale' },
@@ -6442,11 +6459,11 @@
                 onlineSection.removeChild(onlineSection.firstChild);
             }
 
-            if (!data || !data['ONLINE']) {
+            if (!data) {
                 return;
             }
 
-            const onlineCourses = data['ONLINE']['async'] || [];
+            const onlineCourses = readOnlineCoursesFromQuarter(data);
 
             if (onlineCourses.length === 0) {
                 return;
@@ -6463,14 +6480,15 @@
             coursesList.className = 'online-courses-list';
 
             onlineCourses.forEach((course, index) => {
+                const courseTitle = course.name || course.title || '';
                 const item = document.createElement('div');
                 item.className = 'online-course-item';
 
                 const courseInfo = document.createElement('span');
-                courseInfo.innerHTML = `<strong>${course.code}</strong> <span style="color:#57606a">${course.name}</span> <span style="color:#8b949e">- ${course.instructor}</span>`;
+                courseInfo.innerHTML = `<strong>${course.code}</strong> <span style="color:#57606a">${courseTitle}</span> <span style="color:#8b949e">- ${course.instructor}</span>`;
                 courseInfo.style.cursor = 'pointer';
                 courseInfo.onclick = () => {
-                    showCourseDetails(course.code, course.name, course.instructor, course.credits, 'ONLINE', null, quarter, 'ONLINE', 'async');
+                    showCourseDetails(course.code, courseTitle, course.instructor, course.credits, 'ONLINE', null, quarter, 'ONLINE', 'async');
                 };
 
                 const deleteBtn = document.createElement('button');
@@ -6495,8 +6513,9 @@
 
         function deleteOnlineCourse(quarter, index) {
             const data = scheduleData[quarter];
-            if (data && data['ONLINE'] && data['ONLINE']['async']) {
-                data['ONLINE']['async'].splice(index, 1);
+            const onlineCourses = data ? readOnlineCoursesFromQuarter(data) : [];
+            if (Array.isArray(onlineCourses) && onlineCourses[index]) {
+                onlineCourses.splice(index, 1);
                 saveScheduleData();
                 setScheduleDirty(true);
                 renderOnlineCourses(quarter);
@@ -6651,9 +6670,7 @@
                 }
             });
 
-            if (data['ONLINE'] && data['ONLINE']['async']) {
-                allCourses = allCourses.concat(data['ONLINE']['async']);
-            }
+            allCourses = allCourses.concat(readOnlineCoursesFromQuarter(data));
 
             // Categorize courses
             const highEnrollment = [];
@@ -6882,6 +6899,7 @@
             quarters.forEach((quarter) => {
                 const quarterData = data?.[quarter];
                 if (!quarterData || typeof quarterData !== 'object') return;
+                normalizeOnlineQuarterBucket(quarterData);
 
                 Object.values(quarterData).forEach((timeBucket) => {
                     if (!timeBucket || typeof timeBucket !== 'object') return;
@@ -11720,8 +11738,7 @@
                     bucket[dayPattern] = {};
                 }
             });
-            if (!bucket.ONLINE || typeof bucket.ONLINE !== 'object') bucket.ONLINE = {};
-            if (!Array.isArray(bucket.ONLINE.async)) bucket.ONLINE.async = [];
+            normalizeOnlineQuarterBucket(bucket);
             if (!bucket.ARRANGED || typeof bucket.ARRANGED !== 'object') bucket.ARRANGED = {};
             if (!Array.isArray(bucket.ARRANGED.arranged)) bucket.ARRANGED.arranged = [];
             return bucket;
@@ -13499,6 +13516,37 @@
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.6/dist/purify.min.js"></script>
 
     <script>
+        const scheduleDataRuntimeUtils = window.ScheduleDataUtils || {};
+        const flattenQuarterScheduleData = typeof scheduleDataRuntimeUtils.flattenQuarterData === 'function'
+            ? scheduleDataRuntimeUtils.flattenQuarterData
+            : function(quarterData) {
+                const courses = [];
+                Object.keys(quarterData || {}).forEach((day) => {
+                    const dayData = quarterData[day];
+                    if (!dayData || typeof dayData !== 'object') return;
+
+                    Object.keys(dayData).forEach((time) => {
+                        const timeCourses = dayData[time];
+                        if (!Array.isArray(timeCourses)) return;
+
+                        timeCourses.forEach((course) => {
+                            courses.push({
+                                ...course,
+                                day,
+                                time
+                            });
+                        });
+                    });
+                });
+                return courses;
+            };
+        const getQuarterOnlineCourses = typeof scheduleDataRuntimeUtils.getOnlineCoursesForQuarter === 'function'
+            ? scheduleDataRuntimeUtils.getOnlineCoursesForQuarter
+            : function(quarterData) {
+                const onlineData = quarterData && quarterData['ONLINE'] ? quarterData['ONLINE'] : {};
+                return Array.isArray(onlineData.async) ? onlineData.async : [];
+            };
+
         // ============================================
         // SAVE, CONFLICT DETECTION & AI ANALYSIS
         // ============================================
@@ -13542,25 +13590,7 @@
         }
 
         function flattenQuarterData(quarterData) {
-            const courses = [];
-            for (const day of Object.keys(quarterData)) {
-                const dayData = quarterData[day];
-                if (!dayData || typeof dayData !== 'object') continue;
-
-                for (const time of Object.keys(dayData)) {
-                    const timeCourses = dayData[time];
-                    if (!Array.isArray(timeCourses)) continue;
-
-                    for (const course of timeCourses) {
-                        courses.push({
-                            ...course,
-                            day: day,
-                            time: time
-                        });
-                    }
-                }
-            }
-            return courses;
+            return flattenQuarterScheduleData(quarterData);
         }
 
         /**
@@ -15137,9 +15167,7 @@ RESPONSE FORMAT:
         }
 
         function getOnlineCoursesForQuarter(quarterData) {
-            const onlineData = quarterData['ONLINE'] || {};
-            const asyncData = onlineData['async'] || [];
-            return asyncData;
+            return getQuarterOnlineCourses(quarterData);
         }
     </script>
 </body>

--- a/js/schedule-data-utils.js
+++ b/js/schedule-data-utils.js
@@ -1,0 +1,123 @@
+(function(root, factory) {
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = factory();
+        return;
+    }
+
+    root.ScheduleDataUtils = factory();
+})(typeof globalThis !== 'undefined' ? globalThis : this, function() {
+    'use strict';
+
+    const TOP_LEVEL_ONLINE_KEYS = ['ONLINE', 'online', 'ASYNC', 'async', 'ASYNCHRONOUS', 'asynchronous'];
+    const ONLINE_BUCKET_KEY_PATTERN = /^(async|asynchronous|asynch|online|web)$/i;
+
+    function isObject(value) {
+        return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+    }
+
+    function appendCourseList(target, seen, value) {
+        if (!Array.isArray(value)) return;
+
+        value.forEach((course) => {
+            if (!course || typeof course !== 'object') return;
+            if (seen.has(course)) return;
+            seen.add(course);
+
+            if (!String(course.room || '').trim()) {
+                course.room = 'ONLINE';
+            }
+
+            target.push(course);
+        });
+    }
+
+    function ensureOnlineCourseBucketForQuarter(quarterData) {
+        if (!isObject(quarterData)) {
+            return [];
+        }
+
+        const seen = new Set();
+        const onlineCourses = [];
+
+        TOP_LEVEL_ONLINE_KEYS.forEach((containerKey) => {
+            const container = quarterData[containerKey];
+
+            if (Array.isArray(container)) {
+                appendCourseList(onlineCourses, seen, container);
+                return;
+            }
+
+            if (!isObject(container)) {
+                return;
+            }
+
+            Object.entries(container).forEach(([bucketKey, bucketValue]) => {
+                if (ONLINE_BUCKET_KEY_PATTERN.test(String(bucketKey || '').trim())) {
+                    appendCourseList(onlineCourses, seen, bucketValue);
+                }
+            });
+        });
+
+        if (!isObject(quarterData.ONLINE)) {
+            quarterData.ONLINE = {};
+        }
+
+        quarterData.ONLINE.async = onlineCourses;
+
+        Object.keys(quarterData.ONLINE).forEach((bucketKey) => {
+            if (bucketKey !== 'async' && ONLINE_BUCKET_KEY_PATTERN.test(String(bucketKey || '').trim())) {
+                delete quarterData.ONLINE[bucketKey];
+            }
+        });
+
+        TOP_LEVEL_ONLINE_KEYS.forEach((containerKey) => {
+            if (containerKey !== 'ONLINE') {
+                delete quarterData[containerKey];
+            }
+        });
+
+        return quarterData.ONLINE.async;
+    }
+
+    function getOnlineCoursesForQuarter(quarterData) {
+        return ensureOnlineCourseBucketForQuarter(quarterData);
+    }
+
+    function flattenQuarterData(quarterData) {
+        if (!isObject(quarterData)) {
+            return [];
+        }
+
+        ensureOnlineCourseBucketForQuarter(quarterData);
+
+        const courses = [];
+        Object.keys(quarterData).forEach((day) => {
+            const dayData = quarterData[day];
+            if (!isObject(dayData)) return;
+
+            Object.keys(dayData).forEach((time) => {
+                const timeCourses = dayData[time];
+                if (!Array.isArray(timeCourses)) return;
+
+                timeCourses.forEach((course) => {
+                    if (!course || typeof course !== 'object') return;
+
+                    courses.push({
+                        ...course,
+                        room: day === 'ONLINE' ? (course.room || 'ONLINE') : course.room,
+                        day,
+                        time
+                    });
+                });
+            });
+        });
+
+        return courses;
+    }
+
+    return {
+        ensureOnlineCourseBucketForQuarter,
+        getOnlineCoursesForQuarter,
+        flattenQuarterData
+    };
+});

--- a/tests/schedule-data-utils.online.test.js
+++ b/tests/schedule-data-utils.online.test.js
@@ -1,0 +1,85 @@
+const {
+    ensureOnlineCourseBucketForQuarter,
+    getOnlineCoursesForQuarter,
+    flattenQuarterData
+} = require('../js/schedule-data-utils.js');
+
+describe('schedule data utils online bucket normalization', () => {
+    test('normalizes legacy nested online aliases into ONLINE.async', () => {
+        const asyncCourse = {
+            code: 'DESN 216',
+            title: 'Digital Foundations',
+            instructor: 'Barton/Pettigrew'
+        };
+
+        const quarterData = {
+            online: {
+                asynchronous: [asyncCourse]
+            },
+            MW: {}
+        };
+
+        const onlineCourses = ensureOnlineCourseBucketForQuarter(quarterData);
+
+        expect(onlineCourses).toHaveLength(1);
+        expect(onlineCourses[0]).toBe(asyncCourse);
+        expect(quarterData.ONLINE.async).toEqual([asyncCourse]);
+        expect(quarterData.online).toBeUndefined();
+        expect(asyncCourse.room).toBe('ONLINE');
+    });
+
+    test('merges current and legacy ONLINE aliases without dropping either list', () => {
+        const asyncCourse = { code: 'DESN 216', name: 'Digital Foundations', instructor: 'A', room: 'ONLINE' };
+        const legacyCourse = { code: 'DESN 316', name: 'UI Systems', instructor: 'B' };
+
+        const quarterData = {
+            ONLINE: {
+                async: [asyncCourse],
+                online: [legacyCourse]
+            }
+        };
+
+        const onlineCourses = getOnlineCoursesForQuarter(quarterData);
+
+        expect(onlineCourses).toEqual([asyncCourse, legacyCourse]);
+        expect(quarterData.ONLINE.async).toEqual([asyncCourse, legacyCourse]);
+        expect(quarterData.ONLINE.online).toBeUndefined();
+        expect(legacyCourse.room).toBe('ONLINE');
+    });
+
+    test('flattenQuarterData includes legacy top-level async arrays under ONLINE/async', () => {
+        const inPersonCourse = {
+            code: 'DESN 100',
+            name: 'Drawing Communication',
+            instructor: 'Faculty A',
+            room: '206'
+        };
+        const onlineCourse = {
+            code: 'DESN 216',
+            title: 'Digital Foundations',
+            instructor: 'Faculty B'
+        };
+
+        const quarterData = {
+            MW: {
+                '10:00-12:20': [inPersonCourse]
+            },
+            async: [onlineCourse]
+        };
+
+        const flattened = flattenQuarterData(quarterData);
+        const onlineResult = flattened.find((course) => course.day === 'ONLINE');
+        const inPersonResult = flattened.find((course) => course.day === 'MW');
+
+        expect(flattened).toHaveLength(2);
+        expect(inPersonResult.time).toBe('10:00-12:20');
+        expect(onlineResult).toMatchObject({
+            code: 'DESN 216',
+            day: 'ONLINE',
+            time: 'async',
+            room: 'ONLINE'
+        });
+        expect(quarterData.async).toBeUndefined();
+        expect(quarterData.ONLINE.async).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Summary
- normalize legacy async/online bucket shapes into the canonical `ONLINE.async` structure
- route scheduler reads through the shared normalization helper so render, analytics, print, and persistence stay in sync
- add regression coverage for legacy online bucket normalization

## Local verification
- Reproduced the bug on latest `main` at `http://127.0.0.1:8080/index.html` with a localStorage payload using `spring.ONLINE.online`; the page rendered `0` async items under the grid.
- Verified the fix on this branch at `http://127.0.0.1:8081/index.html` with the same payload; the page rendered `1` async item and rewrote the bucket to `ONLINE.async`.
- Ran `npx jest tests/schedule-data-utils.online.test.js --runInBand`
- Ran `npx jest tests/schedule-save-reload-ay2627.test.js --runInBand`

Closes #231
