### PR TITLE
Fix catalog source drift on production surfaces

### DIFF
--- a/data/course-catalog.json
+++ b/data/course-catalog.json
@@ -1,11 +1,11 @@
 {
   "version": "1.0",
-  "lastModified": "2025-12-02",
+  "lastModified": "2026-04-20",
   "department": "Design",
   "courses": [
     {
       "code": "DESN 100",
-      "title": "Introduction to Design",
+      "title": "Drawing for Communication",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "100",
@@ -17,7 +17,7 @@
     },
     {
       "code": "DESN 200",
-      "title": "Visual Communication I",
+      "title": "Visual Thinking + Making",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "200",
@@ -25,7 +25,8 @@
         "Fall",
         "Winter",
         "Spring"
-      ]
+      ],
+      "notes": "BACR: humanities/arts"
     },
     {
       "code": "DESN 216",
@@ -37,7 +38,8 @@
         "Fall",
         "Winter",
         "Spring"
-      ]
+      ],
+      "notes": "Gateway course - unlocks most 300-level courses"
     },
     {
       "code": "DESN 243",
@@ -49,6 +51,10 @@
         "Fall",
         "Winter",
         "Spring"
+      ],
+      "prerequisites": [
+        "DESN 100",
+        "DESN 216"
       ]
     },
     {
@@ -61,6 +67,241 @@
         "Fall",
         "Winter",
         "Spring"
+      ],
+      "prerequisites": [
+        "DESN 100",
+        "DESN 216"
+      ]
+    },
+    {
+      "code": "DESN 213",
+      "title": "Photoshop",
+      "defaultCredits": 2,
+      "typicalEnrollmentCap": 24,
+      "level": "200",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "notes": "Self-paced"
+    },
+    {
+      "code": "DESN 214",
+      "title": "Illustrator",
+      "defaultCredits": 2,
+      "typicalEnrollmentCap": 24,
+      "level": "200",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "notes": "Self-paced"
+    },
+    {
+      "code": "DESN 215",
+      "title": "InDesign",
+      "defaultCredits": 2,
+      "typicalEnrollmentCap": 24,
+      "level": "200",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "notes": "Self-paced"
+    },
+    {
+      "code": "DESN 217",
+      "title": "Figma",
+      "defaultCredits": 2,
+      "typicalEnrollmentCap": 24,
+      "level": "200",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "notes": "Self-paced"
+    },
+    {
+      "code": "DESN 210",
+      "title": "Design Lab",
+      "defaultCredits": 2,
+      "typicalEnrollmentCap": 24,
+      "level": "200",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ]
+    },
+    {
+      "code": "DESN 368",
+      "title": "Code + Design 1",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Fall"
+      ],
+      "prerequisites": [
+        "DESN 216"
+      ],
+      "required": true,
+      "notes": "Required course starting 2026-27. Required for senior capstone. | Required course starting 2026-27 academic year"
+    },
+    {
+      "code": "DESN 369",
+      "title": "Web Development 1",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Winter"
+      ],
+      "prerequisites": [
+        "DESN 216",
+        "DESN 368"
+      ],
+      "notes": "Requires DESN-368 (Fall→Winter sequence) starting 2026-27 | Requires DESN 368 (Fall→Winter sequence)"
+    },
+    {
+      "code": "DESN 378",
+      "title": "Code + Design 2",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Fall",
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 368"
+      ]
+    },
+    {
+      "code": "DESN 379",
+      "title": "Web Development 2",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 369"
+      ]
+    },
+    {
+      "code": "DESN 325",
+      "title": "Emergent Design",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 216"
+      ],
+      "notes": "Repeatable"
+    },
+    {
+      "code": "DESN 374",
+      "title": "AI + Design",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Winter"
+      ],
+      "prerequisites": [
+        "DESN 216"
+      ]
+    },
+    {
+      "code": "DESN 326",
+      "title": "Introduction to Animation",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Winter",
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 200",
+        "DESN 216"
+      ]
+    },
+    {
+      "code": "DESN 336",
+      "title": "3D Animation",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Winter",
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 326"
+      ]
+    },
+    {
+      "code": "DESN 355",
+      "title": "Motion Design",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Winter"
+      ],
+      "prerequisites": [
+        "DESN 200",
+        "DESN 216"
+      ]
+    },
+    {
+      "code": "DESN 365",
+      "title": "Motion Design 2",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Fall",
+        "Winter"
+      ],
+      "prerequisites": [
+        "DESN 355"
+      ]
+    },
+    {
+      "code": "DESN 338",
+      "title": "User Experience Design 1",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Fall",
+        "Winter"
+      ]
+    },
+    {
+      "code": "DESN 348",
+      "title": "User Experience Design 2",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Winter"
+      ],
+      "prerequisites": [
+        "DESN 338"
       ]
     },
     {
@@ -73,45 +314,14 @@
         "Fall",
         "Winter",
         "Spring"
-      ]
-    },
-    {
-      "code": "DESN 305",
-      "title": "Social Media Design",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Fall",
-        "Winter"
-      ]
-    },
-    {
-      "code": "DESN 325",
-      "title": "Motion Graphics I",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Fall",
-        "Winter",
-        "Spring"
-      ]
-    },
-    {
-      "code": "DESN 326",
-      "title": "Motion Graphics II",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Winter",
-        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 100"
       ]
     },
     {
       "code": "DESN 335",
-      "title": "Web Design I",
+      "title": "Board Game Design",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "300",
@@ -119,33 +329,27 @@
         "Fall",
         "Winter",
         "Spring"
-      ]
+      ],
+      "standingRequired": "junior"
     },
     {
-      "code": "DESN 336",
-      "title": "Web Design II",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Winter",
-        "Spring"
-      ]
-    },
-    {
-      "code": "DESN 338",
-      "title": "Interactive Design",
+      "code": "DESN 345",
+      "title": "Digital Game Design",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "300",
       "offeredQuarters": [
         "Fall",
-        "Winter"
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 301",
+        "DESN 326"
       ]
     },
     {
       "code": "DESN 343",
-      "title": "Typography II",
+      "title": "Typography 2",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "300",
@@ -153,76 +357,14 @@
         "Fall",
         "Winter",
         "Spring"
-      ]
-    },
-    {
-      "code": "DESN 345",
-      "title": "Publication Design",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Fall",
-        "Spring"
-      ]
-    },
-    {
-      "code": "DESN 348",
-      "title": "Packaging Design",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Winter"
-      ]
-    },
-    {
-      "code": "DESN 350",
-      "title": "Brand Identity Design",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Fall",
-        "Winter",
-        "Spring"
-      ]
-    },
-    {
-      "code": "DESN 351",
-      "title": "Advanced Brand Identity",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Spring"
-      ]
-    },
-    {
-      "code": "DESN 355",
-      "title": "Environmental Graphics",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Winter"
-      ]
-    },
-    {
-      "code": "DESN 359",
-      "title": "Design Studio I",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Fall",
-        "Winter",
-        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 243"
       ]
     },
     {
       "code": "DESN 360",
-      "title": "Design Studio II",
+      "title": "Zine and Publication Design",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "300",
@@ -230,125 +372,67 @@
         "Fall",
         "Winter",
         "Spring"
-      ]
-    },
-    {
-      "code": "DESN 363",
-      "title": "User Experience Design II",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Fall",
-        "Winter",
-        "Spring"
-      ]
-    },
-    {
-      "code": "DESN 365",
-      "title": "UX Research Methods",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Fall",
-        "Winter"
-      ]
-    },
-    {
-      "code": "DESN 366",
-      "title": "UI Design",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Winter",
-        "Spring"
-      ]
-    },
-    {
-      "code": "DESN 368",
-      "title": "Interaction Design",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Fall"
-      ],
-      "required": true,
-      "notes": "Required course starting 2026-27 academic year"
-    },
-    {
-      "code": "DESN 369",
-      "title": "Advanced UX",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Winter"
       ],
       "prerequisites": [
-        "DESN 368"
-      ],
-      "notes": "Requires DESN 368 (Fall\u2192Winter sequence)"
-    },
-    {
-      "code": "DESN 374",
-      "title": "Design for Social Good",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Winter"
+        "DESN 200"
       ]
     },
     {
-      "code": "DESN 378",
-      "title": "Data Visualization",
+      "code": "DESN 350",
+      "title": "Digital Photography",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "300",
       "offeredQuarters": [
         "Fall",
+        "Winter",
         "Spring"
-      ]
+      ],
+      "standingRequired": "junior"
     },
     {
-      "code": "DESN 379",
-      "title": "Advanced Data Visualization",
+      "code": "DESN 351",
+      "title": "Advanced Photography",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "300",
       "offeredQuarters": [
         "Spring"
+      ],
+      "prerequisites": [
+        "DESN 350"
+      ]
+    },
+    {
+      "code": "DESN 375",
+      "title": "Digital Video",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 216"
       ]
     },
     {
       "code": "DESN 384",
       "title": "Digital Sound",
       "defaultCredits": 5,
-      "defaultModality": "online",
       "typicalEnrollmentCap": 24,
       "level": "300",
       "offeredQuarters": [
         "Winter",
         "Spring"
-      ]
+      ],
+      "standingRequired": "junior"
     },
     {
-      "code": "DESN 385",
-      "title": "Design Portfolio",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "300",
-      "offeredQuarters": [
-        "Winter",
-        "Spring"
-      ]
-    },
-    {
-      "code": "DESN 396",
-      "title": "Special Topics",
+      "code": "DESN 359",
+      "title": "Histories of Design",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "300",
@@ -356,7 +440,70 @@
         "Fall",
         "Winter",
         "Spring"
+      ],
+      "prerequisites": [
+        "ENGL 201"
+      ],
+      "notes": "Diversity requirement"
+    },
+    {
+      "code": "DESN 305",
+      "title": "Social Media Design and Management",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Fall",
+        "Winter"
+      ],
+      "prerequisites": [
+        "DESN 216"
       ]
+    },
+    {
+      "code": "DESN 366",
+      "title": "Production Design",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Winter",
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 243",
+        "DESN 263"
+      ]
+    },
+    {
+      "code": "DESN 396",
+      "title": "Experimental Course",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "notes": "repeatable",
+      "creditRange": "1-5",
+      "isVariable": true
+    },
+    {
+      "code": "DESN 398",
+      "title": "Seminar",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "300",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "notes": "repeatable",
+      "creditRange": "1-6",
+      "isVariable": true
     },
     {
       "code": "DESN 399",
@@ -369,35 +516,84 @@
         "Winter",
         "Spring"
       ],
+      "notes": "repeatable",
+      "creditRange": "1-10",
       "isVariable": true,
       "workloadMultiplier": 0.2
     },
     {
-      "code": "DESN 401",
-      "title": "Senior Design Studio",
+      "code": "DESN 468",
+      "title": "Code + Design 3",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "400",
       "offeredQuarters": [
-        "Fall",
         "Winter",
         "Spring"
+      ],
+      "prerequisites": [
+        "DESN 378"
+      ]
+    },
+    {
+      "code": "DESN 469",
+      "title": "Web Development 3",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "400",
+      "offeredQuarters": [
+        "Fall"
+      ],
+      "prerequisites": [
+        "DESN 379"
+      ]
+    },
+    {
+      "code": "DESN 446",
+      "title": "4D Animation",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "400",
+      "offeredQuarters": [
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 336",
+        "DESN 365"
       ]
     },
     {
       "code": "DESN 458",
-      "title": "Advanced Design Topics",
+      "title": "User Experience Design 3",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "400",
       "offeredQuarters": [
         "Fall",
         "Winter"
+      ],
+      "prerequisites": [
+        "DESN 348"
+      ]
+    },
+    {
+      "code": "DESN 401",
+      "title": "Imaginary Worlds",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "400",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 301"
       ]
     },
     {
       "code": "DESN 463",
-      "title": "User Experience Design III",
+      "title": "Community-Driven Design",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "400",
@@ -405,44 +601,43 @@
         "Fall",
         "Winter",
         "Spring"
-      ]
-    },
-    {
-      "code": "DESN 468",
-      "title": "Advanced Interaction Design",
-      "defaultCredits": 5,
-      "typicalEnrollmentCap": 24,
-      "level": "400",
-      "offeredQuarters": [
-        "Winter",
-        "Spring"
+      ],
+      "prerequisites": [
+        "DESN 243",
+        "DESN 263"
       ]
     },
     {
       "code": "DESN 480",
-      "title": "Design Capstone",
+      "title": "Professional Practice",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "400",
       "offeredQuarters": [
         "Spring"
-      ]
+      ],
+      "standingRequired": "senior"
     },
     {
       "code": "DESN 490",
-      "title": "Senior Seminar",
-      "defaultCredits": 2,
+      "title": "Senior Capstone",
+      "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "400",
       "offeredQuarters": [
         "Fall",
         "Winter",
         "Spring"
-      ]
+      ],
+      "prerequisites": [
+        "DESN 368"
+      ],
+      "standingRequired": "senior",
+      "notes": "Capstone requirement"
     },
     {
       "code": "DESN 491",
-      "title": "Practicum",
+      "title": "Senior Project",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 10,
       "level": "400",
@@ -451,20 +646,23 @@
         "Winter",
         "Spring"
       ],
+      "notes": "Pass/Fail",
+      "creditRange": "1-10",
       "isVariable": true,
       "workloadMultiplier": 0.2
     },
     {
       "code": "DESN 493",
-      "title": "Senior Project",
-      "defaultCredits": 5,
+      "title": "Portfolio Practice",
+      "defaultCredits": 2,
       "typicalEnrollmentCap": 24,
       "level": "400",
       "offeredQuarters": [
         "Fall",
         "Winter",
         "Spring"
-      ]
+      ],
+      "notes": "Repeatable"
     },
     {
       "code": "DESN 495",
@@ -478,12 +676,15 @@
         "Spring",
         "Summer"
       ],
+      "standingRequired": "junior",
+      "notes": "Pass/Fail",
+      "creditRange": "2-15",
       "isVariable": true,
       "workloadMultiplier": 0.1
     },
     {
       "code": "DESN 496",
-      "title": "Experimental Topics",
+      "title": "Experimental",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 24,
       "level": "400",
@@ -491,11 +692,44 @@
         "Fall",
         "Winter",
         "Spring"
-      ]
+      ],
+      "notes": "repeatable",
+      "creditRange": "1-6",
+      "isVariable": true
+    },
+    {
+      "code": "DESN 497",
+      "title": "Workshop, Short Course, Conference, Seminar",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "400",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "notes": "repeatable",
+      "creditRange": "1-6",
+      "isVariable": true
+    },
+    {
+      "code": "DESN 498",
+      "title": "Seminar",
+      "defaultCredits": 5,
+      "typicalEnrollmentCap": 24,
+      "level": "400",
+      "offeredQuarters": [
+        "Fall",
+        "Winter",
+        "Spring"
+      ],
+      "notes": "repeatable",
+      "creditRange": "1-6",
+      "isVariable": true
     },
     {
       "code": "DESN 499",
-      "title": "Independent Study",
+      "title": "Directed Study",
       "defaultCredits": 5,
       "typicalEnrollmentCap": 10,
       "level": "400",
@@ -505,6 +739,8 @@
         "Spring",
         "Summer"
       ],
+      "notes": "repeatable",
+      "creditRange": "1-6",
       "isVariable": true,
       "workloadMultiplier": 0.2
     }

--- a/index.html
+++ b/index.html
@@ -4463,7 +4463,8 @@
     <!-- Supabase -->
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="js/department-profile.js"></script>
-    <script type="module" src="js/supabase-config.js"></script>
+    <script src="js/supabase-config.js"></script>
+    <script src="js/db-service.js"></script>
     <script src="js/auth-service.js"></script>
     <script src="js/auth-guard.js"></script>
     <script src="js/dirty-state-tracker.js"></script>

--- a/js/db-service.js
+++ b/js/db-service.js
@@ -975,6 +975,10 @@ const dbService = {
     }
 };
 
+if (typeof window !== 'undefined') {
+    window.dbService = dbService;
+}
+
 // Export for use in other scripts
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = dbService;

--- a/js/demand-predictor.js
+++ b/js/demand-predictor.js
@@ -10,6 +10,36 @@ const DemandPredictor = (function() {
     let enrollmentData = null;
     let catalogData = null;
 
+    function getRuntimeDbService() {
+        if (typeof window !== 'undefined'
+            && window.dbService
+            && typeof window.dbService.getCourses === 'function') {
+            return window.dbService;
+        }
+
+        return null;
+    }
+
+    function normalizeCatalogEntry(course = {}) {
+        return {
+            code: String(course.code || '').trim(),
+            title: String(course.title || course.name || '').trim(),
+            typicalEnrollmentCap: Number(course.typicalEnrollmentCap ?? course.typical_cap) || CONFIG.defaultEnrollmentCap
+        };
+    }
+
+    function normalizeCatalogData(input) {
+        const courses = Array.isArray(input?.courses)
+            ? input.courses
+            : Array.isArray(input)
+                ? input
+                : [];
+
+        return courses
+            .map((course) => normalizeCatalogEntry(course))
+            .filter((course) => course.code);
+    }
+
     // Configuration
     const CONFIG = {
         defaultEnrollmentCap: 24,
@@ -39,20 +69,40 @@ const DemandPredictor = (function() {
                 });
             }
 
-            // Load enrollment data directly for additional analysis
-            const enrollmentPath = options.enrollmentPath || 'enrollment-dashboard-data.json';
-            const enrollmentResponse = await fetch(enrollmentPath);
-            if (enrollmentResponse.ok) {
-                const data = await enrollmentResponse.json();
-                enrollmentData = data.courseStats || {};
+            if (options.enrollmentData) {
+                enrollmentData = options.enrollmentData.courseStats || options.enrollmentData;
+            } else {
+                const enrollmentPath = options.enrollmentPath || 'enrollment-dashboard-data.json';
+                const enrollmentResponse = await fetch(enrollmentPath);
+                if (enrollmentResponse.ok) {
+                    const data = await enrollmentResponse.json();
+                    enrollmentData = data.courseStats || {};
+                }
             }
 
-            // Load course catalog
-            const catalogPath = options.catalogPath || 'data/course-catalog.json';
-            const catalogResponse = await fetch(catalogPath);
-            if (catalogResponse.ok) {
-                const data = await catalogResponse.json();
-                catalogData = data.courses || data;
+            if (options.catalogData) {
+                catalogData = normalizeCatalogData(options.catalogData);
+            } else {
+                const runtimeDbService = getRuntimeDbService();
+                if (runtimeDbService) {
+                    try {
+                        const courses = await runtimeDbService.getCourses();
+                        catalogData = normalizeCatalogData({ courses });
+                    } catch (error) {
+                        console.warn('Could not load demand predictor catalog from dbService:', error);
+                    }
+                }
+
+                if (!catalogData) {
+                    const catalogPath = options.catalogPath || 'data/course-catalog.json';
+                    const catalogResponse = await fetch(catalogPath);
+                    if (catalogResponse.ok) {
+                        const data = await catalogResponse.json();
+                        catalogData = normalizeCatalogData(data);
+                    } else {
+                        catalogData = [];
+                    }
+                }
             }
 
             initialized = true;

--- a/js/schedule-analyzer.js
+++ b/js/schedule-analyzer.js
@@ -6,6 +6,47 @@
 const ScheduleAnalyzer = (function() {
     'use strict';
 
+    function getRuntimeDbService() {
+        if (typeof window !== 'undefined'
+            && window.dbService
+            && typeof window.dbService.getCourses === 'function') {
+            return window.dbService;
+        }
+
+        return null;
+    }
+
+    function normalizeCourseCatalogEntry(course = {}) {
+        return {
+            code: String(course.code || '').trim(),
+            title: String(course.title || course.name || '').trim(),
+            defaultCredits: Number(course.defaultCredits ?? course.default_credits) || 5,
+            typicalEnrollmentCap: Number(course.typicalEnrollmentCap ?? course.typical_cap) || CONFIG.defaultEnrollmentCap,
+            level: String(course.level || '').trim(),
+            offeredQuarters: Array.isArray(course.offeredQuarters)
+                ? course.offeredQuarters
+                : Array.isArray(course.quarters_offered)
+                    ? course.quarters_offered
+                    : ['Fall', 'Winter', 'Spring'],
+            required: course.required === true,
+            prerequisites: Array.isArray(course.prerequisites) ? course.prerequisites.slice() : []
+        };
+    }
+
+    function normalizeCourseCatalog(input) {
+        const courses = Array.isArray(input?.courses)
+            ? input.courses
+            : Array.isArray(input)
+                ? input
+                : [];
+
+        return {
+            courses: courses
+                .map((course) => normalizeCourseCatalogEntry(course))
+                .filter((course) => course.code)
+        };
+    }
+
     // Configuration
     const CONFIG = {
         enrollmentThresholds: {
@@ -27,32 +68,56 @@ const ScheduleAnalyzer = (function() {
     /**
      * Initialize analyzer with data sources
      */
-    async function init() {
+    async function init(options = {}) {
         try {
-            // Load enrollment dashboard data
-            const enrollmentResponse = await fetch('../enrollment-dashboard-data.json');
-            if (enrollmentResponse.ok) {
-                enrollmentData = await enrollmentResponse.json();
+            if (options.enrollmentData) {
+                enrollmentData = options.enrollmentData;
                 console.log('Enrollment data loaded for analyzer');
+            } else {
+                const enrollmentResponse = await fetch('../enrollment-dashboard-data.json');
+                if (enrollmentResponse.ok) {
+                    enrollmentData = await enrollmentResponse.json();
+                    console.log('Enrollment data loaded for analyzer');
+                }
             }
 
-            // Load course catalog
-            const catalogResponse = await fetch('../data/course-catalog.json');
-            if (catalogResponse.ok) {
-                courseCatalog = await catalogResponse.json();
+            if (options.courseCatalogData) {
+                courseCatalog = normalizeCourseCatalog(options.courseCatalogData);
                 console.log('Course catalog loaded for analyzer');
+            } else {
+                const runtimeDbService = getRuntimeDbService();
+                if (runtimeDbService) {
+                    try {
+                        const courses = await runtimeDbService.getCourses();
+                        courseCatalog = normalizeCourseCatalog({ courses });
+                    } catch (error) {
+                        console.warn('Could not load analyzer catalog from dbService:', error);
+                    }
+                }
+
+                if (!courseCatalog) {
+                    const catalogResponse = await fetch('../data/course-catalog.json');
+                    if (catalogResponse.ok) {
+                        courseCatalog = normalizeCourseCatalog(await catalogResponse.json());
+                        console.log('Course catalog loaded for analyzer');
+                    }
+                }
             }
 
-            // Load prerequisite graph
-            const prereqResponse = await fetch('../data/prerequisite-graph.json');
-            if (prereqResponse.ok) {
-                prerequisiteGraph = await prereqResponse.json();
+            if (options.prerequisiteGraphData) {
+                prerequisiteGraph = options.prerequisiteGraphData;
                 console.log('Prerequisite graph loaded for analyzer');
+            } else {
+                const prereqResponse = await fetch('../data/prerequisite-graph.json');
+                if (prereqResponse.ok) {
+                    prerequisiteGraph = await prereqResponse.json();
+                    console.log('Prerequisite graph loaded for analyzer');
+                }
             }
 
             // Initialize constraints engine if available
             if (typeof ConstraintsEngine !== 'undefined') {
-                await ConstraintsEngine.init('../data/scheduling-rules.json');
+                await ConstraintsEngine.init(options.constraintRules || '../data/scheduling-rules.json');
                 console.log('Constraints engine loaded for analyzer');
             }
 

--- a/js/schedule-generator.js
+++ b/js/schedule-generator.js
@@ -11,6 +11,47 @@ const ScheduleGenerator = (function() {
     let catalogData = null;
     let enrollmentData = null;
 
+    function getRuntimeDbService() {
+        if (typeof window !== 'undefined'
+            && window.dbService
+            && typeof window.dbService.getCourses === 'function') {
+            return window.dbService;
+        }
+
+        return null;
+    }
+
+    function normalizeCatalogCourse(course = {}) {
+        return {
+            code: String(course.code || '').trim(),
+            title: String(course.title || course.name || '').trim(),
+            defaultCredits: Number(course.defaultCredits ?? course.default_credits) || 5,
+            typicalEnrollmentCap: Number(course.typicalEnrollmentCap ?? course.typical_cap) || CONFIG.defaultEnrollmentCap,
+            level: String(course.level || '').trim(),
+            offeredQuarters: Array.isArray(course.offeredQuarters)
+                ? course.offeredQuarters
+                : Array.isArray(course.quarters_offered)
+                    ? course.quarters_offered
+                    : ['Fall', 'Winter', 'Spring'],
+            workloadMultiplier: Number(course.workloadMultiplier ?? course.workload_multiplier) || 1,
+            isVariable: course.isVariable === true || course.is_variable === true
+        };
+    }
+
+    function normalizeCatalogData(input) {
+        const courses = Array.isArray(input?.courses)
+            ? input.courses
+            : Array.isArray(input)
+                ? input
+                : [];
+
+        return {
+            courses: courses
+                .map((course) => normalizeCatalogCourse(course))
+                .filter((course) => course.code)
+        };
+    }
+
     // Configuration
     const CONFIG = {
         defaultEnrollmentCap: 24,
@@ -29,25 +70,48 @@ const ScheduleGenerator = (function() {
      */
     async function init(options = {}) {
         try {
-            // Load workload data
-            const workloadPath = options.workloadPath || '../workload-data.json';
-            const workloadResponse = await fetch(workloadPath);
-            if (workloadResponse.ok) {
-                workloadData = await workloadResponse.json();
+            if (options.workloadData) {
+                workloadData = options.workloadData;
+            } else {
+                const workloadPath = options.workloadPath || '../workload-data.json';
+                const workloadResponse = await fetch(workloadPath);
+                if (workloadResponse.ok) {
+                    workloadData = await workloadResponse.json();
+                }
             }
 
-            // Load course catalog
-            const catalogPath = options.catalogPath || '../data/course-catalog.json';
-            const catalogResponse = await fetch(catalogPath);
-            if (catalogResponse.ok) {
-                catalogData = await catalogResponse.json();
+            if (options.catalogData) {
+                catalogData = normalizeCatalogData(options.catalogData);
+            } else {
+                const runtimeDbService = getRuntimeDbService();
+                if (runtimeDbService) {
+                    try {
+                        const courses = await runtimeDbService.getCourses();
+                        catalogData = normalizeCatalogData({ courses });
+                    } catch (error) {
+                        console.warn('Could not load schedule generator catalog from dbService:', error);
+                    }
+                }
+
+                if (!catalogData) {
+                    const catalogPath = options.catalogPath || '../data/course-catalog.json';
+                    const catalogResponse = await fetch(catalogPath);
+                    if (catalogResponse.ok) {
+                        catalogData = normalizeCatalogData(await catalogResponse.json());
+                    } else {
+                        catalogData = { courses: [] };
+                    }
+                }
             }
 
-            // Load enrollment data
-            const enrollmentPath = options.enrollmentPath || '../enrollment-dashboard-data.json';
-            const enrollmentResponse = await fetch(enrollmentPath);
-            if (enrollmentResponse.ok) {
-                enrollmentData = await enrollmentResponse.json();
+            if (options.enrollmentData) {
+                enrollmentData = options.enrollmentData;
+            } else {
+                const enrollmentPath = options.enrollmentPath || '../enrollment-dashboard-data.json';
+                const enrollmentResponse = await fetch(enrollmentPath);
+                if (enrollmentResponse.ok) {
+                    enrollmentData = await enrollmentResponse.json();
+                }
             }
 
             initialized = true;

--- a/js/schedule-manager.js
+++ b/js/schedule-manager.js
@@ -7,6 +7,47 @@
 const ScheduleManager = (function() {
     'use strict';
 
+    function getRuntimeDbService() {
+        if (typeof window !== 'undefined'
+            && window.dbService
+            && typeof window.dbService.getCourses === 'function') {
+            return window.dbService;
+        }
+
+        return null;
+    }
+
+    function normalizeCourseCatalogEntry(course = {}) {
+        const offeredQuarters = Array.isArray(course.offeredQuarters)
+            ? course.offeredQuarters
+            : Array.isArray(course.quarters_offered)
+                ? course.quarters_offered
+                : ['Fall', 'Winter', 'Spring'];
+
+        return {
+            code: String(course.code || '').trim(),
+            title: String(course.title || course.name || '').trim(),
+            defaultCredits: Number(course.defaultCredits ?? course.default_credits) || 5,
+            typicalEnrollmentCap: Number(course.typicalEnrollmentCap ?? course.typical_cap) || 24,
+            level: String(course.level || '').trim(),
+            offeredQuarters,
+            prerequisites: Array.isArray(course.prerequisites) ? course.prerequisites.slice() : [],
+            required: course.required === true,
+            workloadMultiplier: Number(course.workloadMultiplier ?? course.workload_multiplier) || 1,
+            isVariable: course.isVariable === true || course.is_variable === true,
+            standingRequired: String(course.standingRequired ?? course.standing_required ?? '').trim() || null,
+            notes: String(course.notes || '').trim() || null,
+            defaultModality: String(course.defaultModality ?? course.default_modality ?? '').trim() || null,
+            creditRange: String(course.creditRange ?? course.credit_range ?? '').trim() || null
+        };
+    }
+
+    function normalizeCourseCatalog(courses = []) {
+        return (Array.isArray(courses) ? courses : [])
+            .map((course) => normalizeCourseCatalogEntry(course))
+            .filter((course) => course.code);
+    }
+
     // Get constants if available
     const getConstants = () => {
         const profileLoader =
@@ -126,7 +167,7 @@ const ScheduleManager = (function() {
         loadFromStorage();
 
         // Load course catalog
-        if (options.catalogPath) {
+        if (options.catalogPath || getRuntimeDbService()) {
             await loadCourseCatalog(options.catalogPath);
         }
 
@@ -143,17 +184,34 @@ const ScheduleManager = (function() {
      * @param {string} path - Path to course-catalog.json
      */
     async function loadCourseCatalog(path = '../data/course-catalog.json') {
+        const runtimeDbService = getRuntimeDbService();
+
+        if (runtimeDbService) {
+            try {
+                const data = await runtimeDbService.getCourses();
+                courseCatalog = normalizeCourseCatalog(data);
+                console.log(`✅ Loaded ${courseCatalog.length} courses from shared runtime service`);
+                return courseCatalog;
+            } catch (error) {
+                console.warn('⚠️ Could not load course catalog from shared runtime service:', error.message);
+            }
+        }
+
         try {
             const response = await fetch(path);
             if (response.ok) {
                 const data = await response.json();
-                courseCatalog = data.courses || [];
+                courseCatalog = normalizeCourseCatalog(data.courses || data);
                 console.log(`✅ Loaded ${courseCatalog.length} courses from catalog`);
+            } else {
+                courseCatalog = [];
             }
         } catch (error) {
             console.warn('⚠️ Could not load course catalog:', error.message);
             courseCatalog = [];
         }
+
+        return courseCatalog;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "sync:course-catalog": "node scripts/sync-course-catalog.cjs",
     "process-data": "node scripts/process-enrollment-data.js",
     "calculate-workload": "node scripts/workload-calculator.js enrollment-data/processed",
     "validate-data": "node scripts/validate-enrollment.js enrollment-data/processed/corrected-all-quarters.csv",

--- a/pages/demand-planning-dashboard.html
+++ b/pages/demand-planning-dashboard.html
@@ -570,6 +570,9 @@
     </div>
 
     <!-- Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="../js/supabase-config.js"></script>
+    <script src="../js/db-service.js"></script>
     <script src="../js/prerequisite-graph.js"></script>
     <script src="../js/demand-predictor.js"></script>
     <script>
@@ -586,8 +589,7 @@
             // Initialize predictor
             const result = await DemandPredictor.init({
                 graphPath: '../data/prerequisite-graph.json',
-                enrollmentPath: '../enrollment-dashboard-data.json',
-                catalogPath: '../data/course-catalog.json'
+                enrollmentPath: '../enrollment-dashboard-data.json'
             });
 
             if (!result.success) {

--- a/pages/schedule-builder.js
+++ b/pages/schedule-builder.js
@@ -613,27 +613,38 @@ document.addEventListener('DOMContentLoaded', async function() {
             console.log('Room constraints loaded:', roomConstraints);
         }
 
-        // Load course catalog for offering patterns
-        const catalogResponse = await fetch('../data/course-catalog.json');
-        if (catalogResponse.ok) {
-            courseCatalog = await catalogResponse.json();
-            console.log('Course catalog loaded:', courseCatalog.courses?.length, 'courses');
-        }
-
-        // Load courses from database for constraints (if dbService is available)
-        if (typeof dbService !== 'undefined') {
+        // Prefer shared DB service for catalog; keep JSON as fallback.
+        if (typeof dbService !== 'undefined' && typeof dbService.getCourses === 'function') {
             try {
                 dbCourses = await dbService.getCourses();
-                console.log('Database courses loaded:', dbCourses?.length || 0, 'courses');
+                if (dbCourses.length > 0) {
+                    courseCatalog = { courses: dbCourses };
+                    console.log('Course catalog loaded via dbService:', dbCourses.length, 'courses');
+                }
             } catch (err) {
                 console.warn('Could not load courses from database:', err);
             }
         }
 
+        if (!courseCatalog) {
+            const catalogResponse = await fetch('../data/course-catalog.json');
+            if (catalogResponse.ok) {
+                courseCatalog = await catalogResponse.json();
+                console.log('Course catalog loaded from fallback file:', courseCatalog.courses?.length, 'courses');
+            } else {
+                courseCatalog = { courses: [] };
+            }
+        }
+
+        // Ensure constraints engine can still consume DB courses when available.
+        if (!Array.isArray(dbCourses) || dbCourses.length === 0) {
+            dbCourses = Array.isArray(courseCatalog?.courses) ? courseCatalog.courses : [];
+        }
+
         if (typeof ScheduleGenerator !== 'undefined') {
             await ScheduleGenerator.init({
                 workloadPath: '../workload-data.json',
-                catalogPath: '../data/course-catalog.json',
+                catalogData: courseCatalog,
                 enrollmentPath: '../enrollment-dashboard-data.json'
             });
         }
@@ -642,7 +653,7 @@ document.addEventListener('DOMContentLoaded', async function() {
             await DemandPredictor.init({
                 graphPath: '../data/prerequisite-graph.json',
                 enrollmentPath: '../enrollment-dashboard-data.json',
-                catalogPath: '../data/course-catalog.json'
+                catalogData: courseCatalog?.courses || []
             });
         }
 

--- a/pages/schedule-editor.html
+++ b/pages/schedule-editor.html
@@ -12,6 +12,9 @@
     <link rel="stylesheet" href="../css/program-command-dashboard-theme.css">
 
     <!-- Utility Scripts -->
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="../js/supabase-config.js"></script>
+    <script src="../js/db-service.js"></script>
     <script src="../js/profile-loader.js"></script>
     <script src="../js/config/constants.js"></script>
     <script src="../js/dom-utils.js"></script>

--- a/pages/schedule-editor.js
+++ b/pages/schedule-editor.js
@@ -38,11 +38,8 @@ document.addEventListener('DOMContentLoaded', async () => {
  */
 async function loadData() {
     try {
-        // Initialize ScheduleManager with catalog
-        await ScheduleManager.init({ catalogPath: '../data/course-catalog.json' });
-
-        // Also load catalog explicitly to ensure it's available
-        await ScheduleManager.loadCourseCatalog('../data/course-catalog.json');
+        // Initialize ScheduleManager with the shared DB-aware course loader
+        await ScheduleManager.init();
 
         // Load workload data
         workloadData = await loadWorkloadData('../data/workload-data.json');

--- a/pages/workload-dashboard.html
+++ b/pages/workload-dashboard.html
@@ -570,6 +570,7 @@
     <script src="./workload-dashboard.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
     <script src="../js/supabase-config.js"></script>
+    <script src="../js/db-service.js"></script>
     <script src="../js/auth-service.js"></script>
     <script src="../js/auth-guard.js"></script>
 </body>

--- a/scripts/sync-course-catalog.cjs
+++ b/scripts/sync-course-catalog.cjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const catalogPath = path.join(repoRoot, 'data', 'course-catalog.json');
+const graphPath = path.join(repoRoot, 'data', 'prerequisite-graph.json');
+const courseIndexPath = path.join(repoRoot, 'ewu-design-catalog', 'COURSE-INDEX.md');
+const enrollmentCsvPath = path.join(repoRoot, 'enrollment-data', 'processed', 'corrected-all-quarters.csv');
+const quarterOrder = ['Fall', 'Winter', 'Spring', 'Summer'];
+
+const fallbackQuartersByCode = {
+    'DESN 210': ['Fall', 'Winter', 'Spring'],
+    'DESN 213': ['Fall', 'Winter', 'Spring'],
+    'DESN 214': ['Fall', 'Winter', 'Spring'],
+    'DESN 215': ['Fall', 'Winter', 'Spring'],
+    'DESN 217': ['Fall', 'Winter', 'Spring'],
+    'DESN 375': ['Fall', 'Winter', 'Spring'],
+    'DESN 398': ['Fall', 'Winter', 'Spring'],
+    'DESN 446': ['Spring'],
+    'DESN 469': ['Fall'],
+    'DESN 497': ['Fall', 'Winter', 'Spring'],
+    'DESN 498': ['Fall', 'Winter', 'Spring']
+};
+
+const specialMetadataByCode = {
+    'DESN 399': { isVariable: true, workloadMultiplier: 0.2, typicalEnrollmentCap: 5 },
+    'DESN 491': { isVariable: true, workloadMultiplier: 0.2, typicalEnrollmentCap: 10 },
+    'DESN 495': { isVariable: true, workloadMultiplier: 0.1, typicalEnrollmentCap: 15 },
+    'DESN 499': { isVariable: true, workloadMultiplier: 0.2, typicalEnrollmentCap: 10 },
+    'DESN 396': { isVariable: true },
+    'DESN 398': { isVariable: true },
+    'DESN 496': { isVariable: true },
+    'DESN 497': { isVariable: true },
+    'DESN 498': { isVariable: true }
+};
+
+function readJson(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, data) {
+    fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function normalizeCourseCode(code) {
+    return String(code || '')
+        .trim()
+        .toUpperCase()
+        .replace(/-/g, ' ');
+}
+
+function mergeNotes(...values) {
+    const unique = [];
+    const seen = new Set();
+
+    values.flat().forEach((value) => {
+        String(value || '')
+            .split('|')
+            .map((entry) => entry.trim())
+            .filter(Boolean)
+            .forEach((normalized) => {
+                const key = normalized.toLowerCase().replace(/[^a-z0-9]+/g, '');
+                if (!normalized || seen.has(key)) return;
+                seen.add(key);
+                unique.push(normalized);
+            });
+    });
+
+    return unique.join(' | ') || null;
+}
+
+function deriveLevelFromCode(code) {
+    const match = String(code || '').match(/\b(\d)\d{2}\b/);
+    return match ? `${match[1]}00` : '';
+}
+
+function parseCatalogIndex(markdown) {
+    const byLevelSection = markdown.split('## By Track')[0];
+
+    return byLevelSection
+        .split(/\r?\n/)
+        .map((line) => line.match(/^- \*\*(DESN-\d{3})\*\*\s+(.+?)(?:\s+\(([^)]*)\))?(?:\s+\*\[.*)?$/))
+        .filter(Boolean)
+        .map((match) => ({
+            dashCode: match[1],
+            code: normalizeCourseCode(match[1]),
+            title: String(match[2] || '').trim(),
+            metaText: String(match[3] || '').trim()
+        }));
+}
+
+function buildHistoricalQuarterMap(csvText) {
+    const quarterMap = new Map();
+    const rows = csvText.trim().split(/\r?\n/).slice(1);
+
+    rows.forEach((row) => {
+        const columns = row.split(',');
+        const quarter = String(columns[1] || '').trim();
+        const code = normalizeCourseCode(columns[3] || '');
+
+        if (!/^DESN \d{3}$/.test(code)) return;
+        if (!['Fall', 'Winter', 'Spring', 'Summer'].includes(quarter)) return;
+
+        if (!quarterMap.has(code)) {
+            quarterMap.set(code, new Set());
+        }
+
+        quarterMap.get(code).add(quarter);
+    });
+
+    return quarterMap;
+}
+
+function orderQuarters(quarters = []) {
+    return Array.from(new Set(quarters))
+        .sort((left, right) => quarterOrder.indexOf(left) - quarterOrder.indexOf(right));
+}
+
+function parseCreditMetadata(metaText) {
+    const meta = String(metaText || '').trim();
+    if (!meta) {
+        return { creditRange: null, exactCredits: null, derivedNotes: null };
+    }
+
+    const creditMatch = meta.match(/(\d+(?:-\d+)?)\s*cr/i);
+    const creditRange = creditMatch ? creditMatch[1] : null;
+    const exactCredits = creditRange && !creditRange.includes('-') ? Number(creditRange) : null;
+    const notesText = creditMatch
+        ? meta.replace(creditMatch[0], '').replace(/^[,\s]+|[,\s]+$/g, '')
+        : meta;
+
+    return {
+        creditRange,
+        exactCredits,
+        derivedNotes: notesText || null
+    };
+}
+
+function syncCourseCatalog() {
+    const existingCatalog = readJson(catalogPath);
+    const prerequisiteGraph = readJson(graphPath);
+    const courseIndex = fs.readFileSync(courseIndexPath, 'utf8');
+    const historicalQuarterMap = buildHistoricalQuarterMap(fs.readFileSync(enrollmentCsvPath, 'utf8'));
+
+    const existingCourseMap = new Map(
+        (existingCatalog.courses || []).map((course) => [normalizeCourseCode(course.code), course])
+    );
+
+    const canonicalCourses = parseCatalogIndex(courseIndex).map((courseEntry) => {
+        const existingCourse = existingCourseMap.get(courseEntry.code) || {};
+        const graphCourse = prerequisiteGraph.courses?.[courseEntry.dashCode] || {};
+        const specialMetadata = specialMetadataByCode[courseEntry.code] || {};
+        const creditMeta = parseCreditMetadata(courseEntry.metaText);
+        const graphCredits = graphCourse.credits;
+        const offeredQuarters = Array.isArray(existingCourse.offeredQuarters) && existingCourse.offeredQuarters.length > 0
+            ? existingCourse.offeredQuarters.slice()
+            : historicalQuarterMap.has(courseEntry.code)
+                ? Array.from(historicalQuarterMap.get(courseEntry.code))
+                : (fallbackQuartersByCode[courseEntry.code] || ['Fall', 'Winter', 'Spring']).slice();
+
+        const catalogCourse = {
+            code: courseEntry.code,
+            title: courseEntry.title,
+            defaultCredits: Number.isFinite(Number(graphCredits))
+                ? Number(graphCredits)
+                : Number.isFinite(creditMeta.exactCredits)
+                    ? creditMeta.exactCredits
+                    : Number(existingCourse.defaultCredits) || 5,
+            typicalEnrollmentCap: Number(existingCourse.typicalEnrollmentCap)
+                || Number(specialMetadata.typicalEnrollmentCap)
+                || 24,
+            level: String(graphCourse.level || existingCourse.level || deriveLevelFromCode(courseEntry.code)),
+            offeredQuarters: orderQuarters(offeredQuarters)
+        };
+
+        const prerequisites = Array.isArray(graphCourse.prerequisites)
+            ? graphCourse.prerequisites.map((value) => normalizeCourseCode(value))
+            : Array.isArray(existingCourse.prerequisites)
+                ? existingCourse.prerequisites.slice()
+                : [];
+        if (prerequisites.length > 0) {
+            catalogCourse.prerequisites = prerequisites;
+        }
+
+        if (graphCourse.isRequired || existingCourse.required === true) {
+            catalogCourse.required = true;
+        }
+
+        const standingRequired = String(graphCourse.standingRequired || existingCourse.standingRequired || '').trim();
+        if (standingRequired) {
+            catalogCourse.standingRequired = standingRequired;
+        }
+
+        if (existingCourse.defaultModality) {
+            catalogCourse.defaultModality = existingCourse.defaultModality;
+        }
+
+        const mergedNotes = mergeNotes(graphCourse.notes, existingCourse.notes, creditMeta.derivedNotes);
+        if (mergedNotes) {
+            catalogCourse.notes = mergedNotes;
+        }
+
+        const effectiveCreditRange = String(graphCredits || creditMeta.creditRange || '');
+        if (effectiveCreditRange.includes('-')) {
+            catalogCourse.creditRange = effectiveCreditRange;
+        }
+
+        if (specialMetadata.isVariable || existingCourse.isVariable === true) {
+            catalogCourse.isVariable = true;
+        }
+
+        const workloadMultiplier = Number(
+            specialMetadata.workloadMultiplier ?? existingCourse.workloadMultiplier
+        );
+        if (Number.isFinite(workloadMultiplier) && workloadMultiplier > 0 && workloadMultiplier !== 1) {
+            catalogCourse.workloadMultiplier = workloadMultiplier;
+        }
+
+        return catalogCourse;
+    });
+
+    const syncedCatalog = {
+        version: existingCatalog.version || '1.0',
+        lastModified: new Date().toISOString().slice(0, 10),
+        department: existingCatalog.department || 'Design',
+        courses: canonicalCourses
+    };
+
+    writeJson(catalogPath, syncedCatalog);
+
+    console.log(`Synced ${canonicalCourses.length} courses into ${path.relative(repoRoot, catalogPath)}`);
+}
+
+syncCourseCatalog();

--- a/tests/course-catalog.sync.test.js
+++ b/tests/course-catalog.sync.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const catalogPath = path.join(repoRoot, 'data', 'course-catalog.json');
+const courseIndexPath = path.join(repoRoot, 'ewu-design-catalog', 'COURSE-INDEX.md');
+
+function parseCatalogIndex(markdown) {
+    const byLevelSection = markdown.split('## By Track')[0];
+
+    return byLevelSection
+        .split(/\r?\n/)
+        .map((line) => line.match(/^- \*\*(DESN-\d{3})\*\*\s+(.+?)(?:\s+\(([^)]*)\))?(?:\s+\*\[.*)?$/))
+        .filter(Boolean)
+        .map((match) => ({
+            code: match[1].replace('-', ' '),
+            title: String(match[2] || '').trim()
+        }));
+}
+
+describe('course catalog sync', () => {
+    test('fallback JSON course codes and titles match COURSE-INDEX.md', () => {
+        const catalog = JSON.parse(fs.readFileSync(catalogPath, 'utf8'));
+        const indexMarkdown = fs.readFileSync(courseIndexPath, 'utf8');
+
+        const indexCourses = parseCatalogIndex(indexMarkdown);
+        const catalogCourses = (catalog.courses || []).map((course) => ({
+            code: String(course.code || '').trim(),
+            title: String(course.title || '').trim()
+        }));
+
+        expect(catalogCourses).toEqual(indexCourses);
+    });
+});


### PR DESCRIPTION
## Summary
- Isolate the course-catalog/runtime-source fix on a `main`-based hotfix branch so GitHub Pages can deploy it without unrelated `develop` work.
- Route schedule-facing catalog loads through the shared DB service first, with the existing local JSON fallback preserved behind that same service path.
- Regenerate `data/course-catalog.json` from `ewu-design-catalog/COURSE-INDEX.md` and add a sync test to prevent silent fallback drift.

## Test plan
- [x] `npm test -- tests/course-catalog.sync.test.js tests/db-service.source-status.test.js tests/copy-year-correctness.test.js`
- [x] `npm run build`

Made with [Cursor](https://cursor.com)