### PR TITLE
Load shared schedules before local drafts

### DIFF
--- a/index.html
+++ b/index.html
@@ -5056,6 +5056,15 @@
         const readOnlineCoursesFromQuarter = typeof scheduleDataUtils.getOnlineCoursesForQuarter === 'function'
             ? scheduleDataUtils.getOnlineCoursesForQuarter
             : normalizeOnlineQuarterBucket;
+        const buildScheduleDataFromDatabaseRecords = typeof scheduleDataUtils.buildScheduleDataFromDatabaseRecords === 'function'
+            ? scheduleDataUtils.buildScheduleDataFromDatabaseRecords
+            : null;
+        const scheduleSnapshotHasCourses = typeof scheduleDataUtils.scheduleHasCourses === 'function'
+            ? scheduleDataUtils.scheduleHasCourses
+            : function(snapshot) {
+                if (!snapshot || typeof snapshot !== 'object') return false;
+                return Object.values(snapshot).some((quarterData) => flattenQuarterData(quarterData || {}).length > 0);
+            };
         // Faculty color mapping
         const facultyColors = {
             'T.Masingale': { class: 'faculty-masingale', color: '#667eea', name: 'T.Masingale' },
@@ -5946,9 +5955,30 @@
                 quarterTitle.textContent = currentQuarter.charAt(0).toUpperCase() + currentQuarter.slice(1) + ' ' + qYear;
             }
 
-            // Re-render schedule UI
+            // Re-render quarter-specific scheduler UI
             if (typeof renderSchedule === 'function') {
                 renderSchedule(currentQuarter);
+            }
+            if (typeof renderOnlineCourses === 'function') {
+                renderOnlineCourses(currentQuarter);
+            }
+            if (typeof renderArrangedCourses === 'function') {
+                renderArrangedCourses(currentQuarter);
+            }
+            if (typeof renderEnrollmentAnalytics === 'function') {
+                renderEnrollmentAnalytics(currentQuarter);
+            }
+            if (typeof renderConflicts === 'function') {
+                renderConflicts(currentQuarter);
+            }
+            if (typeof renderConflictSolver === 'function') {
+                renderConflictSolver(currentQuarter);
+            }
+            if (typeof renderRecommendations === 'function') {
+                renderRecommendations(currentQuarter);
+            }
+            if (typeof updateStats === 'function') {
+                updateStats(currentQuarter);
             }
         });
 
@@ -12470,6 +12500,22 @@
             }
         }
 
+        function applyScheduleDataSnapshot(snapshot) {
+            const nextSnapshot = snapshot && typeof snapshot === 'object'
+                ? snapshot
+                : createEmptyAcademicYearScheduleData();
+
+            ['fall', 'winter', 'spring'].forEach((quarter) => {
+                const quarterSnapshot = nextSnapshot[quarter] && typeof nextSnapshot[quarter] === 'object'
+                    ? nextSnapshot[quarter]
+                    : createEmptyQuarterScheduleBucket();
+                scheduleData[quarter] = quarterSnapshot;
+                ensureQuarterScheduleBucketForSchedule(scheduleData, quarter);
+            });
+
+            normalizeScheduleCourseCodes(scheduleData);
+        }
+
         function openWorkloadReviewFromScheduler(options = {}) {
             const {
                 yearOverride = null,
@@ -12546,20 +12592,15 @@
                     let parsed = JSON.parse(saved);
                     parsed = migrateTimeSlots(parsed);
                     parsed = normalizeScheduleCourseCodes(parsed);
-                    const hasCourses = (qData) => {
-                        if (!qData) return false;
-                        return Object.values(qData).some(dayData =>
-                            Object.values(dayData).some(timeData =>
-                                Array.isArray(timeData) && timeData.length > 0
-                            )
-                        );
-                    };
-
-                    for (const quarter of ['fall', 'winter', 'spring']) {
-                        if (parsed[quarter] && hasCourses(parsed[quarter])) {
-                            scheduleData[quarter] = parsed[quarter];
+                    const snapshot = createEmptyAcademicYearScheduleData();
+                    ['fall', 'winter', 'spring'].forEach((quarter) => {
+                        if (parsed[quarter] && typeof parsed[quarter] === 'object') {
+                            snapshot[quarter] = parsed[quarter];
                         }
-                    }
+                        ensureQuarterScheduleBucketForSchedule(snapshot, quarter);
+                    });
+
+                    applyScheduleDataSnapshot(snapshot);
                     console.log('Schedule data loaded for year:', targetYear);
                     saveScheduleData();
                     return true;
@@ -12568,6 +12609,134 @@
                 console.warn('Could not load schedule data:', e);
             }
             return false;
+        }
+
+        async function loadScheduleDataFromDatabase(year) {
+            const targetYear = year || currentAcademicYear;
+            const client = getDatabaseClient();
+
+            if (!client) {
+                return { ok: false, reason: 'no-client' };
+            }
+
+            try {
+                const departmentIdentity = getActiveDepartmentIdentity();
+                const departmentResult = await client
+                    .from('departments')
+                    .select('id')
+                    .eq('code', departmentIdentity.code)
+                    .maybeSingle();
+                if (departmentResult.error) throw departmentResult.error;
+
+                if (!departmentResult.data?.id) {
+                    return {
+                        ok: true,
+                        hasData: false,
+                        reason: 'missing-department',
+                        scheduleData: createEmptyAcademicYearScheduleData()
+                    };
+                }
+
+                const academicYearResult = await client
+                    .from('academic_years')
+                    .select('id')
+                    .eq('department_id', departmentResult.data.id)
+                    .eq('year', targetYear)
+                    .maybeSingle();
+                if (academicYearResult.error) throw academicYearResult.error;
+
+                if (!academicYearResult.data?.id) {
+                    return {
+                        ok: true,
+                        hasData: false,
+                        reason: 'missing-academic-year',
+                        scheduleData: createEmptyAcademicYearScheduleData()
+                    };
+                }
+
+                const scheduledCourseResult = await client
+                    .from('scheduled_courses')
+                    .select(`
+                        quarter,
+                        day_pattern,
+                        time_slot,
+                        section,
+                        projected_enrollment,
+                        course:courses(code, title, default_credits),
+                        faculty:faculty(name),
+                        room:rooms(room_code)
+                    `)
+                    .eq('academic_year_id', academicYearResult.data.id)
+                    .order('quarter')
+                    .order('day_pattern')
+                    .order('time_slot')
+                    .order('section');
+                if (scheduledCourseResult.error) throw scheduledCourseResult.error;
+
+                const hydratedSchedule = typeof buildScheduleDataFromDatabaseRecords === 'function'
+                    ? buildScheduleDataFromDatabaseRecords(scheduledCourseResult.data || [], {
+                        quarters: ['fall', 'winter', 'spring'],
+                        dayPatterns: getSchedulerDayIds(),
+                        normalizeCourseCode,
+                        normalizeInstructor: getCanonicalFacultyName,
+                        normalizeRoom: (value) => String(value || '').trim()
+                    })
+                    : createEmptyAcademicYearScheduleData();
+
+                return {
+                    ok: true,
+                    hasData: scheduleSnapshotHasCourses(hydratedSchedule),
+                    reason: 'loaded',
+                    scheduleData: hydratedSchedule,
+                    recordCount: Array.isArray(scheduledCourseResult.data) ? scheduledCourseResult.data.length : 0
+                };
+            } catch (error) {
+                console.warn('Could not load schedule data from Supabase:', error);
+                return {
+                    ok: false,
+                    reason: 'load-failed',
+                    error
+                };
+            }
+        }
+
+        async function hydrateScheduleDataForYear(year) {
+            const targetYear = year || currentAcademicYear;
+            const localSnapshot = loadScheduleDataSnapshotForYear(targetYear);
+            const localHasData = scheduleSnapshotHasCourses(localSnapshot);
+            const cloudResult = await loadScheduleDataFromDatabase(targetYear);
+
+            if (cloudResult.ok && cloudResult.hasData) {
+                applyScheduleDataSnapshot(cloudResult.scheduleData);
+                saveScheduleDataSnapshotForYear(targetYear, scheduleData);
+                console.log(`Hydrated ${targetYear} schedule from Supabase`, { records: cloudResult.recordCount || 0 });
+                return {
+                    ok: true,
+                    source: 'supabase',
+                    hasData: true,
+                    recordCount: cloudResult.recordCount || 0
+                };
+            }
+
+            if (localHasData) {
+                applyScheduleDataSnapshot(localSnapshot);
+                return {
+                    ok: true,
+                    source: 'local',
+                    hasData: true,
+                    fallbackReason: cloudResult.ok ? cloudResult.reason : 'cloud-load-failed',
+                    error: cloudResult.error
+                };
+            }
+
+            applyScheduleDataSnapshot(createEmptyAcademicYearScheduleData());
+            return {
+                ok: Boolean(cloudResult.ok),
+                source: 'empty',
+                hasData: false,
+                fallbackReason: cloudResult.ok ? cloudResult.reason : 'cloud-load-failed',
+                error: cloudResult.error
+            };
         }
 
         function clearScheduleData() {
@@ -12612,7 +12781,7 @@
         }
 
         // Switch academic year
-        function switchAcademicYear(newYear) {
+        async function switchAcademicYearAsync(newYear) {
             // Save current year's data first
             saveScheduleData();
 
@@ -12620,12 +12789,10 @@
             currentAcademicYear = newYear;
 
             // Reset scheduleData to defaults
-            scheduleData.fall = {};
-            scheduleData.winter = {};
-            scheduleData.spring = {};
+            applyScheduleDataSnapshot(createEmptyAcademicYearScheduleData());
 
-            // Load the new year's data (if any)
-            const hasData = loadScheduleData(newYear);
+            // Load the new year's shared schedule first, then fall back to local draft data.
+            const loadResult = await hydrateScheduleDataForYear(newYear);
             syncDirtyStateForCurrentYear();
 
             // Update quarter tab labels
@@ -12636,14 +12803,22 @@
             const quarter = navComponent ? navComponent.currentQuarter : (window.StateManager?.get('currentQuarter') || 'spring');
 
             renderSchedule(quarter);
+            renderOnlineCourses(quarter);
+            renderArrangedCourses(quarter);
             renderConflicts(quarter);
             updateStats(quarter);
 
-            if (!hasData) {
+            if (!loadResult.hasData) {
                 showToast('Viewing ' + newYear + ' schedule (empty - use Copy to populate)');
+            } else if (loadResult.source === 'local') {
+                showToast(`Switched to ${newYear} schedule (local draft)`, 'warning');
             } else {
                 showToast('Switched to ' + newYear + ' schedule');
             }
+        }
+
+        function switchAcademicYear(newYear) {
+            void switchAcademicYearAsync(newYear);
         }
 
         function updateQuarterTabLabels(year) {
@@ -12925,8 +13100,11 @@
             // Migrate old schedule data format to year-aware format
             migrateOldScheduleData();
 
-            // Load saved schedule data from localStorage
-            loadScheduleData();
+            // Load shared schedule data first, then fall back to this browser's local draft.
+            const initialScheduleLoad = await hydrateScheduleDataForYear(currentAcademicYear);
+            if (initialScheduleLoad.source === 'local' && initialScheduleLoad.fallbackReason === 'cloud-load-failed') {
+                console.warn(`Using local schedule draft for ${currentAcademicYear} because shared schedule load failed.`, initialScheduleLoad.error);
+            }
 
             // Check for imported schedule from schedule builder
             checkForImportedSchedule();

--- a/js/schedule-data-utils.js
+++ b/js/schedule-data-utils.js
@@ -10,6 +10,7 @@
 
     const TOP_LEVEL_ONLINE_KEYS = ['ONLINE', 'online', 'ASYNC', 'async', 'ASYNCHRONOUS', 'asynchronous'];
     const ONLINE_BUCKET_KEY_PATTERN = /^(async|asynchronous|asynch|online|web)$/i;
+    const DEFAULT_QUARTERS = ['fall', 'winter', 'spring'];
 
     function isObject(value) {
         return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -83,12 +84,171 @@
         return ensureOnlineCourseBucketForQuarter(quarterData);
     }
 
+    function ensureArrangedCourseBucketForQuarter(quarterData) {
+        if (!isObject(quarterData)) {
+            return [];
+        }
+
+        if (!isObject(quarterData.ARRANGED)) {
+            quarterData.ARRANGED = {};
+        }
+
+        if (!Array.isArray(quarterData.ARRANGED.arranged)) {
+            quarterData.ARRANGED.arranged = [];
+        }
+
+        return quarterData.ARRANGED.arranged;
+    }
+
+    function createEmptyQuarterScheduleBucket(dayPatterns) {
+        const bucket = {
+            ONLINE: { async: [] },
+            ARRANGED: { arranged: [] }
+        };
+
+        (Array.isArray(dayPatterns) ? dayPatterns : []).forEach((dayPattern) => {
+            const key = String(dayPattern || '').trim();
+            if (!key || key === 'ONLINE' || key === 'ARRANGED') return;
+            bucket[key] = {};
+        });
+
+        return bucket;
+    }
+
+    function createEmptyAcademicYearScheduleData(options) {
+        const normalizedOptions = isObject(options) ? options : {};
+        const quarters = Array.isArray(normalizedOptions.quarters) && normalizedOptions.quarters.length
+            ? normalizedOptions.quarters
+            : DEFAULT_QUARTERS;
+        const dayPatterns = Array.isArray(normalizedOptions.dayPatterns)
+            ? normalizedOptions.dayPatterns
+            : [];
+        const schedule = {};
+
+        quarters.forEach((quarter) => {
+            const quarterKey = String(quarter || '').trim().toLowerCase();
+            if (!quarterKey) return;
+            schedule[quarterKey] = createEmptyQuarterScheduleBucket(dayPatterns);
+        });
+
+        return schedule;
+    }
+
+    function scheduleHasCourses(scheduleData) {
+        if (!isObject(scheduleData)) {
+            return false;
+        }
+
+        return Object.values(scheduleData).some((quarterData) => {
+            if (!isObject(quarterData)) return false;
+            return flattenQuarterData(quarterData).length > 0;
+        });
+    }
+
+    function buildScheduleDataFromDatabaseRecords(records, options) {
+        const normalizedOptions = isObject(options) ? options : {};
+        const normalizeCourseCode = typeof normalizedOptions.normalizeCourseCode === 'function'
+            ? normalizedOptions.normalizeCourseCode
+            : function(value) {
+                return String(value || '').trim();
+            };
+        const normalizeInstructor = typeof normalizedOptions.normalizeInstructor === 'function'
+            ? normalizedOptions.normalizeInstructor
+            : function(value) {
+                const normalized = String(value || '').trim();
+                return normalized || 'TBD';
+            };
+        const normalizeRoom = typeof normalizedOptions.normalizeRoom === 'function'
+            ? normalizedOptions.normalizeRoom
+            : function(value) {
+                return String(value || '').trim();
+            };
+        const quarters = Array.isArray(normalizedOptions.quarters) && normalizedOptions.quarters.length
+            ? normalizedOptions.quarters
+            : DEFAULT_QUARTERS;
+        const dayPatterns = Array.isArray(normalizedOptions.dayPatterns)
+            ? normalizedOptions.dayPatterns
+            : [];
+        const schedule = createEmptyAcademicYearScheduleData({ quarters, dayPatterns });
+
+        (Array.isArray(records) ? records : []).forEach((record) => {
+            const quarterKey = String(record?.quarter || '').trim().toLowerCase();
+            if (!quarterKey) return;
+
+            if (!isObject(schedule[quarterKey])) {
+                schedule[quarterKey] = createEmptyQuarterScheduleBucket(dayPatterns);
+            }
+
+            const quarterData = schedule[quarterKey];
+            const code = normalizeCourseCode(record?.course?.code || record?.code || record?.course_code || '');
+            if (!code) return;
+
+            const title = String(record?.course?.title || record?.title || record?.name || code).trim();
+            const instructor = normalizeInstructor(record?.faculty?.name || record?.instructor || 'TBD');
+            const credits = Number(record?.course?.default_credits ?? record?.credits);
+            const projectedEnrollment = Number(record?.projected_enrollment ?? record?.projectedEnrollment);
+            const baseCourse = {
+                code,
+                name: title,
+                instructor,
+                credits: Number.isFinite(credits) && credits > 0 ? credits : 5,
+                section: String(record?.section || '').trim()
+            };
+
+            if (Number.isFinite(projectedEnrollment)) {
+                baseCourse.enrollmentCap = projectedEnrollment;
+            }
+
+            const dayPattern = String(record?.day_pattern || record?.day || '').trim().toUpperCase();
+            const timeSlot = String(record?.time_slot || record?.time || '').trim();
+
+            if (dayPattern === 'ONLINE') {
+                ensureOnlineCourseBucketForQuarter(quarterData).push({
+                    ...baseCourse,
+                    room: 'ONLINE'
+                });
+                return;
+            }
+
+            if (dayPattern === 'ARRANGED') {
+                ensureArrangedCourseBucketForQuarter(quarterData).push({
+                    ...baseCourse,
+                    room: 'ARRANGED'
+                });
+                return;
+            }
+
+            if (!dayPattern) return;
+
+            if (!isObject(quarterData[dayPattern])) {
+                quarterData[dayPattern] = {};
+            }
+
+            if (!Array.isArray(quarterData[dayPattern][timeSlot])) {
+                quarterData[dayPattern][timeSlot] = [];
+            }
+
+            quarterData[dayPattern][timeSlot].push({
+                ...baseCourse,
+                room: normalizeRoom(record?.room?.room_code || record?.room_code || record?.room || 'TBD') || 'TBD'
+            });
+        });
+
+        Object.keys(schedule).forEach((quarterKey) => {
+            ensureOnlineCourseBucketForQuarter(schedule[quarterKey]);
+            ensureArrangedCourseBucketForQuarter(schedule[quarterKey]);
+        });
+
+        return schedule;
+    }
+
     function flattenQuarterData(quarterData) {
         if (!isObject(quarterData)) {
             return [];
         }
 
         ensureOnlineCourseBucketForQuarter(quarterData);
+        ensureArrangedCourseBucketForQuarter(quarterData);
 
         const courses = [];
         Object.keys(quarterData).forEach((day) => {
@@ -116,8 +276,11 @@
     }
 
     return {
+        buildScheduleDataFromDatabaseRecords,
+        createEmptyAcademicYearScheduleData,
         ensureOnlineCourseBucketForQuarter,
         getOnlineCoursesForQuarter,
-        flattenQuarterData
+        flattenQuarterData,
+        scheduleHasCourses
     };
 });

--- a/js/supabase-config.js
+++ b/js/supabase-config.js
@@ -17,9 +17,15 @@ const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBh
 const CURRENT_DEPARTMENT_CODE = 'DESN';
 const CURRENT_DEPARTMENT_NAME = 'Design';
 
+// Capture the CDN SDK namespace before legacy pages alias `supabase` to the client.
+const supabaseSdkNamespace =
+    (typeof window !== 'undefined' && window.supabase && typeof window.supabase.createClient === 'function')
+        ? window.supabase
+        : null;
+
 // Initialize Supabase client (only if credentials are configured)
 let supabaseClient = null;
-var supabase = (typeof window !== 'undefined' && window.supabase) ? window.supabase : null; // Preserve CDN global until client init.
+var supabase = null; // Global reference for legacy scripts.
 
 function isSupabaseConfigured() {
     return SUPABASE_URL !== 'YOUR_SUPABASE_PROJECT_URL' &&
@@ -27,14 +33,21 @@ function isSupabaseConfigured() {
 }
 
 function initSupabase() {
+    if (supabaseClient) {
+        return supabaseClient;
+    }
+
     if (!isSupabaseConfigured()) {
         console.warn('Supabase not configured. Using local JSON files as fallback.');
         return null;
     }
 
-    const supabaseLibrary = (typeof window !== 'undefined' && window.supabase && typeof window.supabase.createClient === 'function')
-        ? window.supabase
-        : (supabase && typeof supabase.createClient === 'function' ? supabase : null);
+    const supabaseLibrary =
+        (supabaseSdkNamespace && typeof supabaseSdkNamespace.createClient === 'function')
+            ? supabaseSdkNamespace
+            : ((typeof window !== 'undefined' && window.supabase && typeof window.supabase.createClient === 'function')
+                ? window.supabase
+                : null);
 
     if (!supabaseLibrary) {
         console.error('Supabase JS library not loaded. Add the script tag before this file.');
@@ -44,7 +57,11 @@ function initSupabase() {
     supabaseClient = supabaseLibrary.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
     supabase = supabaseClient; // Set global reference
     if (typeof window !== 'undefined') {
-        window.supabase = supabaseClient;
+        window.supabaseClient = supabaseClient;
+        window.getSupabaseClient = getSupabaseClient;
+        window.isSupabaseConfigured = isSupabaseConfigured;
+        window.getActiveDepartmentIdentity = getActiveDepartmentIdentity;
+        window.initSupabase = initSupabase;
     }
     console.log('Supabase client initialized successfully');
     return supabaseClient;
@@ -80,3 +97,10 @@ function getActiveDepartmentIdentity() {
 document.addEventListener('DOMContentLoaded', () => {
     initSupabase();
 });
+
+if (typeof window !== 'undefined') {
+    window.getSupabaseClient = getSupabaseClient;
+    window.isSupabaseConfigured = isSupabaseConfigured;
+    window.getActiveDepartmentIdentity = getActiveDepartmentIdentity;
+    window.initSupabase = initSupabase;
+}

--- a/tests/schedule-data-utils.online.test.js
+++ b/tests/schedule-data-utils.online.test.js
@@ -1,7 +1,10 @@
 const {
+    buildScheduleDataFromDatabaseRecords,
+    createEmptyAcademicYearScheduleData,
     ensureOnlineCourseBucketForQuarter,
     getOnlineCoursesForQuarter,
-    flattenQuarterData
+    flattenQuarterData,
+    scheduleHasCourses
 } = require('../js/schedule-data-utils.js');
 
 describe('schedule data utils online bucket normalization', () => {
@@ -81,5 +84,80 @@ describe('schedule data utils online bucket normalization', () => {
         });
         expect(quarterData.async).toBeUndefined();
         expect(quarterData.ONLINE.async).toHaveLength(1);
+    });
+
+    test('builds scheduler buckets from Supabase scheduled course rows', () => {
+        const scheduleData = buildScheduleDataFromDatabaseRecords([
+            {
+                quarter: 'fall',
+                day_pattern: 'MW',
+                time_slot: '10:00-12:20',
+                section: '001',
+                projected_enrollment: 24,
+                course: { code: 'desn 216', title: 'Digital Foundations', default_credits: 5 },
+                faculty: { name: 'A. Faculty' },
+                room: { room_code: '206' }
+            },
+            {
+                quarter: 'fall',
+                day_pattern: 'online',
+                time_slot: 'async',
+                section: '002',
+                course: { code: 'DESN 316', title: 'UI Systems', default_credits: 5 },
+                faculty: { name: 'B. Faculty' }
+            },
+            {
+                quarter: 'winter',
+                day_pattern: 'arranged',
+                time_slot: 'arranged',
+                section: '003',
+                course: { code: 'DESN 490', title: 'Capstone', default_credits: 5 },
+                faculty: { name: 'C. Faculty' }
+            }
+        ], {
+            dayPatterns: ['MW', 'TR'],
+            normalizeCourseCode: (value) => String(value || '').trim().toUpperCase().replace(/\s+/g, ' '),
+            normalizeInstructor: (value) => String(value || '').trim() || 'TBD'
+        });
+
+        expect(scheduleData.fall.MW['10:00-12:20']).toEqual([
+            expect.objectContaining({
+                code: 'DESN 216',
+                room: '206',
+                instructor: 'A. Faculty',
+                enrollmentCap: 24
+            })
+        ]);
+        expect(scheduleData.fall.ONLINE.async).toEqual([
+            expect.objectContaining({
+                code: 'DESN 316',
+                room: 'ONLINE',
+                instructor: 'B. Faculty'
+            })
+        ]);
+        expect(scheduleData.winter.ARRANGED.arranged).toEqual([
+            expect.objectContaining({
+                code: 'DESN 490',
+                room: 'ARRANGED',
+                instructor: 'C. Faculty'
+            })
+        ]);
+    });
+
+    test('scheduleHasCourses distinguishes empty and populated schedule snapshots', () => {
+        const emptySchedule = createEmptyAcademicYearScheduleData({ dayPatterns: ['MW', 'TR'] });
+        const populatedSchedule = buildScheduleDataFromDatabaseRecords([
+            {
+                quarter: 'spring',
+                day_pattern: 'ONLINE',
+                time_slot: 'async',
+                course: { code: 'DESN 379', title: 'Web Dev 2', default_credits: 5 }
+            }
+        ], {
+            dayPatterns: ['MW', 'TR']
+        });
+
+        expect(scheduleHasCourses(emptySchedule)).toBe(false);
+        expect(scheduleHasCourses(populatedSchedule)).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- load schedule data from Supabase on startup and on academic-year switches before falling back to browser-local drafts
- rebuild scheduler snapshots from `scheduled_courses` rows and refresh the local cache from the shared copy
- re-render quarter-specific side panels on quarter changes so async and arranged courses appear when switching terms
- preserve legacy online bucket normalization coverage with new Supabase hydration tests

## Testing
- npx jest tests/schedule-data-utils.online.test.js --runInBand
- npx jest tests/schedule-save-reload-ay2627.test.js --runInBand
- npx jest tests/db-service.atomic-save.test.js --runInBand
- Playwright check at http://127.0.0.1:8082/index.html after seeding stale `designSchedulerData_2025-26`: local draft was overwritten from Supabase and Winter 2026 rendered 3 async courses under the grid

Closes #234