### PR TITLE
Harden Supabase programs RLS

### DIFF
--- a/docs/supabase-current-program-helper-t04.md
+++ b/docs/supabase-current-program-helper-t04.md
@@ -9,6 +9,7 @@ Run:
 
 This migration adds:
 
+- scoped RLS policies for `public.programs`
 - `public.user_programs` mapping table (`user_id` ↔ `program_id`)
 - `public.jwt_program_id()` helper (safe JWT claim parse)
 - `public.current_program()` helper for RLS policy usage
@@ -42,8 +43,22 @@ select user_id, program_id, role, is_default
 from public.user_programs
 order by updated_at desc
 limit 20;
+
+-- Confirm programs RLS is enabled and policies are present
+select tablename, policyname, cmd
+from pg_policies
+where schemaname = 'public'
+  and tablename = 'programs'
+order by policyname;
 ```
 
 Expected `provolatile`:
 
 - `s` for all helper functions above (`STABLE`).
+
+Expected program policies:
+
+- `programs_select_current_or_platform_admin`
+- `programs_insert_platform_admin_only`
+- `programs_update_platform_admin_only`
+- `programs_delete_platform_admin_only`

--- a/docs/supabase-policy-smoke-check.md
+++ b/docs/supabase-policy-smoke-check.md
@@ -4,6 +4,7 @@
 
 Quickly verify RLS behavior after C-06 migration:
 
+- anonymous reads cannot see `programs`
 - anonymous writes are denied
 - authorized writes are allowed
 - output is explicit pass/fail
@@ -43,10 +44,12 @@ npm run check:rls
 
 The smoke check uses `academic_years` for a temporary probe row and runs:
 
-1. anon insert (expect denied)
-2. authorized insert (expect allowed)
-3. anon update/delete against probe row (expect denied)
-4. authorized update/delete (expect allowed)
+1. anon `programs` read (expect denied or empty result)
+2. authorized `programs` read (expect allowed)
+3. anon insert (expect denied)
+4. authorized insert (expect allowed)
+5. anon update/delete against probe row (expect denied)
+6. authorized update/delete (expect allowed)
 
 The script attempts cleanup even if a later check fails.
 

--- a/docs/supabase-program-id-migration-t02.md
+++ b/docs/supabase-program-id-migration-t02.md
@@ -13,12 +13,13 @@ Execute the first tenantization migration by adding `program_id` to all program-
 ## What The Migration Does
 1. Creates `public.programs` (if missing).
 2. Inserts/updates EWU Design tenant row (`code='ewu-design'`).
-3. Adds `program_id` to all scoped tables.
-4. Backfills existing rows based on current FK hierarchy.
-5. Applies transition default (`program_id = EWU Design`) for backward-compatible inserts.
-6. Sets `program_id` to `NOT NULL`.
-7. Adds `program_id` FK constraints to `public.programs(id)`.
-8. Adds required indexes on every `program_id` column plus high-value query indexes.
+3. Enables RLS on `public.programs` so the tenant root is not left publicly exposed.
+4. Adds `program_id` to all scoped tables.
+5. Backfills existing rows based on current FK hierarchy.
+6. Applies transition default (`program_id = EWU Design`) for backward-compatible inserts.
+7. Sets `program_id` to `NOT NULL`.
+8. Adds `program_id` FK constraints to `public.programs(id)`.
+9. Adds required indexes on every `program_id` column plus high-value query indexes.
 
 ## Program-Scoped Tables Updated
 - `departments`
@@ -87,6 +88,16 @@ order by s.table_name;
 Expected:
 - `is_nullable = NO` for all rows.
 - `column_default` resolves to EWU Design UUID for transition compatibility.
+
+### 2b) Confirm `programs` now has RLS enabled
+```sql
+select schemaname, tablename, rowsecurity
+from pg_tables
+where schemaname = 'public'
+  and tablename = 'programs';
+```
+
+Expected: `rowsecurity = true`
 
 ### 3) Check data backfill completed
 ```sql

--- a/scripts/supabase-current-program-helper-t04.sql
+++ b/scripts/supabase-current-program-helper-t04.sql
@@ -150,7 +150,33 @@ CREATE TRIGGER trg_sync_user_program_claims
     FOR EACH ROW
     EXECUTE FUNCTION public.sync_user_program_claims_from_membership();
 
+ALTER TABLE public.programs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.user_programs ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "programs_select_current_or_platform_admin" ON public.programs;
+CREATE POLICY "programs_select_current_or_platform_admin"
+    ON public.programs
+    FOR SELECT TO authenticated
+    USING (id = public.current_program() OR public.is_platform_admin());
+
+DROP POLICY IF EXISTS "programs_insert_platform_admin_only" ON public.programs;
+CREATE POLICY "programs_insert_platform_admin_only"
+    ON public.programs
+    FOR INSERT TO authenticated
+    WITH CHECK (public.is_platform_admin());
+
+DROP POLICY IF EXISTS "programs_update_platform_admin_only" ON public.programs;
+CREATE POLICY "programs_update_platform_admin_only"
+    ON public.programs
+    FOR UPDATE TO authenticated
+    USING (public.is_platform_admin())
+    WITH CHECK (public.is_platform_admin());
+
+DROP POLICY IF EXISTS "programs_delete_platform_admin_only" ON public.programs;
+CREATE POLICY "programs_delete_platform_admin_only"
+    ON public.programs
+    FOR DELETE TO authenticated
+    USING (public.is_platform_admin());
 
 DROP POLICY IF EXISTS "user_programs_select_self_or_platform_admin" ON public.user_programs;
 CREATE POLICY "user_programs_select_self_or_platform_admin"

--- a/scripts/supabase-policy-smoke-check.js
+++ b/scripts/supabase-policy-smoke-check.js
@@ -115,6 +115,7 @@ async function main() {
         : authorizedClient;
 
     let departmentId = null;
+    let authorizedProgramId = null;
     let insertedAnonYearId = null;
     let insertedAuthYearId = null;
 
@@ -133,6 +134,34 @@ async function main() {
 
         departmentId = deptRow.id;
         logPass('resolve target department', `${TARGET_DEPARTMENT_CODE} -> ${departmentId}`);
+
+        {
+            const { data, error } = await anonClient
+                .from('programs')
+                .select('id, code')
+                .eq('code', 'ewu-design');
+
+            if (hasPermissionError(error) || !Array.isArray(data) || data.length === 0) {
+                logPass('anon programs read denied');
+            } else {
+                logFail('anon programs read denied', 'program config row was visible to anon');
+            }
+        }
+
+        {
+            const { data, error } = await authorizedClient
+                .from('programs')
+                .select('id, code')
+                .eq('code', 'ewu-design')
+                .maybeSingle();
+
+            if (error || !data?.id) {
+                logFail('authorized programs read allowed', error?.message || 'program config row not visible');
+            } else {
+                authorizedProgramId = data.id;
+                logPass('authorized programs read allowed', `program id=${authorizedProgramId}`);
+            }
+        }
 
         const anonSmokeYear = makeSmokeYear('A');
         const authSmokeYear = makeSmokeYear('B');

--- a/scripts/supabase-program-id-migration-t02.sql
+++ b/scripts/supabase-program-id-migration-t02.sql
@@ -24,6 +24,9 @@ SET
     name = EXCLUDED.name,
     updated_at = NOW();
 
+-- Keep the tenant root table out of the public Data API until T-04 adds scoped policies.
+ALTER TABLE public.programs ENABLE ROW LEVEL SECURITY;
+
 -- 3) Add program_id to scoped tables, backfill, enforce constraints and defaults
 DO $$
 DECLARE

--- a/tests/supabase-current-program-helper-t04.test.js
+++ b/tests/supabase-current-program-helper-t04.test.js
@@ -9,6 +9,7 @@ function loadMigrationSql() {
 describe('T-04 current_program migration contract', () => {
     test('creates user_programs mapping table and default-membership index', () => {
         const sql = loadMigrationSql();
+        expect(sql).toMatch(/ALTER TABLE public\.programs ENABLE ROW LEVEL SECURITY/i);
         expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS public\.user_programs/i);
         expect(sql).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS idx_user_programs_single_default/i);
     });
@@ -29,5 +30,14 @@ describe('T-04 current_program migration contract', () => {
         expect(sql).toMatch(/UPDATE auth\.users/i);
         expect(sql).toMatch(/DROP TRIGGER IF EXISTS trg_sync_user_program_claims ON public\.user_programs/i);
         expect(sql).toMatch(/CREATE TRIGGER trg_sync_user_program_claims/i);
+    });
+
+    test('adds scoped programs policies for config reads and admin-only writes', () => {
+        const sql = loadMigrationSql();
+        expect(sql).toMatch(/CREATE POLICY "programs_select_current_or_platform_admin"/i);
+        expect(sql).toMatch(/id = public\.current_program\(\) OR public\.is_platform_admin\(\)/i);
+        expect(sql).toMatch(/CREATE POLICY "programs_insert_platform_admin_only"/i);
+        expect(sql).toMatch(/CREATE POLICY "programs_update_platform_admin_only"/i);
+        expect(sql).toMatch(/CREATE POLICY "programs_delete_platform_admin_only"/i);
     });
 });

--- a/tests/supabase-policy-smoke-check.test.js
+++ b/tests/supabase-policy-smoke-check.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadScript() {
+    const filePath = path.resolve(__dirname, '..', 'scripts', 'supabase-policy-smoke-check.js');
+    return fs.readFileSync(filePath, 'utf8');
+}
+
+describe('supabase policy smoke check coverage', () => {
+    test('verifies programs visibility before write probes', () => {
+        const script = loadScript();
+        expect(script).toMatch(/from\('programs'\)/i);
+        expect(script).toMatch(/anon programs read denied/i);
+        expect(script).toMatch(/authorized programs read allowed/i);
+        expect(script).toMatch(/eq\('code', 'ewu-design'\)/i);
+    });
+});

--- a/tests/supabase-program-id-migration-t02.test.js
+++ b/tests/supabase-program-id-migration-t02.test.js
@@ -13,6 +13,7 @@ describe('T-02 program_id migration contract', () => {
         expect(sql).toMatch(/INSERT INTO public\.programs/i);
         expect(sql).toMatch(/VALUES \('EWU Design', 'ewu-design'/i);
         expect(sql).toMatch(/ON CONFLICT \(code\) DO UPDATE/i);
+        expect(sql).toMatch(/ALTER TABLE public\.programs ENABLE ROW LEVEL SECURITY/i);
     });
 
     test('forward migration adds program_id columns, constraints, defaults, and indexes', () => {


### PR DESCRIPTION
## Summary
- enable RLS on the tenant root programs table as part of the migration chain
- add scoped programs policies for authenticated reads and platform-admin writes
- extend the Supabase smoke check and tests to catch public exposure regressions

## Testing
- npm test -- tests/supabase-program-id-migration-t02.test.js tests/supabase-current-program-helper-t04.test.js tests/supabase-policy-smoke-check.test.js