### PR TITLE
Load shared schedules on stable UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4679,6 +4679,15 @@
         const readOnlineCoursesFromQuarter = typeof scheduleDataUtils.getOnlineCoursesForQuarter === 'function'
             ? scheduleDataUtils.getOnlineCoursesForQuarter
             : normalizeOnlineQuarterBucket;
+        const buildScheduleDataFromDatabaseRecords = typeof scheduleDataUtils.buildScheduleDataFromDatabaseRecords === 'function'
+            ? scheduleDataUtils.buildScheduleDataFromDatabaseRecords
+            : null;
+        const scheduleSnapshotHasCourses = typeof scheduleDataUtils.scheduleHasCourses === 'function'
+            ? scheduleDataUtils.scheduleHasCourses
+            : function(snapshot) {
+                if (!snapshot || typeof snapshot !== 'object') return false;
+                return Object.values(snapshot).some((quarterData) => flattenQuarterData(quarterData || {}).length > 0);
+            };
         // Faculty color mapping
         const facultyColors = {
             'T.Masingale': { class: 'faculty-masingale', color: '#667eea', name: 'T.Masingale' },
@@ -5856,9 +5865,30 @@
                 quarterTitle.textContent = currentQuarter.charAt(0).toUpperCase() + currentQuarter.slice(1) + ' ' + qYear;
             }
 
-            // Re-render schedule UI
+            // Re-render quarter-specific scheduler UI
             if (typeof renderSchedule === 'function') {
                 renderSchedule(currentQuarter);
+            }
+            if (typeof renderOnlineCourses === 'function') {
+                renderOnlineCourses(currentQuarter);
+            }
+            if (typeof renderArrangedCourses === 'function') {
+                renderArrangedCourses(currentQuarter);
+            }
+            if (typeof renderEnrollmentAnalytics === 'function') {
+                renderEnrollmentAnalytics(currentQuarter);
+            }
+            if (typeof renderConflicts === 'function') {
+                renderConflicts(currentQuarter);
+            }
+            if (typeof renderConflictSolver === 'function') {
+                renderConflictSolver(currentQuarter);
+            }
+            if (typeof renderRecommendations === 'function') {
+                renderRecommendations(currentQuarter);
+            }
+            if (typeof updateStats === 'function') {
+                updateStats(currentQuarter);
             }
         });
 
@@ -12152,6 +12182,8 @@
                 let parsed = JSON.parse(saved);
                 parsed = migrateTimeSlots(parsed);
                 parsed = normalizeScheduleCourseCodes(parsed);
+                const modalityMigrated = enforceCourseDefaultModalities(parsed);
+                const canonicalPatternMigrated = applyCanonicalSchedulePatternMigrations(targetYear, parsed);
 
                 const snapshot = createEmptyAcademicYearScheduleData();
                 CLSS_IMPORT_QUARTERS.forEach((quarter) => {
@@ -12160,6 +12192,11 @@
                     }
                     ensureQuarterScheduleBucketForSchedule(snapshot, quarter);
                 });
+
+                if (modalityMigrated || canonicalPatternMigrated) {
+                    saveScheduleDataSnapshotForYear(targetYear, snapshot);
+                }
+
                 return snapshot;
             } catch (error) {
                 console.warn('Could not load schedule snapshot for year:', targetYear, error);
@@ -12768,6 +12805,22 @@
             }
         }
 
+        function applyScheduleDataSnapshot(snapshot) {
+            const nextSnapshot = snapshot && typeof snapshot === 'object'
+                ? snapshot
+                : createEmptyAcademicYearScheduleData();
+
+            CLSS_IMPORT_QUARTERS.forEach((quarter) => {
+                const quarterSnapshot = nextSnapshot[quarter] && typeof nextSnapshot[quarter] === 'object'
+                    ? nextSnapshot[quarter]
+                    : createEmptyQuarterScheduleBucket();
+                scheduleData[quarter] = quarterSnapshot;
+                ensureQuarterScheduleBucketForSchedule(scheduleData, quarter);
+            });
+
+            normalizeScheduleCourseCodes(scheduleData);
+        }
+
         function openWorkloadReviewFromScheduler(options = {}) {
             const {
                 yearOverride = null,
@@ -12979,42 +13032,156 @@
 
         function loadScheduleData(year) {
             const targetYear = year || currentAcademicYear;
-            try {
-                const saved = localStorage.getItem(getStorageKey(targetYear));
-                if (saved) {
-                    let parsed = JSON.parse(saved);
-                    parsed = migrateTimeSlots(parsed);
-                    parsed = normalizeScheduleCourseCodes(parsed);
-                    const modalityMigrated = enforceCourseDefaultModalities(parsed);
-                    const canonicalPatternMigrated = applyCanonicalSchedulePatternMigrations(targetYear, parsed);
-                    const hasCourses = (qData) => {
-                        if (!qData) return false;
-                        return Object.values(qData).some(dayData =>
-                            Object.values(dayData).some(timeData =>
-                                Array.isArray(timeData) && timeData.length > 0
-                            )
-                        );
-                    };
-
-                    for (const quarter of ['fall', 'winter', 'spring']) {
-                        if (parsed[quarter] && hasCourses(parsed[quarter])) {
-                            scheduleData[quarter] = parsed[quarter];
-                        }
-                    }
-                    console.log('Schedule data loaded for year:', targetYear);
-                    if (modalityMigrated) {
-                        console.log('Migrated course modality defaults for year:', targetYear);
-                    }
-                    if (canonicalPatternMigrated) {
-                        console.log('Applied canonical schedule pattern updates for year:', targetYear);
-                    }
-                    saveScheduleData();
-                    return true;
-                }
-            } catch (e) {
-                console.warn('Could not load schedule data:', e);
+            const snapshot = loadScheduleDataSnapshotForYear(targetYear);
+            if (!scheduleSnapshotHasCourses(snapshot)) {
+                return false;
             }
-            return false;
+
+            applyScheduleDataSnapshot(snapshot);
+            console.log('Schedule data loaded for year:', targetYear);
+            saveScheduleData();
+            return true;
+        }
+
+        async function loadScheduleDataFromDatabase(year) {
+            const targetYear = year || currentAcademicYear;
+            const client = getDatabaseClient();
+
+            if (!client) {
+                return { ok: false, reason: 'no-client' };
+            }
+
+            try {
+                const departmentIdentity = getActiveDepartmentIdentity();
+                const departmentResult = await client
+                    .from('departments')
+                    .select('id')
+                    .eq('code', departmentIdentity.code)
+                    .maybeSingle();
+                if (departmentResult.error) throw departmentResult.error;
+
+                if (!departmentResult.data?.id) {
+                    return {
+                        ok: true,
+                        hasData: false,
+                        reason: 'missing-department',
+                        scheduleData: createEmptyAcademicYearScheduleData()
+                    };
+                }
+
+                const academicYearResult = await client
+                    .from('academic_years')
+                    .select('id')
+                    .eq('department_id', departmentResult.data.id)
+                    .eq('year', targetYear)
+                    .maybeSingle();
+                if (academicYearResult.error) throw academicYearResult.error;
+
+                if (!academicYearResult.data?.id) {
+                    return {
+                        ok: true,
+                        hasData: false,
+                        reason: 'missing-academic-year',
+                        scheduleData: createEmptyAcademicYearScheduleData()
+                    };
+                }
+
+                const scheduledCourseResult = await client
+                    .from('scheduled_courses')
+                    .select(`
+                        quarter,
+                        day_pattern,
+                        time_slot,
+                        section,
+                        projected_enrollment,
+                        course:courses(code, title, default_credits),
+                        faculty:faculty(name),
+                        room:rooms(room_code)
+                    `)
+                    .eq('academic_year_id', academicYearResult.data.id)
+                    .order('quarter')
+                    .order('day_pattern')
+                    .order('time_slot')
+                    .order('section');
+                if (scheduledCourseResult.error) throw scheduledCourseResult.error;
+
+                const hydratedSchedule = typeof buildScheduleDataFromDatabaseRecords === 'function'
+                    ? buildScheduleDataFromDatabaseRecords(scheduledCourseResult.data || [], {
+                        quarters: CLSS_IMPORT_QUARTERS,
+                        dayPatterns: getSchedulerDayIds(),
+                        normalizeCourseCode,
+                        normalizeInstructor: getCanonicalFacultyName,
+                        normalizeRoom: (value) => String(value || '').trim()
+                    })
+                    : createEmptyAcademicYearScheduleData();
+
+                return {
+                    ok: true,
+                    hasData: scheduleSnapshotHasCourses(hydratedSchedule),
+                    reason: 'loaded',
+                    scheduleData: hydratedSchedule,
+                    recordCount: Array.isArray(scheduledCourseResult.data) ? scheduledCourseResult.data.length : 0
+                };
+            } catch (error) {
+                console.warn('Could not load schedule data from Supabase:', error);
+                return {
+                    ok: false,
+                    reason: 'load-failed',
+                    error
+                };
+            }
+        }
+
+        async function hydrateScheduleDataForYear(year, options = {}) {
+            const targetYear = year || currentAcademicYear;
+            const preserveExistingOnEmpty = Boolean(options.preserveExistingOnEmpty);
+            const localSnapshot = loadScheduleDataSnapshotForYear(targetYear);
+            const localHasData = scheduleSnapshotHasCourses(localSnapshot);
+            const cloudResult = await loadScheduleDataFromDatabase(targetYear);
+
+            if (cloudResult.ok && cloudResult.hasData) {
+                applyScheduleDataSnapshot(cloudResult.scheduleData);
+                saveScheduleDataSnapshotForYear(targetYear, scheduleData);
+                console.log(`Hydrated ${targetYear} schedule from Supabase`, { records: cloudResult.recordCount || 0 });
+                return {
+                    ok: true,
+                    source: 'supabase',
+                    hasData: true,
+                    recordCount: cloudResult.recordCount || 0
+                };
+            }
+
+            if (localHasData) {
+                applyScheduleDataSnapshot(localSnapshot);
+                return {
+                    ok: true,
+                    source: 'local',
+                    hasData: true,
+                    fallbackReason: cloudResult.ok ? cloudResult.reason : 'cloud-load-failed',
+                    error: cloudResult.error
+                };
+            }
+
+            if (preserveExistingOnEmpty) {
+                CLSS_IMPORT_QUARTERS.forEach((quarter) => ensureQuarterScheduleBucketForSchedule(scheduleData, quarter));
+                normalizeScheduleCourseCodes(scheduleData);
+                return {
+                    ok: Boolean(cloudResult.ok),
+                    source: 'existing',
+                    hasData: scheduleSnapshotHasCourses(scheduleData),
+                    fallbackReason: cloudResult.ok ? cloudResult.reason : 'cloud-load-failed',
+                    error: cloudResult.error
+                };
+            }
+
+            applyScheduleDataSnapshot(createEmptyAcademicYearScheduleData());
+            return {
+                ok: Boolean(cloudResult.ok),
+                source: 'empty',
+                hasData: false,
+                fallbackReason: cloudResult.ok ? cloudResult.reason : 'cloud-load-failed',
+                error: cloudResult.error
+            };
         }
 
         function clearScheduleData() {
@@ -13059,7 +13226,7 @@
         }
 
         // Switch academic year
-        function switchAcademicYear(newYear) {
+        async function switchAcademicYearAsync(newYear) {
             // Save current year's data first
             saveScheduleData();
 
@@ -13067,12 +13234,10 @@
             currentAcademicYear = newYear;
 
             // Reset scheduleData to defaults
-            scheduleData.fall = {};
-            scheduleData.winter = {};
-            scheduleData.spring = {};
+            applyScheduleDataSnapshot(createEmptyAcademicYearScheduleData());
 
-            // Load the new year's data (if any)
-            const hasData = loadScheduleData(newYear);
+            // Load the new year's shared schedule first, then fall back to local draft data.
+            const loadResult = await hydrateScheduleDataForYear(newYear);
             syncDirtyStateForCurrentYear();
 
             // Update quarter tab labels
@@ -13082,14 +13247,22 @@
             const quarter = getCurrentSchedulerQuarter();
 
             renderSchedule(quarter);
+            renderOnlineCourses(quarter);
+            renderArrangedCourses(quarter);
             renderConflicts(quarter);
             updateStats(quarter);
 
-            if (!hasData) {
+            if (!loadResult.hasData) {
                 showToast('Viewing ' + newYear + ' schedule (empty - use Copy to populate)');
+            } else if (loadResult.source === 'local') {
+                showToast(`Switched to ${newYear} schedule (local draft)`, 'warning');
             } else {
                 showToast('Switched to ' + newYear + ' schedule');
             }
+        }
+
+        function switchAcademicYear(newYear) {
+            void switchAcademicYearAsync(newYear);
         }
 
         function updateQuarterTabLabels(year) {
@@ -13379,8 +13552,8 @@
             // Migrate old schedule data format to year-aware format
             migrateOldScheduleData();
 
-            // Load saved schedule data from localStorage
-            loadScheduleData();
+            // Load the shared schedule first, then fall back to a local draft or seeded defaults.
+            await hydrateScheduleDataForYear(currentAcademicYear, { preserveExistingOnEmpty: true });
 
             // Check for imported schedule from schedule builder
             checkForImportedSchedule();

--- a/js/schedule-data-utils.js
+++ b/js/schedule-data-utils.js
@@ -10,6 +10,7 @@
 
     const TOP_LEVEL_ONLINE_KEYS = ['ONLINE', 'online', 'ASYNC', 'async', 'ASYNCHRONOUS', 'asynchronous'];
     const ONLINE_BUCKET_KEY_PATTERN = /^(async|asynchronous|asynch|online|web)$/i;
+    const DEFAULT_QUARTERS = ['fall', 'winter', 'spring'];
 
     function isObject(value) {
         return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
@@ -83,12 +84,171 @@
         return ensureOnlineCourseBucketForQuarter(quarterData);
     }
 
+    function ensureArrangedCourseBucketForQuarter(quarterData) {
+        if (!isObject(quarterData)) {
+            return [];
+        }
+
+        if (!isObject(quarterData.ARRANGED)) {
+            quarterData.ARRANGED = {};
+        }
+
+        if (!Array.isArray(quarterData.ARRANGED.arranged)) {
+            quarterData.ARRANGED.arranged = [];
+        }
+
+        return quarterData.ARRANGED.arranged;
+    }
+
+    function createEmptyQuarterScheduleBucket(dayPatterns) {
+        const bucket = {
+            ONLINE: { async: [] },
+            ARRANGED: { arranged: [] }
+        };
+
+        (Array.isArray(dayPatterns) ? dayPatterns : []).forEach((dayPattern) => {
+            const key = String(dayPattern || '').trim();
+            if (!key || key === 'ONLINE' || key === 'ARRANGED') return;
+            bucket[key] = {};
+        });
+
+        return bucket;
+    }
+
+    function createEmptyAcademicYearScheduleData(options) {
+        const normalizedOptions = isObject(options) ? options : {};
+        const quarters = Array.isArray(normalizedOptions.quarters) && normalizedOptions.quarters.length
+            ? normalizedOptions.quarters
+            : DEFAULT_QUARTERS;
+        const dayPatterns = Array.isArray(normalizedOptions.dayPatterns)
+            ? normalizedOptions.dayPatterns
+            : [];
+        const schedule = {};
+
+        quarters.forEach((quarter) => {
+            const quarterKey = String(quarter || '').trim().toLowerCase();
+            if (!quarterKey) return;
+            schedule[quarterKey] = createEmptyQuarterScheduleBucket(dayPatterns);
+        });
+
+        return schedule;
+    }
+
+    function scheduleHasCourses(scheduleData) {
+        if (!isObject(scheduleData)) {
+            return false;
+        }
+
+        return Object.values(scheduleData).some((quarterData) => {
+            if (!isObject(quarterData)) return false;
+            return flattenQuarterData(quarterData).length > 0;
+        });
+    }
+
+    function buildScheduleDataFromDatabaseRecords(records, options) {
+        const normalizedOptions = isObject(options) ? options : {};
+        const normalizeCourseCode = typeof normalizedOptions.normalizeCourseCode === 'function'
+            ? normalizedOptions.normalizeCourseCode
+            : function(value) {
+                return String(value || '').trim();
+            };
+        const normalizeInstructor = typeof normalizedOptions.normalizeInstructor === 'function'
+            ? normalizedOptions.normalizeInstructor
+            : function(value) {
+                const normalized = String(value || '').trim();
+                return normalized || 'TBD';
+            };
+        const normalizeRoom = typeof normalizedOptions.normalizeRoom === 'function'
+            ? normalizedOptions.normalizeRoom
+            : function(value) {
+                return String(value || '').trim();
+            };
+        const quarters = Array.isArray(normalizedOptions.quarters) && normalizedOptions.quarters.length
+            ? normalizedOptions.quarters
+            : DEFAULT_QUARTERS;
+        const dayPatterns = Array.isArray(normalizedOptions.dayPatterns)
+            ? normalizedOptions.dayPatterns
+            : [];
+        const schedule = createEmptyAcademicYearScheduleData({ quarters, dayPatterns });
+
+        (Array.isArray(records) ? records : []).forEach((record) => {
+            const quarterKey = String(record?.quarter || '').trim().toLowerCase();
+            if (!quarterKey) return;
+
+            if (!isObject(schedule[quarterKey])) {
+                schedule[quarterKey] = createEmptyQuarterScheduleBucket(dayPatterns);
+            }
+
+            const quarterData = schedule[quarterKey];
+            const code = normalizeCourseCode(record?.course?.code || record?.code || record?.course_code || '');
+            if (!code) return;
+
+            const title = String(record?.course?.title || record?.title || record?.name || code).trim();
+            const instructor = normalizeInstructor(record?.faculty?.name || record?.instructor || 'TBD');
+            const credits = Number(record?.course?.default_credits ?? record?.credits);
+            const projectedEnrollment = Number(record?.projected_enrollment ?? record?.projectedEnrollment);
+            const baseCourse = {
+                code,
+                name: title,
+                instructor,
+                credits: Number.isFinite(credits) && credits > 0 ? credits : 5,
+                section: String(record?.section || '').trim()
+            };
+
+            if (Number.isFinite(projectedEnrollment)) {
+                baseCourse.enrollmentCap = projectedEnrollment;
+            }
+
+            const dayPattern = String(record?.day_pattern || record?.day || '').trim().toUpperCase();
+            const timeSlot = String(record?.time_slot || record?.time || '').trim();
+
+            if (dayPattern === 'ONLINE') {
+                ensureOnlineCourseBucketForQuarter(quarterData).push({
+                    ...baseCourse,
+                    room: 'ONLINE'
+                });
+                return;
+            }
+
+            if (dayPattern === 'ARRANGED') {
+                ensureArrangedCourseBucketForQuarter(quarterData).push({
+                    ...baseCourse,
+                    room: 'ARRANGED'
+                });
+                return;
+            }
+
+            if (!dayPattern) return;
+
+            if (!isObject(quarterData[dayPattern])) {
+                quarterData[dayPattern] = {};
+            }
+
+            if (!Array.isArray(quarterData[dayPattern][timeSlot])) {
+                quarterData[dayPattern][timeSlot] = [];
+            }
+
+            quarterData[dayPattern][timeSlot].push({
+                ...baseCourse,
+                room: normalizeRoom(record?.room?.room_code || record?.room_code || record?.room || 'TBD') || 'TBD'
+            });
+        });
+
+        Object.keys(schedule).forEach((quarterKey) => {
+            ensureOnlineCourseBucketForQuarter(schedule[quarterKey]);
+            ensureArrangedCourseBucketForQuarter(schedule[quarterKey]);
+        });
+
+        return schedule;
+    }
+
     function flattenQuarterData(quarterData) {
         if (!isObject(quarterData)) {
             return [];
         }
 
         ensureOnlineCourseBucketForQuarter(quarterData);
+        ensureArrangedCourseBucketForQuarter(quarterData);
 
         const courses = [];
         Object.keys(quarterData).forEach((day) => {
@@ -116,8 +276,11 @@
     }
 
     return {
+        buildScheduleDataFromDatabaseRecords,
+        createEmptyAcademicYearScheduleData,
         ensureOnlineCourseBucketForQuarter,
         getOnlineCoursesForQuarter,
-        flattenQuarterData
+        flattenQuarterData,
+        scheduleHasCourses
     };
 });

--- a/js/supabase-config.js
+++ b/js/supabase-config.js
@@ -33,6 +33,10 @@ function isSupabaseConfigured() {
 }
 
 function initSupabase() {
+    if (supabaseClient) {
+        return supabaseClient;
+    }
+
     if (!isSupabaseConfigured()) {
         console.warn('Supabase not configured. Using local JSON files as fallback.');
         return null;

--- a/tests/schedule-data-utils.online.test.js
+++ b/tests/schedule-data-utils.online.test.js
@@ -1,7 +1,10 @@
 const {
+    buildScheduleDataFromDatabaseRecords,
+    createEmptyAcademicYearScheduleData,
     ensureOnlineCourseBucketForQuarter,
     getOnlineCoursesForQuarter,
-    flattenQuarterData
+    flattenQuarterData,
+    scheduleHasCourses
 } = require('../js/schedule-data-utils.js');
 
 describe('schedule data utils online bucket normalization', () => {
@@ -81,5 +84,80 @@ describe('schedule data utils online bucket normalization', () => {
         });
         expect(quarterData.async).toBeUndefined();
         expect(quarterData.ONLINE.async).toHaveLength(1);
+    });
+
+    test('builds scheduler buckets from Supabase scheduled course rows', () => {
+        const scheduleData = buildScheduleDataFromDatabaseRecords([
+            {
+                quarter: 'fall',
+                day_pattern: 'MW',
+                time_slot: '10:00-12:20',
+                section: '001',
+                projected_enrollment: 24,
+                course: { code: 'desn 216', title: 'Digital Foundations', default_credits: 5 },
+                faculty: { name: 'A. Faculty' },
+                room: { room_code: '206' }
+            },
+            {
+                quarter: 'fall',
+                day_pattern: 'online',
+                time_slot: 'async',
+                section: '002',
+                course: { code: 'DESN 316', title: 'UI Systems', default_credits: 5 },
+                faculty: { name: 'B. Faculty' }
+            },
+            {
+                quarter: 'winter',
+                day_pattern: 'arranged',
+                time_slot: 'arranged',
+                section: '003',
+                course: { code: 'DESN 490', title: 'Capstone', default_credits: 5 },
+                faculty: { name: 'C. Faculty' }
+            }
+        ], {
+            dayPatterns: ['MW', 'TR'],
+            normalizeCourseCode: (value) => String(value || '').trim().toUpperCase().replace(/\s+/g, ' '),
+            normalizeInstructor: (value) => String(value || '').trim() || 'TBD'
+        });
+
+        expect(scheduleData.fall.MW['10:00-12:20']).toEqual([
+            expect.objectContaining({
+                code: 'DESN 216',
+                room: '206',
+                instructor: 'A. Faculty',
+                enrollmentCap: 24
+            })
+        ]);
+        expect(scheduleData.fall.ONLINE.async).toEqual([
+            expect.objectContaining({
+                code: 'DESN 316',
+                room: 'ONLINE',
+                instructor: 'B. Faculty'
+            })
+        ]);
+        expect(scheduleData.winter.ARRANGED.arranged).toEqual([
+            expect.objectContaining({
+                code: 'DESN 490',
+                room: 'ARRANGED',
+                instructor: 'C. Faculty'
+            })
+        ]);
+    });
+
+    test('scheduleHasCourses distinguishes empty and populated schedule snapshots', () => {
+        const emptySchedule = createEmptyAcademicYearScheduleData({ dayPatterns: ['MW', 'TR'] });
+        const populatedSchedule = buildScheduleDataFromDatabaseRecords([
+            {
+                quarter: 'spring',
+                day_pattern: 'ONLINE',
+                time_slot: 'async',
+                course: { code: 'DESN 379', title: 'Web Dev 2', default_credits: 5 }
+            }
+        ], {
+            dayPatterns: ['MW', 'TR']
+        });
+
+        expect(scheduleHasCourses(emptySchedule)).toBe(false);
+        expect(scheduleHasCourses(populatedSchedule)).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- load the scheduler from Supabase on the stable `main` UI before falling back to browser-local drafts
- rebuild quarter buckets from `scheduled_courses` rows and refresh the local cache from the shared copy
- re-render online and arranged sections on quarter changes so async courses show under the grid in this production-style surface
- guard Supabase client initialization and extend the online bucket regression tests

## Testing
- npm ci
- npx jest tests/schedule-data-utils.online.test.js --runInBand
- npx jest tests/schedule-save-reload-ay2627.test.js --runInBand
- npx jest tests/db-service.atomic-save.test.js --runInBand
- Playwright check at http://127.0.0.1:8083/index.html after seeding stale `designSchedulerData_2025-26`: reload hydrated 2025-26 from Supabase, removed the local-only marker, and Winter 2026 rendered 3 async courses under the grid on the stable UI

Closes #234