### PR TITLE
Add public view-only schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Read-only production schedule view for signed-out visitors.
 - Defaults to AY `2026-27`, Fall
 - Lets visitors switch among AY `2026-27`, `2025-26`, `2024-25`, and `2023-24`
 - Reads through the `public.get_public_schedule` Supabase RPC
+- Displays course titles from the same canonical catalog/title overrides used by the authenticated scheduler
 - Does not load editor, save, import, dirty-state, presence, or auth-guard scripts
 - Requires the `scripts/supabase-public-schedule-read.sql` migration to be applied before sharing the URL
 - If course titles drift, apply `scripts/supabase-sync-course-catalog.sql` to sync existing Supabase course rows to `data/course-catalog.json`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm run check:data-freshness -- --department DESN --year 2026-27 --output output
 ```
 
 If drift is detected, the command exits with code `2` and lists tables that need carry-over review.
+The check fingerprints course metadata and scheduled-course rows, so course-title drift is caught even when row counts match.
 See `/docs/dev-data-freshness.md` for full usage.
 
 ## ✅ Onboarding QA Gate
@@ -72,6 +73,7 @@ Read-only production schedule view for signed-out visitors.
 - Reads through the `public.get_public_schedule` Supabase RPC
 - Does not load editor, save, import, dirty-state, presence, or auth-guard scripts
 - Requires the `scripts/supabase-public-schedule-read.sql` migration to be applied before sharing the URL
+- If course titles drift, apply `scripts/supabase-sync-course-catalog.sql` to sync existing Supabase course rows to `data/course-catalog.json`
 
 ### Schedule Analyzer (Main)
 **`index.html`**

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ npm run serve
 Read-only production schedule view for signed-out visitors.
 
 - Defaults to AY `2026-27`, Fall
+- Lets visitors switch among AY `2026-27`, `2025-26`, `2024-25`, and `2023-24`
 - Reads through the `public.get_public_schedule` Supabase RPC
 - Does not load editor, save, import, dirty-state, presence, or auth-guard scripts
 - Requires the `scripts/supabase-public-schedule-read.sql` migration to be applied before sharing the URL

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ npm run serve
 
 ## 📊 Dashboards
 
+### Public Schedule
+**`public-schedule.html`**
+
+Read-only production schedule view for signed-out visitors.
+
+- Defaults to AY `2026-27`, Fall
+- Reads through the `public.get_public_schedule` Supabase RPC
+- Does not load editor, save, import, dirty-state, presence, or auth-guard scripts
+- Requires the `scripts/supabase-public-schedule-read.sql` migration to be applied before sharing the URL
+
 ### Schedule Analyzer (Main)
 **`index.html`**
 

--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -1,17 +1,16 @@
 :root {
-    --public-bg: #f6f8fa;
+    --public-red: #B7142E;
+    --public-red-dark: #8F0F24;
+    --public-black: #1a1a1a;
+    --public-paper: #faf9f7;
+    --public-stone: #f0eeeb;
+    --public-muted: #6b6560;
+    --public-line: #ddd8d2;
+    --public-accent: #c4450c;
+    --public-success: #2a7d4f;
+    --public-warning: #b45309;
     --public-surface: #ffffff;
-    --public-surface-muted: #f3f5f7;
-    --public-text: #1f2328;
-    --public-muted: #656d76;
-    --public-border: #d0d7de;
-    --public-border-soft: #eaeef2;
-    --public-red: #a10022;
-    --public-red-dark: #7e001a;
-    --public-blue: #0969da;
-    --public-green: #1a7f37;
-    --public-yellow: #9a6700;
-    --public-radius: 8px;
+    --public-mono: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 * {
@@ -20,19 +19,16 @@
 
 body {
     margin: 0;
-    background: var(--public-bg);
-    color: var(--public-text);
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+    background: var(--public-paper);
+    color: var(--public-black);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
 }
 
 .public-shell {
-    width: min(1600px, calc(100vw - 32px));
+    width: min(1600px, 96vw);
     margin: 16px auto 40px;
-    background: var(--public-surface);
-    border: 1px solid var(--public-border);
-    border-radius: var(--public-radius);
-    overflow: hidden;
-    box-shadow: 0 8px 24px rgba(140, 149, 159, 0.18);
 }
 
 .public-header {
@@ -40,9 +36,10 @@ body {
     justify-content: space-between;
     align-items: center;
     gap: 24px;
-    padding: 18px 28px;
-    color: #ffffff;
-    background: linear-gradient(180deg, var(--public-red) 0%, var(--public-red-dark) 100%);
+    padding: 2rem 2rem 1.75rem;
+    background: var(--public-black);
+    color: var(--public-paper);
+    border-bottom: 3px solid var(--public-red);
 }
 
 .public-header-copy {
@@ -51,50 +48,52 @@ body {
 
 .public-header h1 {
     margin: 0;
-    color: #ffffff;
-    font-size: 22px;
-    font-weight: 700;
-    line-height: 1.12;
+    color: var(--public-paper);
+    font-size: 2.2rem;
+    font-weight: 800;
+    line-height: 1.15;
+    letter-spacing: 0;
 }
 
 .public-login-link {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: 36px;
-    padding: 7px 14px;
-    border: 1px solid rgba(255, 255, 255, 0.28);
-    border-radius: 6px;
-    color: #ffffff;
-    background: rgba(255, 255, 255, 0.12);
-    font-size: 14px;
+    min-height: 38px;
+    padding: 8px 14px;
+    border: 1px solid #3a3a3a;
+    border-radius: 0;
+    color: var(--public-paper);
+    background: transparent;
+    font-family: var(--public-mono);
+    font-size: 12px;
     font-weight: 700;
+    letter-spacing: 1px;
     text-decoration: none;
+    text-transform: uppercase;
 }
 
 .public-login-link:hover {
-    background: rgba(255, 255, 255, 0.2);
+    background: #2b2b2b;
 }
 
-.public-login-link:focus-visible {
-    outline: 3px solid rgba(255, 255, 255, 0.44);
+.public-login-link:focus-visible,
+.public-quarter-tab:focus-visible {
+    outline: 3px solid rgba(183, 20, 46, 0.28);
     outline-offset: 2px;
 }
 
-.public-status[data-state="ready"] {
-    color: var(--public-green);
-    background: rgba(26, 127, 55, 0.12);
-    border-color: rgba(26, 127, 55, 0.26);
-}
-
-.public-status[data-state="error"] {
-    color: var(--public-yellow);
-    background: rgba(154, 103, 0, 0.12);
-    border-color: rgba(154, 103, 0, 0.28);
-}
-
 .public-main {
-    padding: 24px 28px 32px;
+    padding: 24px 0 32px;
+}
+
+.public-context,
+.public-quarter-tabs,
+.public-faculty-legend,
+.public-schedule-panel,
+.public-special-group {
+    background: var(--public-stone);
+    border: 1px solid var(--public-line);
 }
 
 .public-context {
@@ -102,22 +101,25 @@ body {
     justify-content: space-between;
     align-items: flex-end;
     gap: 16px;
-    margin-bottom: 18px;
+    padding: 18px;
+    border-bottom: 0;
 }
 
 .public-eyebrow {
     margin: 0 0 6px;
-    color: var(--public-muted);
-    font-size: 12px;
-    font-weight: 800;
-    letter-spacing: 0;
+    color: var(--public-accent);
+    font-family: var(--public-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
     text-transform: uppercase;
 }
 
 .public-context h2 {
     margin: 0;
-    font-size: 24px;
-    font-weight: 750;
+    font-size: 1.55rem;
+    font-weight: 800;
+    line-height: 1.15;
 }
 
 .public-meta {
@@ -133,24 +135,161 @@ body {
     align-items: center;
     min-height: 30px;
     padding: 5px 10px;
-    border: 1px solid var(--public-border);
-    border-radius: 999px;
+    border: 1px solid var(--public-line);
+    border-radius: 0;
     color: var(--public-muted);
-    background: var(--public-surface);
+    background: #ffffff;
+    font-family: var(--public-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+}
+
+.public-status[data-state="ready"] {
+    color: var(--public-success);
+    border-color: rgba(42, 125, 79, 0.32);
+    background: #f0f8f3;
+}
+
+.public-status[data-state="error"] {
+    color: var(--public-warning);
+    border-color: rgba(180, 83, 9, 0.32);
+    background: #fff7ed;
+}
+
+.public-quarter-tabs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    padding: 10px;
+    border-bottom: 0;
+}
+
+.public-quarter-tab {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto auto 1fr;
+    align-items: baseline;
+    gap: 8px;
+    min-height: 46px;
+    padding: 10px 12px;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    color: var(--public-muted);
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+}
+
+.public-quarter-tab:hover {
+    background: #ffffff;
+    color: var(--public-black);
+}
+
+.public-quarter-tab[aria-selected="true"] {
+    background: #ffffff;
+    color: var(--public-black);
+}
+
+.public-quarter-tab[aria-selected="true"]::after {
+    position: absolute;
+    right: 10px;
+    bottom: 0;
+    left: 10px;
+    height: 3px;
+    background: var(--public-red);
+    content: "";
+}
+
+.public-quarter-name {
+    font-family: var(--public-mono);
     font-size: 13px;
+    font-weight: 800;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+}
+
+.public-quarter-year,
+.public-quarter-count {
+    font-family: var(--public-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+}
+
+.public-quarter-count {
+    justify-self: end;
+}
+
+.public-faculty-legend {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 10px 12px;
+    border-bottom: 0;
+}
+
+.public-faculty-legend-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    color: var(--public-muted);
+    font-size: 12px;
+}
+
+.public-faculty-legend-header strong {
+    color: var(--public-black);
+    font-family: var(--public-mono);
+    font-size: 11px;
+    letter-spacing: 1.4px;
+    text-transform: uppercase;
+}
+
+.public-faculty-legend-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.public-faculty-legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 28px;
+    padding: 4px 8px;
+    border: 1px solid var(--public-line);
+    border-left: 4px solid var(--faculty-accent, #bdc3c7);
+    background: #ffffff;
+    font-size: 12px;
+}
+
+.public-faculty-swatch,
+.public-faculty-dot {
+    display: inline-block;
+    flex: 0 0 auto;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--faculty-accent, #bdc3c7);
+}
+
+.public-faculty-name {
     font-weight: 700;
 }
 
+.public-faculty-meta,
+.public-faculty-legend-empty,
 .public-summary,
 .public-panel-count {
     color: var(--public-muted);
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 700;
 }
 
 .public-schedule-panel {
-    border: 1px solid var(--public-border);
-    border-radius: var(--public-radius);
     background: var(--public-surface);
     overflow: hidden;
 }
@@ -160,21 +299,19 @@ body {
     justify-content: space-between;
     align-items: center;
     gap: 18px;
-    padding: 18px 20px;
-    border-bottom: 1px solid var(--public-border);
-    background: #fbfcfd;
-}
-
-.public-panel-heading h2 {
-    margin: 0;
-    font-size: 20px;
-    font-weight: 700;
+    padding: 14px 18px;
+    border-bottom: 1px solid var(--public-line);
+    background: var(--public-stone);
 }
 
 .public-panel-heading p {
-    margin: 4px 0 0;
+    margin: 0;
     color: var(--public-muted);
-    font-size: 13px;
+    font-family: var(--public-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1.1px;
+    text-transform: uppercase;
 }
 
 .public-grid-scroll {
@@ -185,36 +322,44 @@ body {
     display: grid;
     grid-template-columns: 104px repeat(7, minmax(132px, 1fr));
     min-width: 1050px;
+    background: var(--public-line);
+    border-top: 1px solid var(--public-line);
 }
 
 .public-grid-header,
 .public-time-slot,
 .public-schedule-cell,
 .public-day-divider {
-    border-right: 1px solid var(--public-border-soft);
-    border-bottom: 1px solid var(--public-border-soft);
+    border-right: 1px solid var(--public-line);
+    border-bottom: 1px solid var(--public-line);
 }
 
 .public-grid-header {
     position: sticky;
     top: 0;
     z-index: 1;
-    min-height: 42px;
-    padding: 10px;
-    background: #f6f8fa;
-    color: var(--public-muted);
-    font-size: 12px;
-    font-weight: 800;
+    min-height: 44px;
+    padding: 12px 10px;
+    background: var(--public-black);
+    color: var(--public-paper);
+    font-family: var(--public-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 1px;
     text-align: center;
+    text-transform: uppercase;
 }
 
 .public-day-divider {
     grid-column: 1 / -1;
     padding: 8px 12px;
-    background: #f0f3f6;
-    color: var(--public-text);
-    font-size: 12px;
+    background: var(--public-red);
+    color: var(--public-paper);
+    font-family: var(--public-mono);
+    font-size: 10px;
     font-weight: 800;
+    letter-spacing: 1px;
+    text-align: center;
     text-transform: uppercase;
 }
 
@@ -224,11 +369,14 @@ body {
     justify-content: center;
     min-height: 126px;
     padding: 10px;
-    background: #fbfcfd;
-    color: var(--public-muted);
-    font-size: 12px;
-    font-weight: 800;
+    background: var(--public-black);
+    color: var(--public-paper);
+    font-family: var(--public-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.6px;
     text-align: center;
+    text-transform: uppercase;
 }
 
 .public-schedule-cell {
@@ -238,9 +386,9 @@ body {
 }
 
 .public-schedule-cell:empty::after {
-    content: "";
     display: block;
     min-height: 1px;
+    content: "";
 }
 
 .public-course-block {
@@ -248,12 +396,18 @@ body {
     flex-direction: column;
     gap: 4px;
     min-height: 88px;
-    padding: 10px;
-    border: 1px solid #d8dee4;
-    border-left: 4px solid var(--public-red);
-    border-radius: 6px;
+    padding: 8px 10px;
+    border: 1px solid #e2ddd7;
+    border-left: 4px solid var(--faculty-accent, var(--public-red));
+    border-radius: 0;
     background: #ffffff;
-    box-shadow: 0 1px 2px rgba(27, 31, 36, 0.05);
+    box-shadow: none;
+    transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.public-course-block:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(31, 35, 40, 0.12);
 }
 
 .public-course-block + .public-course-block {
@@ -261,18 +415,23 @@ body {
 }
 
 .public-course-code {
+    color: #212529;
     font-size: 13px;
     font-weight: 800;
+    line-height: 1.25;
 }
 
 .public-course-title {
-    color: var(--public-text);
+    color: var(--public-black);
     font-size: 12px;
     font-weight: 650;
     line-height: 1.25;
 }
 
 .public-course-meta {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     color: var(--public-muted);
     font-size: 12px;
     line-height: 1.25;
@@ -284,6 +443,21 @@ body {
     font-weight: 700;
 }
 
+.faculty-masingale { --faculty-accent: #667eea; }
+.faculty-durr { --faculty-accent: #e67e22; }
+.faculty-manikoth { --faculty-accent: #27ae60; }
+.faculty-mills { --faculty-accent: #9b59b6; }
+.faculty-lybbert { --faculty-accent: #e74c3c; }
+.faculty-hustrulid { --faculty-accent: #f39c12; }
+.faculty-sopu { --faculty-accent: #3498db; }
+.faculty-norris { --faculty-accent: #1abc9c; }
+.faculty-braukmann { --faculty-accent: #34495e; }
+.faculty-allison { --faculty-accent: #d35400; }
+.faculty-online { --faculty-accent: #7f8c8d; }
+.faculty-adjunct { --faculty-accent: #95a5a6; }
+.faculty-tbd { --faculty-accent: #bdc3c7; }
+.faculty-generated { --faculty-accent: #64748b; }
+
 .public-special-sections {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -292,8 +466,6 @@ body {
 }
 
 .public-special-group {
-    border: 1px solid var(--public-border);
-    border-radius: var(--public-radius);
     background: #ffffff;
     overflow: hidden;
 }
@@ -303,8 +475,8 @@ body {
     justify-content: space-between;
     gap: 12px;
     padding: 12px 14px;
-    border-bottom: 1px solid var(--public-border-soft);
-    background: #fbfcfd;
+    border-bottom: 1px solid var(--public-line);
+    background: var(--public-stone);
 }
 
 .public-special-heading h3 {
@@ -329,16 +501,13 @@ body {
 }
 
 .public-error {
-    color: var(--public-yellow);
+    color: var(--public-warning);
 }
 
-@media (max-width: 760px) {
+@media (max-width: 820px) {
     .public-shell {
         width: 100%;
         margin: 0;
-        border-right: 0;
-        border-left: 0;
-        border-radius: 0;
     }
 
     .public-header,
@@ -348,12 +517,38 @@ body {
         align-items: stretch;
     }
 
-    .public-main {
-        padding: 18px 14px 28px;
+    .public-header {
+        padding: 24px 18px;
     }
 
-    .public-meta {
+    .public-header h1 {
+        font-size: 1.7rem;
+    }
+
+    .public-main {
+        padding: 16px 0 28px;
+    }
+
+    .public-quarter-tabs {
+        grid-template-columns: 1fr;
+    }
+
+    .public-quarter-tab {
+        grid-template-columns: auto auto;
+    }
+
+    .public-quarter-count {
+        grid-column: 1 / -1;
+        justify-self: start;
+    }
+
+    .public-meta,
+    .public-faculty-legend-header {
         justify-content: flex-start;
+    }
+
+    .public-faculty-legend-header {
+        flex-direction: column;
     }
 
     .public-special-sections {

--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -365,18 +365,26 @@ body {
 
 .public-time-slot {
     display: flex;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
     justify-content: center;
+    gap: 3px;
     min-height: 126px;
-    padding: 10px;
+    padding: 10px 12px;
     background: var(--public-black);
     color: var(--public-paper);
     font-family: var(--public-mono);
     font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.6px;
-    text-align: center;
+    text-align: left;
     text-transform: uppercase;
+}
+
+.public-time-start,
+.public-time-end {
+    display: block;
+    line-height: 1.2;
 }
 
 .public-schedule-cell {

--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -228,8 +228,8 @@ body {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    margin-top: 18px;
     padding: 10px 12px;
-    border-bottom: 0;
 }
 
 .public-faculty-legend-header {
@@ -463,6 +463,10 @@ body {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 16px;
     margin-top: 18px;
+}
+
+.public-special-sections:empty {
+    display: none;
 }
 
 .public-special-group {

--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -418,15 +418,16 @@ body {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    justify-content: center;
-    gap: 3px;
+    justify-content: flex-start;
+    gap: 5px;
     min-height: 126px;
-    padding: 10px 12px;
+    padding: 16px 12px 10px;
     background: var(--public-black);
     color: var(--public-paper);
     font-family: var(--public-mono);
     font-size: 11px;
     font-weight: 700;
+    font-variant-numeric: tabular-nums;
     letter-spacing: 0.6px;
     text-align: left;
     text-transform: uppercase;
@@ -434,8 +435,21 @@ body {
 
 .public-time-start,
 .public-time-end {
-    display: block;
+    display: grid;
+    grid-template-columns: 6ch 2.2ch;
+    align-items: baseline;
+    column-gap: 0.55ch;
     line-height: 1.2;
+    white-space: nowrap;
+}
+
+.public-time-clock {
+    min-width: 6ch;
+    text-align: right;
+}
+
+.public-time-period {
+    text-align: left;
 }
 
 .public-schedule-cell {

--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -38,9 +38,9 @@ body {
 .public-header {
     display: flex;
     justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
     gap: 24px;
-    padding: 28px 32px;
+    padding: 18px 28px;
     color: #ffffff;
     background: linear-gradient(180deg, var(--public-red) 0%, var(--public-red-dark) 100%);
 }
@@ -49,113 +49,96 @@ body {
     min-width: 0;
 }
 
-.public-eyebrow {
-    margin: 0 0 6px;
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0;
-    text-transform: uppercase;
-    opacity: 0.84;
-}
-
 .public-header h1 {
     margin: 0;
     color: #ffffff;
-    font-size: 28px;
+    font-size: 22px;
     font-weight: 700;
     line-height: 1.12;
 }
 
-.public-meta {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 12px;
-}
-
-.public-meta span,
-.public-status {
+.public-login-link {
     display: inline-flex;
     align-items: center;
-    min-height: 28px;
-    padding: 4px 10px;
+    justify-content: center;
+    min-height: 36px;
+    padding: 7px 14px;
     border: 1px solid rgba(255, 255, 255, 0.28);
-    border-radius: 999px;
+    border-radius: 6px;
     color: #ffffff;
     background: rgba(255, 255, 255, 0.12);
-    font-size: 13px;
-    font-weight: 600;
+    font-size: 14px;
+    font-weight: 700;
+    text-decoration: none;
 }
 
-.public-status {
-    flex-shrink: 0;
+.public-login-link:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.public-login-link:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.44);
+    outline-offset: 2px;
 }
 
 .public-status[data-state="ready"] {
-    background: rgba(26, 127, 55, 0.28);
+    color: var(--public-green);
+    background: rgba(26, 127, 55, 0.12);
+    border-color: rgba(26, 127, 55, 0.26);
 }
 
 .public-status[data-state="error"] {
-    background: rgba(154, 103, 0, 0.34);
+    color: var(--public-yellow);
+    background: rgba(154, 103, 0, 0.12);
+    border-color: rgba(154, 103, 0, 0.28);
 }
 
 .public-main {
     padding: 24px 28px 32px;
 }
 
-.public-toolbar {
+.public-context {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-end;
     gap: 16px;
     margin-bottom: 18px;
 }
 
-.public-quarter-tabs {
-    display: inline-grid;
-    grid-template-columns: repeat(3, minmax(112px, 1fr));
-    gap: 6px;
-    padding: 6px;
-    background: var(--public-surface-muted);
-    border: 1px solid var(--public-border);
-    border-radius: var(--public-radius);
-}
-
-.public-quarter-tab {
-    display: inline-flex;
-    justify-content: center;
-    align-items: baseline;
-    gap: 6px;
-    min-height: 36px;
-    padding: 7px 12px;
-    border: 0;
-    border-radius: 6px;
-    background: transparent;
+.public-eyebrow {
+    margin: 0 0 6px;
     color: var(--public-muted);
-    font: inherit;
-    font-weight: 700;
-    cursor: pointer;
-}
-
-.public-quarter-tab:hover {
-    color: var(--public-text);
-    background: #ffffff;
-}
-
-.public-quarter-tab:focus-visible {
-    outline: 3px solid rgba(9, 105, 218, 0.28);
-    outline-offset: 2px;
-}
-
-.public-quarter-tab[aria-selected="true"] {
-    color: #ffffff;
-    background: var(--public-blue);
-}
-
-.public-quarter-tab span {
     font-size: 12px;
-    font-weight: 600;
-    opacity: 0.8;
+    font-weight: 800;
+    letter-spacing: 0;
+    text-transform: uppercase;
+}
+
+.public-context h2 {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 750;
+}
+
+.public-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 8px;
+}
+
+.public-meta span,
+.public-status {
+    display: inline-flex;
+    align-items: center;
+    min-height: 30px;
+    padding: 5px 10px;
+    border: 1px solid var(--public-border);
+    border-radius: 999px;
+    color: var(--public-muted);
+    background: var(--public-surface);
+    font-size: 13px;
+    font-weight: 700;
 }
 
 .public-summary,
@@ -359,7 +342,7 @@ body {
     }
 
     .public-header,
-    .public-toolbar,
+    .public-context,
     .public-panel-heading {
         flex-direction: column;
         align-items: stretch;
@@ -369,9 +352,8 @@ body {
         padding: 18px 14px 28px;
     }
 
-    .public-quarter-tabs {
-        width: 100%;
-        grid-template-columns: 1fr;
+    .public-meta {
+        justify-content: flex-start;
     }
 
     .public-special-sections {

--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -1,16 +1,41 @@
-:root {
-    --public-red: #B7142E;
-    --public-red-dark: #8F0F24;
-    --public-black: #1a1a1a;
-    --public-paper: #f6f8fa;
-    --public-stone: #eef2f6;
-    --public-muted: #57606a;
-    --public-line: #d0d7de;
-    --public-accent: #B7142E;
-    --public-success: #2a7d4f;
-    --public-warning: #b45309;
-    --public-surface: #ffffff;
-    --public-mono: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+:root,
+.foundry {
+    --f-bg: #F7F7F8;
+    --f-surface: #FFFFFF;
+    --f-surface-raised: #FFFFFF;
+    --f-surface-subtle: #F1F2F4;
+    --f-surface-inset: #E7E9ED;
+    --f-ink: #0D1117;
+    --f-ink-inverse: #FFFFFF;
+    --f-muted: #3F4652;
+    --f-soft: #6A737D;
+    --f-hairline: #C9D1D9;
+    --f-rule: #111827;
+    --f-blue: #0969DA;
+    --f-blue-text: #0550AE;
+    --f-green: #1A7F37;
+    --f-amber: #9A6700;
+    --f-red: #CF222E;
+    --f-focus: 0 0 0 3px rgba(9, 105, 218, 0.22);
+    --f-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+    --f-mono: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+
+    --public-red: var(--f-blue);
+    --public-red-dark: var(--f-blue-text);
+    --public-black: var(--f-ink);
+    --public-paper: var(--f-bg);
+    --public-stone: var(--f-surface-subtle);
+    --public-muted: var(--f-muted);
+    --public-soft: var(--f-soft);
+    --public-line: var(--f-hairline);
+    --public-accent: var(--f-blue);
+    --public-success: var(--f-green);
+    --public-warning: var(--f-amber);
+    --public-danger: var(--f-red);
+    --public-surface: var(--f-surface);
+    --public-inset: var(--f-surface-inset);
+    --public-mono: var(--f-mono);
+    --public-sans: var(--f-sans);
 }
 
 * {
@@ -21,9 +46,10 @@ body {
     margin: 0;
     background: var(--public-paper);
     color: var(--public-black);
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-family: var(--public-sans);
     font-size: 16px;
-    line-height: 1.6;
+    line-height: 1.55;
+    letter-spacing: 0;
 }
 
 .public-shell {
@@ -36,22 +62,51 @@ body {
     justify-content: space-between;
     align-items: center;
     gap: 24px;
-    padding: 2rem 2rem 1.75rem;
-    background: var(--public-black);
-    color: var(--public-paper);
-    border-bottom: 3px solid var(--public-red);
+    padding: 14px 18px;
+    background: var(--public-surface);
+    color: var(--public-black);
+    border: 1px solid var(--public-line);
+    border-bottom: 3px solid var(--public-black);
 }
 
 .public-header-copy {
+    display: flex;
+    align-items: center;
+    gap: 12px;
     min-width: 0;
+}
+
+.public-header-mark {
+    display: inline-grid;
+    place-items: center;
+    flex: 0 0 auto;
+    width: 38px;
+    height: 38px;
+    border: 2px solid var(--public-black);
+    color: var(--public-black);
+    font-family: var(--public-mono);
+    font-size: 13px;
+    font-weight: 900;
+    line-height: 1;
+}
+
+.public-header-label {
+    margin: 0 0 2px;
+    color: var(--public-soft);
+    font-family: var(--public-mono);
+    font-size: 11px;
+    font-weight: 850;
+    letter-spacing: 0;
+    line-height: 1;
+    text-transform: uppercase;
 }
 
 .public-header h1 {
     margin: 0;
-    color: var(--public-paper);
-    font-size: 2.2rem;
-    font-weight: 800;
-    line-height: 1.15;
+    color: var(--public-black);
+    font-size: clamp(1.5rem, 2.4vw, 2rem);
+    font-weight: 850;
+    line-height: 1;
     letter-spacing: 0;
 }
 
@@ -61,27 +116,28 @@ body {
     justify-content: center;
     min-height: 38px;
     padding: 8px 14px;
-    border: 1px solid #3a3a3a;
+    border: 1px solid var(--public-line);
     border-radius: 0;
-    color: var(--public-paper);
+    color: var(--public-black);
     background: transparent;
     font-family: var(--public-mono);
     font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 1px;
+    font-weight: 850;
+    letter-spacing: 0;
     text-decoration: none;
     text-transform: uppercase;
 }
 
 .public-login-link:hover {
-    background: #2b2b2b;
+    background: var(--public-stone);
+    border-color: var(--public-black);
 }
 
 .public-login-link:focus-visible,
 .public-year-tab:focus-visible,
 .public-quarter-tab:focus-visible {
-    outline: 3px solid rgba(183, 20, 46, 0.28);
-    outline-offset: 2px;
+    outline: none;
+    box-shadow: var(--f-focus);
 }
 
 .public-main {
@@ -103,25 +159,25 @@ body {
     justify-content: space-between;
     align-items: flex-end;
     gap: 16px;
-    padding: 18px;
+    padding: 22px 18px;
     border-bottom: 0;
 }
 
 .public-eyebrow {
     margin: 0 0 6px;
-    color: var(--public-accent);
+    color: var(--public-soft);
     font-family: var(--public-mono);
     font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 1.5px;
+    font-weight: 850;
+    letter-spacing: 0;
     text-transform: uppercase;
 }
 
 .public-context h2 {
     margin: 0;
-    font-size: 1.55rem;
-    font-weight: 800;
-    line-height: 1.15;
+    font-size: clamp(2rem, 4vw, 3.2rem);
+    font-weight: 850;
+    line-height: 1;
 }
 
 .public-meta {
@@ -131,8 +187,7 @@ body {
     gap: 8px;
 }
 
-.public-meta span,
-.public-status {
+.public-meta span {
     display: inline-flex;
     align-items: center;
     min-height: 30px;
@@ -143,21 +198,38 @@ body {
     background: #ffffff;
     font-family: var(--public-mono);
     font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 1px;
+    font-weight: 850;
+    letter-spacing: 0;
     text-transform: uppercase;
+}
+
+.public-status {
+    gap: 7px;
+    border-color: transparent;
+    background: transparent;
+    color: var(--public-muted);
+    padding-inline: 4px;
+}
+
+.public-status::before {
+    content: "";
+    flex: 0 0 auto;
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: currentColor;
 }
 
 .public-status[data-state="ready"] {
     color: var(--public-success);
-    border-color: rgba(42, 125, 79, 0.32);
-    background: #f0f8f3;
+    border-color: transparent;
+    background: transparent;
 }
 
 .public-status[data-state="error"] {
     color: var(--public-warning);
-    border-color: rgba(180, 83, 9, 0.32);
-    background: #fff7ed;
+    border-color: transparent;
+    background: transparent;
 }
 
 .public-year-tabs {
@@ -184,7 +256,7 @@ body {
     gap: 7px;
     min-height: 38px;
     padding: 8px 10px;
-    border: 1px solid transparent;
+    border: 1px solid var(--public-line);
     border-radius: 0;
     background: #ffffff;
     color: var(--public-muted);
@@ -201,7 +273,7 @@ body {
     gap: 8px;
     min-height: 46px;
     padding: 10px 12px;
-    border: 0;
+    border: 1px solid transparent;
     border-radius: 0;
     background: transparent;
     color: var(--public-muted);
@@ -214,27 +286,18 @@ body {
 .public-quarter-tab:hover {
     background: #ffffff;
     color: var(--public-black);
+    border-color: var(--public-line);
 }
 
 .public-year-tab[aria-selected="true"],
 .public-quarter-tab[aria-selected="true"] {
     background: #ffffff;
     color: var(--public-black);
+    box-shadow: inset 5px 0 0 var(--public-accent);
 }
 
 .public-year-tab[aria-selected="true"] {
-    border-color: rgba(183, 20, 46, 0.38);
-}
-
-.public-year-tab[aria-selected="true"]::after,
-.public-quarter-tab[aria-selected="true"]::after {
-    position: absolute;
-    right: 10px;
-    bottom: 0;
-    left: 10px;
-    height: 3px;
-    background: var(--public-red);
-    content: "";
+    border-color: var(--public-line);
 }
 
 .public-year-label,
@@ -246,8 +309,8 @@ body {
 .public-year-label,
 .public-year-value {
     font-size: 11px;
-    font-weight: 800;
-    letter-spacing: 0.8px;
+    font-weight: 850;
+    letter-spacing: 0;
     text-transform: uppercase;
 }
 
@@ -257,8 +320,8 @@ body {
 
 .public-quarter-name {
     font-size: 13px;
-    font-weight: 800;
-    letter-spacing: 0.5px;
+    font-weight: 850;
+    letter-spacing: 0;
     text-transform: uppercase;
 }
 
@@ -266,8 +329,8 @@ body {
 .public-quarter-count {
     font-family: var(--public-mono);
     font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 0.6px;
+    font-weight: 850;
+    letter-spacing: 0;
     text-transform: uppercase;
 }
 
@@ -280,7 +343,8 @@ body {
     flex-direction: column;
     gap: 8px;
     margin-top: 18px;
-    padding: 10px 12px;
+    padding: 14px 12px;
+    border-left: 6px solid var(--public-black);
 }
 
 .public-faculty-legend-header {
@@ -295,7 +359,7 @@ body {
     color: var(--public-black);
     font-family: var(--public-mono);
     font-size: 11px;
-    letter-spacing: 1.4px;
+    letter-spacing: 0;
     text-transform: uppercase;
 }
 
@@ -346,22 +410,37 @@ body {
 }
 
 .public-panel-heading {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
     gap: 18px;
     padding: 14px 18px;
-    border-bottom: 1px solid var(--public-line);
+    border-bottom: 3px solid var(--public-black);
     background: var(--public-stone);
+}
+
+.public-panel-heading::before {
+    display: inline-grid;
+    place-items: center;
+    width: 42px;
+    min-width: 42px;
+    height: 30px;
+    background: var(--public-black);
+    color: var(--f-ink-inverse);
+    content: "01";
+    font-family: var(--public-mono);
+    font-size: 11px;
+    font-weight: 900;
+    line-height: 1;
 }
 
 .public-panel-heading p {
     margin: 0;
-    color: var(--public-muted);
+    color: var(--public-soft);
     font-family: var(--public-mono);
     font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 1.1px;
+    font-weight: 850;
+    letter-spacing: 0;
     text-transform: uppercase;
 }
 
@@ -395,8 +474,8 @@ body {
     color: var(--public-paper);
     font-family: var(--public-mono);
     font-size: 11px;
-    font-weight: 700;
-    letter-spacing: 1px;
+    font-weight: 850;
+    letter-spacing: 0;
     text-align: center;
     text-transform: uppercase;
 }
@@ -404,12 +483,12 @@ body {
 .public-day-divider {
     grid-column: 1 / -1;
     padding: 8px 12px;
-    background: var(--public-red);
-    color: var(--public-paper);
+    background: var(--public-stone);
+    color: var(--public-black);
     font-family: var(--public-mono);
     font-size: 10px;
-    font-weight: 800;
-    letter-spacing: 1px;
+    font-weight: 900;
+    letter-spacing: 0;
     text-align: center;
     text-transform: uppercase;
 }
@@ -426,9 +505,9 @@ body {
     color: var(--public-paper);
     font-family: var(--public-mono);
     font-size: 11px;
-    font-weight: 700;
+    font-weight: 850;
     font-variant-numeric: tabular-nums;
-    letter-spacing: 0.6px;
+    letter-spacing: 0;
     text-align: left;
     text-transform: uppercase;
 }
@@ -470,17 +549,17 @@ body {
     gap: 4px;
     min-height: 88px;
     padding: 8px 10px;
-    border: 1px solid #d8dee4;
+    border: 1px solid var(--public-line);
     border-left: 4px solid var(--faculty-accent, var(--public-red));
     border-radius: 0;
     background: #ffffff;
     box-shadow: none;
-    transition: box-shadow 0.15s ease, transform 0.15s ease;
+    transition: border-color 0.15s ease, transform 0.15s ease;
 }
 
 .public-course-block:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(31, 35, 40, 0.12);
+    border-color: var(--faculty-accent, var(--public-line));
 }
 
 .public-course-block + .public-course-block {
@@ -490,7 +569,7 @@ body {
 .public-course-code {
     color: #212529;
     font-size: 13px;
-    font-weight: 800;
+    font-weight: 850;
     line-height: 1.25;
 }
 
@@ -513,7 +592,7 @@ body {
 .public-course-section {
     color: var(--public-muted);
     font-size: 11px;
-    font-weight: 700;
+    font-weight: 750;
 }
 
 .faculty-masingale { --faculty-accent: #667eea; }
@@ -544,6 +623,7 @@ body {
 
 .public-special-group {
     background: #ffffff;
+    border-left: 6px solid var(--public-accent);
     overflow: hidden;
 }
 
@@ -559,7 +639,7 @@ body {
 .public-special-heading h3 {
     margin: 0;
     font-size: 15px;
-    font-weight: 800;
+    font-weight: 850;
 }
 
 .public-special-list {
@@ -588,14 +668,30 @@ body {
     }
 
     .public-header,
-    .public-context,
-    .public-panel-heading {
+    .public-context {
         flex-direction: column;
+    }
+
+    .public-header {
+        align-items: flex-start;
+    }
+
+    .public-context {
         align-items: stretch;
+    }
+
+    .public-panel-heading {
+        grid-template-columns: 1fr;
+        align-items: stretch;
+        gap: 10px;
     }
 
     .public-header {
         padding: 24px 18px;
+    }
+
+    .public-login-link {
+        align-self: flex-start;
     }
 
     .public-header h1 {

--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -78,6 +78,7 @@ body {
 }
 
 .public-login-link:focus-visible,
+.public-year-tab:focus-visible,
 .public-quarter-tab:focus-visible {
     outline: 3px solid rgba(183, 20, 46, 0.28);
     outline-offset: 2px;
@@ -88,6 +89,7 @@ body {
 }
 
 .public-context,
+.public-year-tabs,
 .public-quarter-tabs,
 .public-faculty-legend,
 .public-schedule-panel,
@@ -158,12 +160,37 @@ body {
     background: #fff7ed;
 }
 
+.public-year-tabs {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 8px;
+    padding: 10px 10px 0;
+    border-bottom: 0;
+}
+
 .public-quarter-tabs {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
     padding: 10px;
     border-bottom: 0;
+}
+
+.public-year-tab {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    min-height: 38px;
+    padding: 8px 10px;
+    border: 1px solid transparent;
+    border-radius: 0;
+    background: #ffffff;
+    color: var(--public-muted);
+    cursor: pointer;
+    font: inherit;
+    text-align: center;
 }
 
 .public-quarter-tab {
@@ -183,16 +210,23 @@ body {
     text-align: left;
 }
 
+.public-year-tab:hover,
 .public-quarter-tab:hover {
     background: #ffffff;
     color: var(--public-black);
 }
 
+.public-year-tab[aria-selected="true"],
 .public-quarter-tab[aria-selected="true"] {
     background: #ffffff;
     color: var(--public-black);
 }
 
+.public-year-tab[aria-selected="true"] {
+    border-color: rgba(183, 20, 46, 0.38);
+}
+
+.public-year-tab[aria-selected="true"]::after,
 .public-quarter-tab[aria-selected="true"]::after {
     position: absolute;
     right: 10px;
@@ -203,8 +237,25 @@ body {
     content: "";
 }
 
+.public-year-label,
+.public-year-value,
 .public-quarter-name {
     font-family: var(--public-mono);
+}
+
+.public-year-label,
+.public-year-value {
+    font-size: 11px;
+    font-weight: 800;
+    letter-spacing: 0.8px;
+    text-transform: uppercase;
+}
+
+.public-year-label {
+    color: var(--public-accent);
+}
+
+.public-quarter-name {
     font-size: 13px;
     font-weight: 800;
     letter-spacing: 0.5px;
@@ -539,6 +590,10 @@ body {
 
     .public-main {
         padding: 16px 0 28px;
+    }
+
+    .public-year-tabs {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     .public-quarter-tabs {

--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -2,11 +2,11 @@
     --public-red: #B7142E;
     --public-red-dark: #8F0F24;
     --public-black: #1a1a1a;
-    --public-paper: #faf9f7;
-    --public-stone: #f0eeeb;
-    --public-muted: #6b6560;
-    --public-line: #ddd8d2;
-    --public-accent: #c4450c;
+    --public-paper: #f6f8fa;
+    --public-stone: #eef2f6;
+    --public-muted: #57606a;
+    --public-line: #d0d7de;
+    --public-accent: #B7142E;
     --public-success: #2a7d4f;
     --public-warning: #b45309;
     --public-surface: #ffffff;
@@ -405,7 +405,7 @@ body {
     gap: 4px;
     min-height: 88px;
     padding: 8px 10px;
-    border: 1px solid #e2ddd7;
+    border: 1px solid #d8dee4;
     border-left: 4px solid var(--faculty-accent, var(--public-red));
     border-radius: 0;
     background: #ffffff;

--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -1,0 +1,380 @@
+:root {
+    --public-bg: #f6f8fa;
+    --public-surface: #ffffff;
+    --public-surface-muted: #f3f5f7;
+    --public-text: #1f2328;
+    --public-muted: #656d76;
+    --public-border: #d0d7de;
+    --public-border-soft: #eaeef2;
+    --public-red: #a10022;
+    --public-red-dark: #7e001a;
+    --public-blue: #0969da;
+    --public-green: #1a7f37;
+    --public-yellow: #9a6700;
+    --public-radius: 8px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: var(--public-bg);
+    color: var(--public-text);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+}
+
+.public-shell {
+    width: min(1600px, calc(100vw - 32px));
+    margin: 16px auto 40px;
+    background: var(--public-surface);
+    border: 1px solid var(--public-border);
+    border-radius: var(--public-radius);
+    overflow: hidden;
+    box-shadow: 0 8px 24px rgba(140, 149, 159, 0.18);
+}
+
+.public-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 24px;
+    padding: 28px 32px;
+    color: #ffffff;
+    background: linear-gradient(180deg, var(--public-red) 0%, var(--public-red-dark) 100%);
+}
+
+.public-header-copy {
+    min-width: 0;
+}
+
+.public-eyebrow {
+    margin: 0 0 6px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    opacity: 0.84;
+}
+
+.public-header h1 {
+    margin: 0;
+    color: #ffffff;
+    font-size: 28px;
+    font-weight: 700;
+    line-height: 1.12;
+}
+
+.public-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.public-meta span,
+.public-status {
+    display: inline-flex;
+    align-items: center;
+    min-height: 28px;
+    padding: 4px 10px;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 999px;
+    color: #ffffff;
+    background: rgba(255, 255, 255, 0.12);
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.public-status {
+    flex-shrink: 0;
+}
+
+.public-status[data-state="ready"] {
+    background: rgba(26, 127, 55, 0.28);
+}
+
+.public-status[data-state="error"] {
+    background: rgba(154, 103, 0, 0.34);
+}
+
+.public-main {
+    padding: 24px 28px 32px;
+}
+
+.public-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.public-quarter-tabs {
+    display: inline-grid;
+    grid-template-columns: repeat(3, minmax(112px, 1fr));
+    gap: 6px;
+    padding: 6px;
+    background: var(--public-surface-muted);
+    border: 1px solid var(--public-border);
+    border-radius: var(--public-radius);
+}
+
+.public-quarter-tab {
+    display: inline-flex;
+    justify-content: center;
+    align-items: baseline;
+    gap: 6px;
+    min-height: 36px;
+    padding: 7px 12px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--public-muted);
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.public-quarter-tab:hover {
+    color: var(--public-text);
+    background: #ffffff;
+}
+
+.public-quarter-tab:focus-visible {
+    outline: 3px solid rgba(9, 105, 218, 0.28);
+    outline-offset: 2px;
+}
+
+.public-quarter-tab[aria-selected="true"] {
+    color: #ffffff;
+    background: var(--public-blue);
+}
+
+.public-quarter-tab span {
+    font-size: 12px;
+    font-weight: 600;
+    opacity: 0.8;
+}
+
+.public-summary,
+.public-panel-count {
+    color: var(--public-muted);
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.public-schedule-panel {
+    border: 1px solid var(--public-border);
+    border-radius: var(--public-radius);
+    background: var(--public-surface);
+    overflow: hidden;
+}
+
+.public-panel-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 18px;
+    padding: 18px 20px;
+    border-bottom: 1px solid var(--public-border);
+    background: #fbfcfd;
+}
+
+.public-panel-heading h2 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 700;
+}
+
+.public-panel-heading p {
+    margin: 4px 0 0;
+    color: var(--public-muted);
+    font-size: 13px;
+}
+
+.public-grid-scroll {
+    overflow-x: auto;
+}
+
+.public-schedule-grid {
+    display: grid;
+    grid-template-columns: 104px repeat(7, minmax(132px, 1fr));
+    min-width: 1050px;
+}
+
+.public-grid-header,
+.public-time-slot,
+.public-schedule-cell,
+.public-day-divider {
+    border-right: 1px solid var(--public-border-soft);
+    border-bottom: 1px solid var(--public-border-soft);
+}
+
+.public-grid-header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    min-height: 42px;
+    padding: 10px;
+    background: #f6f8fa;
+    color: var(--public-muted);
+    font-size: 12px;
+    font-weight: 800;
+    text-align: center;
+}
+
+.public-day-divider {
+    grid-column: 1 / -1;
+    padding: 8px 12px;
+    background: #f0f3f6;
+    color: var(--public-text);
+    font-size: 12px;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.public-time-slot {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 126px;
+    padding: 10px;
+    background: #fbfcfd;
+    color: var(--public-muted);
+    font-size: 12px;
+    font-weight: 800;
+    text-align: center;
+}
+
+.public-schedule-cell {
+    min-height: 126px;
+    padding: 8px;
+    background: #ffffff;
+}
+
+.public-schedule-cell:empty::after {
+    content: "";
+    display: block;
+    min-height: 1px;
+}
+
+.public-course-block {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-height: 88px;
+    padding: 10px;
+    border: 1px solid #d8dee4;
+    border-left: 4px solid var(--public-red);
+    border-radius: 6px;
+    background: #ffffff;
+    box-shadow: 0 1px 2px rgba(27, 31, 36, 0.05);
+}
+
+.public-course-block + .public-course-block {
+    margin-top: 8px;
+}
+
+.public-course-code {
+    font-size: 13px;
+    font-weight: 800;
+}
+
+.public-course-title {
+    color: var(--public-text);
+    font-size: 12px;
+    font-weight: 650;
+    line-height: 1.25;
+}
+
+.public-course-meta {
+    color: var(--public-muted);
+    font-size: 12px;
+    line-height: 1.25;
+}
+
+.public-course-section {
+    color: var(--public-muted);
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.public-special-sections {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    margin-top: 18px;
+}
+
+.public-special-group {
+    border: 1px solid var(--public-border);
+    border-radius: var(--public-radius);
+    background: #ffffff;
+    overflow: hidden;
+}
+
+.public-special-heading {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--public-border-soft);
+    background: #fbfcfd;
+}
+
+.public-special-heading h3 {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 800;
+}
+
+.public-special-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    gap: 10px;
+    padding: 12px;
+}
+
+.public-empty,
+.public-error {
+    padding: 24px;
+    color: var(--public-muted);
+    font-weight: 650;
+    text-align: center;
+}
+
+.public-error {
+    color: var(--public-yellow);
+}
+
+@media (max-width: 760px) {
+    .public-shell {
+        width: 100%;
+        margin: 0;
+        border-right: 0;
+        border-left: 0;
+        border-radius: 0;
+    }
+
+    .public-header,
+    .public-toolbar,
+    .public-panel-heading {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .public-main {
+        padding: 18px 14px 28px;
+    }
+
+    .public-quarter-tabs {
+        width: 100%;
+        grid-template-columns: 1fr;
+    }
+
+    .public-special-sections {
+        grid-template-columns: 1fr;
+    }
+}

--- a/docs/auth-contract.md
+++ b/docs/auth-contract.md
@@ -122,6 +122,7 @@ Those are handled in subsequent A/T issues.
 
 ## 9) Environment Auth Enforcement
 - Production/staging hosts enforce auth guard by default.
+- `public-schedule.html` is the intentional no-login exception. It must not load `auth-guard.js`; its data access is limited to the read-only `public.get_public_schedule` RPC and must not grant anonymous table writes or broad table reads.
 - Local development hosts (`localhost`, `127.0.0.1`, `::1`) bypass auth guard by default.
 - Optional override controls:
   - query param: `?auth=required` or `?auth=disabled`

--- a/docs/chair-ay2627-quick-start.md
+++ b/docs/chair-ay2627-quick-start.md
@@ -17,6 +17,7 @@ Current status:
 - Viewing preliminary workload impact by faculty
 - Exporting a draft workload sheet for one faculty at a time
 - Meeting-time planning and "what if" conversations
+- Sharing a read-only public schedule view after the production schedule has been verified
 
 ## What to treat as preliminary (not final)
 
@@ -74,12 +75,22 @@ Then open:
   - TBD/unassigned sections (excluded from faculty totals)
 - Use the `⬇️` button in a faculty row to export an **Export Workload Sheet (.xlsx)** draft.
 
+6. Verify the public read-only schedule
+
+- Apply `scripts/supabase-public-schedule-read.sql` to dev first, then production after review.
+- Open `public-schedule.html` in a signed-out/private browser window.
+- Confirm the first view is `AY 2026-27` and `Fall 2026`.
+- Confirm the public grid matches the authenticated scheduler for AY 2026-27 Fall.
+- Confirm no Save, Add Course, import, dashboard, workload, or admin controls are visible.
+- Confirm the authenticated scheduler (`index.html`) still requires login in production/staging.
+
 ## Recommended chair workflow (meeting-safe)
 
 - Use the scheduler for draft planning decisions.
 - Treat the workload numbers as preliminary planning estimates.
 - Confirm release time / assigned time / manual workload lines before using exported sheets as final.
 - Keep a dated version note (for example: "AY26-27 draft as of Feb 26 meeting").
+- Share the public schedule URL only after the read-only view has been checked against the authenticated scheduler.
 - After the meeting, confirm release-time assumptions and any special assignments.
 
 ## Copy/paste response (send to chair)

--- a/docs/chair-ay2627-quick-start.md
+++ b/docs/chair-ay2627-quick-start.md
@@ -81,6 +81,7 @@ Then open:
 - Open `public-schedule.html` in a signed-out/private browser window.
 - Confirm the first view is `AY 2026-27` and `Fall 2026`.
 - Confirm the public grid matches the authenticated scheduler for AY 2026-27 Fall.
+- Confirm the public year selector can switch back to AY `2025-26`, `2024-25`, and `2023-24`.
 - Confirm no Save, Add Course, import, dashboard, workload, or admin controls are visible.
 - Confirm the authenticated scheduler (`index.html`) still requires login in production/staging.
 

--- a/docs/dev-data-freshness.md
+++ b/docs/dev-data-freshness.md
@@ -18,6 +18,7 @@ For each table it reports:
 
 - row count
 - latest change timestamp (`updated_at` or `created_at`)
+- content fingerprint for course metadata and scheduled-course rows
 - freshness status (`in-sync`, `prod-newer`, `dev-newer`, `prod-has-more`, `dev-has-more`, etc.)
 
 ## Run (live compare)
@@ -49,5 +50,6 @@ npm run check:data-freshness -- \
 - `in-sync`: no action needed for that table.
 - `prod-newer` or `prod-has-more`: production changed after dev snapshot; carry-over likely needed.
 - `dev-newer` or `dev-has-more`: dev contains changes not yet in production.
+- `content-diff`: row counts match, but tracked content differs. For `courses`, this catches title/credit/cap drift; for `scheduled_courses`, this catches schedule row and joined course-title drift.
 
 If drift is reported, review the affected tables and plan a carry-over before merge/deploy.

--- a/docs/plans/2026-04-30-001-feat-public-schedule-view-plan.md
+++ b/docs/plans/2026-04-30-001-feat-public-schedule-view-plan.md
@@ -1,0 +1,236 @@
+---
+title: feat: Add Public Read-Only Schedule View
+type: feat
+status: completed
+date: 2026-04-30
+---
+
+# feat: Add Public Read-Only Schedule View
+
+## Overview
+
+Add a production-safe, no-login public schedule page that shows only the schedule UI, defaults to AY 2026-27 and Fall, and cannot write to scheduler data. The recommended shape is a dedicated public route backed by a narrow read-only Supabase RPC, not a query-param mode on the existing editor page.
+
+## Problem Frame
+
+The current production app protects `index.html` and dashboard pages through `js/auth-guard.js`, while `index.html` contains schedule editing, save, import, conflict, workload, and navigation behavior in one large page. A public page should avoid loading those editor affordances entirely. Public database reads also need an explicit contract because current program-scoped RLS policies are authenticated-only and `public.current_program()` returns `NULL` for unauthenticated calls.
+
+## Requirements Trace
+
+- R1. Visitors can open the production schedule without logging in.
+- R2. The public page shows only schedule information, not Program Command dashboards or editing tools.
+- R3. The initial view is AY 2026-27, Fall.
+- R4. Anonymous users cannot create, update, delete, import, save, or access non-schedule administrative data.
+- R5. The view reads production schedule data rather than a stale static export.
+
+## Scope Boundaries
+
+- Do not weaken auth for `index.html`, `pages/schedule-builder.html`, dashboards, or administrative pages.
+- Do not expose the full course catalog, faculty table, workload data, constraints, release time, or program configuration through broad anonymous table policies.
+- Do not add public editing, commenting, downloads, or schedule publishing workflows in this first pass.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `js/auth-guard.js` enforces auth on production/staging by default and supports an override before the guard loads, but the public page should avoid loading the guard unless a future shared shell requires it.
+- `index.html` defaults `currentAcademicYear` to `2025-26`, hydrates schedules from Supabase through `loadScheduleDataFromDatabase`, then falls back to local drafts.
+- `js/components/quarter-nav.js` defaults to `2025-26` and `spring`; this should either become configurable or the public page should use its own lightweight selector.
+- `js/schedule-data-utils.js` already converts database rows into the scheduler's quarter/day/time data shape.
+- `js/supabase-config.js` creates the browser Supabase client with the anon key, so public access must be enforced by RLS/RPC, not by hiding secrets.
+- `scripts/supabase-program-rls-t03.sql` creates authenticated-only SELECT policies for tenant-scoped tables.
+- `scripts/supabase-current-program-helper-t04.sql` documents that unauthenticated calls have no current program.
+
+### Institutional Learnings
+
+- `docs/auth-contract.md` says production/staging hosts enforce auth by default and browser clients must use the anon/publishable key with DB policy as the authority.
+- `docs/scheduler-save-contract.md` makes year-scoped schedule persistence the canonical contract; the public view should consume the persisted `scheduled_courses` shape and never call the save RPC.
+- `docs/supabase-live-verification-c08-2026-02-28.md` confirms anonymous writes were explicitly denied in live verification.
+
+### External References
+
+- Supabase RLS docs: public schema data should be protected by RLS, anon access requires explicit policies, and the anon role is distinct from an authenticated user.
+- Supabase API security docs: public-schema tables without RLS are accessible through the Data API, so exposed schedule data needs an intentional read boundary.
+
+## Key Technical Decisions
+
+- Use a dedicated public page: This keeps the public runtime from loading editor controls, save handlers, dirty-state tracking, presence, session timeout, dashboard nav, and modals from `index.html`.
+- Use a narrow read-only RPC or view-backed endpoint: Return only the fields needed to render schedule blocks for the published academic year. This avoids granting broad anonymous SELECT on `scheduled_courses`, `courses`, `faculty`, `rooms`, and `academic_years`.
+- Default through explicit constants: Store `PUBLIC_SCHEDULE_DEFAULT_YEAR = '2026-27'` and `PUBLIC_SCHEDULE_DEFAULT_QUARTER = 'fall'` in the public schedule script so the behavior is obvious and testable.
+- Keep authenticated editor pages unchanged: Chair/admin workflows continue to use existing auth, save, and RLS paths.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this be a mode on `index.html`? No. A route mode would still ship too much editor behavior to anonymous visitors and would require many defensive hides/guards.
+- Can we rely on the anon key being public? Yes, but only with RLS/RPC enforcing the allowed data boundary.
+
+### Deferred to Implementation
+
+- Whether the production database already has AY 2026-27 Fall rows: verify during implementation and seed/save the year if needed.
+- Final public URL: suggested `public-schedule.html` or `pages/public-schedule.html`; choose based on deployment routing preference during implementation.
+
+## Implementation Units
+
+- [x] **Unit 1: Add Public Schedule Read Contract**
+
+**Goal:** Create a database contract that anonymous visitors can use to read only the public schedule fields.
+
+**Requirements:** R1, R4, R5
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/supabase-public-schedule-read.sql`
+- Create: `tests/supabase-public-schedule-read.test.js`
+- Modify: `docs/auth-contract.md`
+
+**Approach:**
+- Prefer a `SECURITY DEFINER` RPC such as `public.get_public_schedule(...)` with a fixed default year of `2026-27`, a fixed or validated program code of `DESN`, and a sanitized return table.
+- Return only schedule rendering fields: academic year, quarter, day pattern, time slot, section, course code, course title, credits, instructor display name, room display name, and projected enrollment when needed.
+- Grant `EXECUTE` to `anon` and `authenticated`; do not grant anonymous write permissions.
+- If dynamic future publishing is needed, add a tiny allowlist table or flag rather than opening all years.
+
+**Patterns to follow:**
+- `scripts/supabase-schedule-sync-rpc.sql` for RPC structure, search path, grants, and tests.
+- `docs/supabase-live-verification-c08-2026-02-28.md` for anon write-denial expectations.
+
+**Test scenarios:**
+- Happy path: SQL defines a public schedule RPC and grants execute to `anon`.
+- Security: SQL does not grant INSERT, UPDATE, DELETE, or broad table SELECT to `anon`.
+- Scope: SQL limits anonymous output to AY 2026-27 or an explicit publication allowlist.
+- Data minimization: SQL return columns exclude audit fields, IDs where not needed, user identifiers, program config, and non-schedule tables.
+
+**Verification:**
+- Anonymous clients can read the public schedule data, and anonymous write attempts remain denied.
+
+- [x] **Unit 2: Build Public Schedule Page**
+
+**Goal:** Add a no-login page that renders the schedule only and defaults to AY 2026-27 Fall.
+
+**Requirements:** R1, R2, R3, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Create: `public-schedule.html`
+- Create: `pages/public-schedule.js`
+- Modify: `css/design-system.css` or create `css/public-schedule.css`
+- Test: `tests/public-schedule.test.js`
+
+**Approach:**
+- Load only the assets needed for a read-only schedule: Supabase config, schedule data utilities, and the public schedule renderer.
+- Do not include `js/auth-guard.js`, `js/auth-service.js`, `js/dirty-state-tracker.js`, editor modals, save buttons, import tools, dashboard nav, or presence indicators.
+- On load, call the public schedule RPC, convert rows with `ScheduleDataUtils.buildScheduleDataFromDatabaseRecords`, and render Fall 2026 first.
+- Offer quarter tabs for Fall/Winter/Spring if the public data includes them, but keep AY fixed to `2026-27` for this pass unless implementation confirms a safe publication list.
+
+**Patterns to follow:**
+- `index.html` schedule grid rendering vocabulary and `js/schedule-data-utils.js` data shape.
+- `js/components/quarter-nav.js` display-year logic, but with defaults changed or copied into a lightweight public control.
+
+**Test scenarios:**
+- Happy path: page initializes with year `2026-27` and quarter `fall`.
+- Happy path: RPC rows render into the correct day/time/room schedule cells.
+- Edge case: an empty schedule shows a read-only empty state without login redirects.
+- Security: HTML source does not load `auth-guard.js`, editor scripts, or expose save/import controls.
+- Error path: failed RPC shows a non-editable error state and does not fall back to local drafts.
+
+**Verification:**
+- Opening the public route in a signed-out production-like browser shows the Fall 2026 schedule and no editable controls.
+
+- [x] **Unit 3: Wire Defaults and Production Deployment Behavior**
+
+**Goal:** Ensure production deploys the public page with the intended default and does not alter protected app behavior.
+
+**Requirements:** R1, R3, R4
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `vite.config.js` if the route needs build/deploy handling
+- Modify: `README.md`
+- Test: `tests/auth-editstate.integration.test.js` or a new route-focused auth guard test
+
+**Approach:**
+- Confirm the public page is included in the Vite build output.
+- Add a short README note documenting the public URL and the default AY/quarter.
+- Add regression coverage proving existing protected routes still redirect to login on production-like hosts.
+
+**Patterns to follow:**
+- Existing auth guard tests in `tests/auth-editstate.integration.test.js`.
+- Existing production auth contract in `docs/auth-contract.md`.
+
+**Test scenarios:**
+- Happy path: `public-schedule.html` remains accessible without a session.
+- Integration: `index.html` still redirects to login on a non-localhost production-like host with no session.
+- Regression: `?auth=disabled` behavior is not required for the public page.
+
+**Verification:**
+- Public schedule route is reachable signed out; authenticated app routes remain protected.
+
+- [x] **Unit 4: Production Data Readiness Check**
+
+**Goal:** Make sure AY 2026-27 Fall production schedule data exists and is the data the public page reads.
+
+**Requirements:** R3, R5
+
+**Dependencies:** Units 1 and 2
+
+**Files:**
+- Modify: `docs/chair-ay2627-quick-start.md`
+- Optional create: `docs/public-schedule-release-checklist.md`
+
+**Approach:**
+- Verify `academic_years.year = '2026-27'` exists for the Design program and has Fall `scheduled_courses` rows.
+- If missing, use the authenticated chair workflow to save/publish the schedule rather than allowing the public page to create data.
+- Document the release check so future default-year changes are deliberate.
+
+**Patterns to follow:**
+- `docs/chair-ay2627-quick-start.md`
+- `docs/supabase-live-verification-c08-2026-02-28.md`
+
+**Test scenarios:**
+- Test expectation: none -- this is an operational verification and documentation unit.
+
+**Verification:**
+- Production public view shows the same AY 2026-27 Fall rows that the authenticated scheduler shows.
+
+## System-Wide Impact
+
+- **Interaction graph:** Anonymous visitor -> public schedule page -> public schedule RPC -> sanitized production schedule rows. Authenticated chair/admin -> existing protected editor pages -> existing save RPC.
+- **Error propagation:** Public RPC/read failures should surface as a read-only unavailable state, not login redirects or local draft fallbacks.
+- **State lifecycle risks:** The public page should not touch `designSchedulerData_*`, dirty state, session recovery drafts, or save attribution.
+- **API surface parity:** Existing editor save/read behavior stays unchanged; the new RPC is read-only and public-facing.
+- **Integration coverage:** Route-level tests need to prove public accessibility and protected-route preservation together.
+- **Unchanged invariants:** Anonymous writes remain denied; the browser never receives service-role credentials; production dashboards remain login-protected.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Accidentally exposing non-schedule data | Use a narrow RPC with sanitized columns instead of broad anonymous table SELECT. |
+| Public page drifts from editor rendering | Reuse `js/schedule-data-utils.js` and copy only stable schedule display rules from `index.html`. |
+| Public route accidentally inherits editor affordances | Build a dedicated page that never loads editor modules or action buttons. |
+| Empty production AY 2026-27 data | Add a release checklist and verify against authenticated scheduler data before sharing the URL. |
+| Future years need public access | Add an explicit publication allowlist rather than making all years anonymous-readable. |
+
+## Documentation / Operational Notes
+
+- Document the public URL, default AY/quarter, and release verification steps.
+- Update the default constants when the published academic year changes.
+- Treat the public RPC as a production API surface; changing its output fields should be covered by tests.
+
+## Sources & References
+
+- Related code: `js/auth-guard.js`
+- Related code: `index.html`
+- Related code: `js/components/quarter-nav.js`
+- Related code: `js/schedule-data-utils.js`
+- Related code: `js/supabase-config.js`
+- Related SQL: `scripts/supabase-program-rls-t03.sql`
+- Related SQL: `scripts/supabase-current-program-helper-t04.sql`
+- Related docs: `docs/auth-contract.md`
+- Related docs: `docs/scheduler-save-contract.md`
+- External docs: `https://supabase.com/docs/guides/database/postgres/row-level-security`
+- External docs: `https://supabase.com/docs/guides/api/securing-your-api`

--- a/docs/public-schedule-release-checklist.md
+++ b/docs/public-schedule-release-checklist.md
@@ -6,18 +6,19 @@ Use this before sharing `public-schedule.html` outside the authenticated Program
 
 - Apply `scripts/supabase-public-schedule-read.sql` to the dev Supabase project.
 - Confirm the RPC exists: `public.get_public_schedule(text, text, text)`.
-- Confirm anon can execute the RPC for `2026-27` / `ewu-design`.
+- Confirm anon can execute the RPC for `2026-27`, `2025-26`, `2024-25`, and `2023-24` / `ewu-design`.
 - Confirm anon cannot insert, update, or delete `academic_years` or `scheduled_courses`.
 - Open `public-schedule.html` signed out.
 - Confirm the default view is `AY 2026-27`, `Fall 2026`.
 - Confirm the public schedule rows match the authenticated scheduler for AY 2026-27 Fall.
+- Confirm the academic-year selector can switch to AY `2025-26`, `2024-25`, and `2023-24`.
 - Open `index.html` signed out on a production-like host or with `?auth=required`; confirm it redirects to login.
 
 ## Production Rollout
 
 - Apply `scripts/supabase-public-schedule-read.sql` to production before deploying the frontend.
-- Verify AY `2026-27` exists for `ewu-design`.
-- Verify Fall `scheduled_courses` rows exist and reflect the intended published schedule.
+- Verify AY `2026-27`, `2025-26`, `2024-25`, and `2023-24` exist for `ewu-design`.
+- Verify Fall `scheduled_courses` rows exist for each public academic year that should show published history.
 - Deploy the frontend containing `public-schedule.html`, `css/public-schedule.css`, and `pages/public-schedule.js`.
 - Open the public URL in a private browser window.
 - Confirm no Save, Add Course, import, dashboard, workload, or admin controls are visible.

--- a/docs/public-schedule-release-checklist.md
+++ b/docs/public-schedule-release-checklist.md
@@ -5,11 +5,13 @@ Use this before sharing `public-schedule.html` outside the authenticated Program
 ## Dev Validation
 
 - Apply `scripts/supabase-public-schedule-read.sql` to the dev Supabase project.
+- Apply `scripts/supabase-sync-course-catalog.sql` if dev course titles/credits/caps have drifted from `data/course-catalog.json`.
 - Confirm the RPC exists: `public.get_public_schedule(text, text, text)`.
 - Confirm anon can execute the RPC for `2026-27`, `2025-26`, `2024-25`, and `2023-24` / `ewu-design`.
 - Confirm anon cannot insert, update, or delete `academic_years` or `scheduled_courses`.
 - Open `public-schedule.html` signed out.
 - Confirm the default view is `AY 2026-27`, `Fall 2026`.
+- Confirm displayed course titles match `data/course-catalog.json`.
 - Confirm the public schedule rows match the authenticated scheduler for AY 2026-27 Fall.
 - Confirm the academic-year selector can switch to AY `2025-26`, `2024-25`, and `2023-24`.
 - Open `index.html` signed out on a production-like host or with `?auth=required`; confirm it redirects to login.
@@ -17,6 +19,7 @@ Use this before sharing `public-schedule.html` outside the authenticated Program
 ## Production Rollout
 
 - Apply `scripts/supabase-public-schedule-read.sql` to production before deploying the frontend.
+- Apply `scripts/supabase-sync-course-catalog.sql` to production if the public schedule shows stale course titles.
 - Verify AY `2026-27`, `2025-26`, `2024-25`, and `2023-24` exist for `ewu-design`.
 - Verify Fall `scheduled_courses` rows exist for each public academic year that should show published history.
 - Deploy the frontend containing `public-schedule.html`, `css/public-schedule.css`, and `pages/public-schedule.js`.

--- a/docs/public-schedule-release-checklist.md
+++ b/docs/public-schedule-release-checklist.md
@@ -1,0 +1,29 @@
+# Public Schedule Release Checklist
+
+Use this before sharing `public-schedule.html` outside the authenticated Program Command workflow.
+
+## Dev Validation
+
+- Apply `scripts/supabase-public-schedule-read.sql` to the dev Supabase project.
+- Confirm the RPC exists: `public.get_public_schedule(text, text, text)`.
+- Confirm anon can execute the RPC for `2026-27` / `ewu-design`.
+- Confirm anon cannot insert, update, or delete `academic_years` or `scheduled_courses`.
+- Open `public-schedule.html` signed out.
+- Confirm the default view is `AY 2026-27`, `Fall 2026`.
+- Confirm the public schedule rows match the authenticated scheduler for AY 2026-27 Fall.
+- Open `index.html` signed out on a production-like host or with `?auth=required`; confirm it redirects to login.
+
+## Production Rollout
+
+- Apply `scripts/supabase-public-schedule-read.sql` to production before deploying the frontend.
+- Verify AY `2026-27` exists for `ewu-design`.
+- Verify Fall `scheduled_courses` rows exist and reflect the intended published schedule.
+- Deploy the frontend containing `public-schedule.html`, `css/public-schedule.css`, and `pages/public-schedule.js`.
+- Open the public URL in a private browser window.
+- Confirm no Save, Add Course, import, dashboard, workload, or admin controls are visible.
+
+## Rollback Trigger
+
+- If the public page exposes editor controls, remove or block `public-schedule.html` from the deployment.
+- If the RPC returns incorrect or overbroad data, revoke execute on `public.get_public_schedule(text, text, text)` from `anon` until the SQL is corrected.
+- If protected routes stop redirecting signed-out users, roll back the frontend deploy.

--- a/docs/public-schedule-release-checklist.md
+++ b/docs/public-schedule-release-checklist.md
@@ -11,7 +11,7 @@ Use this before sharing `public-schedule.html` outside the authenticated Program
 - Confirm anon cannot insert, update, or delete `academic_years` or `scheduled_courses`.
 - Open `public-schedule.html` signed out.
 - Confirm the default view is `AY 2026-27`, `Fall 2026`.
-- Confirm displayed course titles match `data/course-catalog.json`.
+- Confirm displayed course titles match the authenticated scheduler, including canonical catalog titles such as `DESN 368` -> `Code + Design 1`.
 - Confirm the public schedule rows match the authenticated scheduler for AY 2026-27 Fall.
 - Confirm the academic-year selector can switch to AY `2025-26`, `2024-25`, and `2023-24`.
 - Open `index.html` signed out on a production-like host or with `?auth=required`; confirm it redirects to login.

--- a/js/supabase-config.js
+++ b/js/supabase-config.js
@@ -1,17 +1,225 @@
 /**
  * Supabase Configuration
  *
- * SETUP INSTRUCTIONS:
- * 1. Go to https://supabase.com and create a free account
- * 2. Create a new project (e.g., "ewu-schedule")
- * 3. Go to Project Settings > API
- * 4. Copy your Project URL and paste below
- * 5. Copy your anon/public key and paste below
+ * Host defaults:
+ * - public-schedule.html: production database
+ * - other localhost / 127.0.0.1 pages: develop database
+ * - deployed hosts: production database
+ *
+ * Local overrides:
+ * - ?supabaseEnv=production or ?supabaseEnv=develop
+ * - localStorage.setItem('programCommand.supabase.environment', 'develop')
+ * - localStorage.setItem('programCommand.supabase.develop.anonKey', '<anon key>')
  */
 
-// Supabase project credentials
-const SUPABASE_URL = 'https://ohnrhjxcjkrdtudpzjgn.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9obnJoanhjamtyZHR1ZHB6amduIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ5NDQ2NzAsImV4cCI6MjA4MDUyMDY3MH0.XN1CC0xC5dizIhF4cIEkv90TApJHXRBYTC7a6AXPvtU';
+const SUPABASE_ENVIRONMENTS = Object.freeze({
+    production: Object.freeze({
+        name: 'production',
+        label: 'Production',
+        projectRef: 'ohnrhjxcjkrdtudpzjgn',
+        url: 'https://ohnrhjxcjkrdtudpzjgn.supabase.co',
+        anonKey: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9obnJoanhjamtyZHR1ZHB6amduIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ5NDQ2NzAsImV4cCI6MjA4MDUyMDY3MH0.XN1CC0xC5dizIhF4cIEkv90TApJHXRBYTC7a6AXPvtU'
+    }),
+    develop: Object.freeze({
+        name: 'develop',
+        label: 'Develop',
+        projectRef: 'cstcwplvioheazoghkgf',
+        url: 'https://cstcwplvioheazoghkgf.supabase.co',
+        anonKey: ''
+    })
+});
+
+const SUPABASE_STORAGE_KEYS = Object.freeze({
+    environment: 'programCommand.supabase.environment',
+    url: (environmentName) => `programCommand.supabase.${environmentName}.url`,
+    anonKey: (environmentName) => `programCommand.supabase.${environmentName}.anonKey`
+});
+
+function getSupabaseRoot() {
+    if (typeof window !== 'undefined') {
+        return window;
+    }
+
+    if (typeof globalThis !== 'undefined') {
+        return globalThis;
+    }
+
+    return {};
+}
+
+function getSupabaseLocation() {
+    const root = getSupabaseRoot();
+
+    if (root.location) {
+        return root.location;
+    }
+
+    if (typeof location !== 'undefined') {
+        return location;
+    }
+
+    return null;
+}
+
+function readSupabaseSearchParam(name) {
+    const currentLocation = getSupabaseLocation();
+
+    if (!currentLocation || !currentLocation.search || typeof URLSearchParams === 'undefined') {
+        return '';
+    }
+
+    try {
+        return new URLSearchParams(currentLocation.search).get(name) || '';
+    } catch (error) {
+        return '';
+    }
+}
+
+function readSupabaseStorageValue(key) {
+    const root = getSupabaseRoot();
+    const stores = [root.sessionStorage, root.localStorage];
+
+    for (const store of stores) {
+        if (!store || typeof store.getItem !== 'function') {
+            continue;
+        }
+
+        try {
+            const value = store.getItem(key);
+            if (value) {
+                return value;
+            }
+        } catch (error) {
+            // Storage may be blocked in private contexts.
+        }
+    }
+
+    return '';
+}
+
+function writeSupabaseStorageValue(key, value) {
+    const root = getSupabaseRoot();
+
+    if (!root.localStorage || typeof root.localStorage.setItem !== 'function') {
+        return false;
+    }
+
+    try {
+        root.localStorage.setItem(key, value);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+function removeSupabaseStorageValue(key) {
+    const root = getSupabaseRoot();
+
+    if (!root.localStorage || typeof root.localStorage.removeItem !== 'function') {
+        return false;
+    }
+
+    try {
+        root.localStorage.removeItem(key);
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
+
+function normalizeSupabaseEnvironmentName(value) {
+    const normalized = String(value || '').trim().toLowerCase();
+
+    if (normalized === 'dev' || normalized === 'development') {
+        return 'develop';
+    }
+
+    if (normalized === 'prod') {
+        return 'production';
+    }
+
+    if (SUPABASE_ENVIRONMENTS[normalized]) {
+        return normalized;
+    }
+
+    return '';
+}
+
+function isLocalSupabaseHost(hostname) {
+    const normalized = String(hostname || '').trim().toLowerCase();
+
+    return normalized === 'localhost' ||
+        normalized === '127.0.0.1' ||
+        normalized === '::1' ||
+        normalized.endsWith('.local');
+}
+
+function isPublicSchedulePage() {
+    const currentLocation = getSupabaseLocation();
+    const pathname = currentLocation && currentLocation.pathname ? currentLocation.pathname : '';
+
+    return /(^|\/)public-schedule\.html$/i.test(pathname);
+}
+
+function getDefaultSupabaseEnvironmentName() {
+    const currentLocation = getSupabaseLocation();
+    const hostname = currentLocation && currentLocation.hostname ? currentLocation.hostname : '';
+
+    if (isPublicSchedulePage()) {
+        return 'production';
+    }
+
+    return isLocalSupabaseHost(hostname) ? 'develop' : 'production';
+}
+
+function getRequestedSupabaseEnvironmentName() {
+    return normalizeSupabaseEnvironmentName(
+        readSupabaseSearchParam('supabaseEnv') ||
+        readSupabaseSearchParam('supabaseEnvironment') ||
+        readSupabaseStorageValue(SUPABASE_STORAGE_KEYS.environment)
+    );
+}
+
+function readWindowSupabaseOverride(environmentName, key) {
+    const root = getSupabaseRoot();
+    const config = root.PROGRAM_COMMAND_SUPABASE_CONFIG || {};
+    const environmentConfig = config[environmentName] || {};
+
+    return environmentConfig[key] || '';
+}
+
+function readSupabaseOverride(environmentName, key) {
+    const queryParam = key === 'url' ? 'supabaseUrl' : 'supabaseAnonKey';
+
+    return readSupabaseSearchParam(queryParam) ||
+        readSupabaseStorageValue(SUPABASE_STORAGE_KEYS[key](environmentName)) ||
+        readWindowSupabaseOverride(environmentName, key);
+}
+
+function resolveSupabaseEnvironmentConfig() {
+    const environmentName = getRequestedSupabaseEnvironmentName() || getDefaultSupabaseEnvironmentName();
+    const baseConfig = SUPABASE_ENVIRONMENTS[environmentName] || SUPABASE_ENVIRONMENTS.production;
+
+    return {
+        name: baseConfig.name,
+        label: baseConfig.label,
+        projectRef: baseConfig.projectRef,
+        url: readSupabaseOverride(baseConfig.name, 'url') || baseConfig.url,
+        anonKey: readSupabaseOverride(baseConfig.name, 'anonKey') || baseConfig.anonKey
+    };
+}
+
+function isUsableSupabaseValue(value) {
+    const normalized = String(value || '').trim();
+
+    return Boolean(normalized) &&
+        normalized !== 'YOUR_SUPABASE_PROJECT_URL' &&
+        normalized !== 'YOUR_SUPABASE_ANON_KEY';
+}
+
+const SUPABASE_CONFIG = Object.freeze(resolveSupabaseEnvironmentConfig());
+const SUPABASE_URL = SUPABASE_CONFIG.url;
+const SUPABASE_ANON_KEY = SUPABASE_CONFIG.anonKey;
 
 // Current department code (for multi-department support)
 const CURRENT_DEPARTMENT_CODE = 'DESN';
@@ -28,8 +236,22 @@ let supabaseClient = null;
 var supabase = null; // Global reference for other services (var to avoid redeclaration issues)
 
 function isSupabaseConfigured() {
-    return SUPABASE_URL !== 'YOUR_SUPABASE_PROJECT_URL' &&
-           SUPABASE_ANON_KEY !== 'YOUR_SUPABASE_ANON_KEY';
+    return isUsableSupabaseValue(SUPABASE_URL) &&
+           isUsableSupabaseValue(SUPABASE_ANON_KEY);
+}
+
+function getSupabaseEnvironment() {
+    return SUPABASE_CONFIG.name;
+}
+
+function getSupabaseEnvironmentConfig() {
+    return {
+        name: SUPABASE_CONFIG.name,
+        label: SUPABASE_CONFIG.label,
+        projectRef: SUPABASE_CONFIG.projectRef,
+        url: SUPABASE_CONFIG.url,
+        anonKeyConfigured: isUsableSupabaseValue(SUPABASE_CONFIG.anonKey)
+    };
 }
 
 function initSupabase() {
@@ -38,7 +260,7 @@ function initSupabase() {
     }
 
     if (!isSupabaseConfigured()) {
-        console.warn('Supabase not configured. Using local JSON files as fallback.');
+        console.warn(`Supabase ${SUPABASE_CONFIG.name} is not configured. Check the anon key for ${SUPABASE_CONFIG.projectRef}.`);
         return null;
     }
 
@@ -64,7 +286,7 @@ function initSupabase() {
     // Expose client for module and non-module scripts.
     window.supabaseClient = supabaseClient;
     window.getSupabaseClient = getSupabaseClient;
-    console.log('Supabase client initialized successfully');
+    console.log(`Supabase client initialized successfully (${SUPABASE_CONFIG.name}: ${SUPABASE_CONFIG.projectRef})`);
     return supabaseClient;
 }
 
@@ -81,6 +303,32 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 if (typeof window !== 'undefined') {
+    window.SUPABASE_ENVIRONMENTS = SUPABASE_ENVIRONMENTS;
+    window.SUPABASE_CONFIG = getSupabaseEnvironmentConfig();
+    window.getSupabaseEnvironment = getSupabaseEnvironment;
+    window.getSupabaseEnvironmentConfig = getSupabaseEnvironmentConfig;
+    window.isSupabaseConfigured = isSupabaseConfigured;
     window.getSupabaseClient = getSupabaseClient;
     window.initSupabase = initSupabase;
+    window.ProgramCommandSupabase = {
+        getEnvironment: getSupabaseEnvironment,
+        getConfig: getSupabaseEnvironmentConfig,
+        setEnvironment(environmentName) {
+            const normalized = normalizeSupabaseEnvironmentName(environmentName);
+            if (!normalized) {
+                throw new Error(`Unknown Supabase environment: ${environmentName}`);
+            }
+            return writeSupabaseStorageValue(SUPABASE_STORAGE_KEYS.environment, normalized);
+        },
+        setDevelopAnonKey(anonKey) {
+            return writeSupabaseStorageValue(SUPABASE_STORAGE_KEYS.anonKey('develop'), anonKey);
+        },
+        clearLocalOverrides() {
+            removeSupabaseStorageValue(SUPABASE_STORAGE_KEYS.environment);
+            Object.keys(SUPABASE_ENVIRONMENTS).forEach((environmentName) => {
+                removeSupabaseStorageValue(SUPABASE_STORAGE_KEYS.url(environmentName));
+                removeSupabaseStorageValue(SUPABASE_STORAGE_KEYS.anonKey(environmentName));
+            });
+        }
+    };
 }

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -398,14 +398,12 @@
                     name: info.name,
                     className: info.className,
                     color: info.color,
-                    sections: 0,
-                    credits: 0
+                    sections: 0
                 });
             }
 
             const summary = summaries.get(info.name);
             summary.sections += 1;
-            summary.credits += Number(course.credits) || 5;
         });
 
         return Array.from(summaries.values()).sort((a, b) => {
@@ -436,7 +434,7 @@
             item.style.setProperty('--faculty-accent', entry.color);
             item.appendChild(createElement(state.documentRef, 'span', 'public-faculty-swatch'));
             item.appendChild(createElement(state.documentRef, 'span', 'public-faculty-name', entry.name));
-            item.appendChild(createElement(state.documentRef, 'span', 'public-faculty-meta', `${entry.sections} sec | ${entry.credits} cr`));
+            item.appendChild(createElement(state.documentRef, 'span', 'public-faculty-meta', `${entry.sections} ${entry.sections === 1 ? 'section' : 'sections'}`));
             list.appendChild(item);
         });
         legend.appendChild(list);

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -218,27 +218,6 @@
         return Array.from(seen);
     }
 
-    function renderQuarterTabs(state) {
-        const { documentRef, scheduleData, activeQuarter, year, utils, onQuarterChange } = state;
-        const tabs = documentRef.getElementById('publicQuarterTabs');
-        clearElement(tabs);
-
-        QUARTERS.forEach((quarter) => {
-            const button = createElement(documentRef, 'button', 'public-quarter-tab');
-            button.type = 'button';
-            button.setAttribute('role', 'tab');
-            button.setAttribute('aria-selected', quarter === activeQuarter ? 'true' : 'false');
-            button.dataset.quarter = quarter;
-            button.textContent = QUARTER_LABELS[quarter];
-
-            const yearSpan = createElement(documentRef, 'span', '', getDisplayYear(year, quarter));
-            button.appendChild(yearSpan);
-            button.title = `${formatQuarterTitle(year, quarter)} (${countQuarterCourses(scheduleData, quarter, { scheduleDataUtils: utils })} sections)`;
-            button.addEventListener('click', () => onQuarterChange(quarter));
-            tabs.appendChild(button);
-        });
-    }
-
     function renderScheduleGrid(state) {
         const { documentRef, scheduleData, activeQuarter } = state;
         const grid = documentRef.getElementById('publicScheduleGrid');
@@ -324,10 +303,8 @@
         setText(state.documentRef, 'publicQuarterLabel', quarterTitle);
         setText(state.documentRef, 'publicScheduleTitle', quarterTitle);
         setText(state.documentRef, 'publicScheduleSubtitle', `AY ${state.year}`);
-        setText(state.documentRef, 'publicSummary', countLabel);
         setText(state.documentRef, 'publicPanelCount', countLabel);
 
-        renderQuarterTabs(state);
         if (count === 0) {
             renderEmptyState(state);
             return;
@@ -361,11 +338,7 @@
             year,
             programCode,
             activeQuarter: options.quarter || DEFAULTS.quarter,
-            scheduleData: createEmptySchedule(utils),
-            onQuarterChange: (quarter) => {
-                state.activeQuarter = quarter;
-                render(state);
-            }
+            scheduleData: createEmptySchedule(utils)
         };
 
         async function load() {
@@ -377,7 +350,7 @@
             const { data, error } = await client.rpc('get_public_schedule', {
                 p_academic_year: year,
                 p_program_code: programCode,
-                p_quarter: null
+                p_quarter: state.activeQuarter
             });
 
             if (error) throw error;

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -1,0 +1,419 @@
+(function(root, factory) {
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = factory(root);
+        return;
+    }
+
+    const api = factory(root);
+    root.PublicSchedulePage = api;
+    if (root.document) {
+        root.document.addEventListener('DOMContentLoaded', () => {
+            api.createPublicScheduleApp().init();
+        });
+    }
+})(typeof globalThis !== 'undefined' ? globalThis : this, function(root) {
+    'use strict';
+
+    const DEFAULTS = Object.freeze({
+        year: '2026-27',
+        quarter: 'fall',
+        programCode: 'ewu-design'
+    });
+
+    const QUARTERS = Object.freeze(['fall', 'winter', 'spring']);
+    const QUARTER_LABELS = Object.freeze({
+        fall: 'Fall',
+        winter: 'Winter',
+        spring: 'Spring'
+    });
+    const DAY_PATTERNS = Object.freeze([
+        { id: 'MW', label: 'Monday / Wednesday' },
+        { id: 'TR', label: 'Tuesday / Thursday' }
+    ]);
+    const TIME_SLOTS = Object.freeze(['10:00-12:20', '13:00-15:20', '16:00-18:20']);
+    const ROOM_ORDER = Object.freeze(['206', '207', '209', '210', '212', 'CEB 102', 'CEB 104']);
+    const ROOM_LABELS = Object.freeze({
+        '206': '206 UX Lab',
+        '207': '207 Media Lab',
+        '209': '209 Mac Lab',
+        '210': '210 Mac Lab',
+        '212': '212 Project Lab',
+        'CEB 102': 'CEB 102',
+        'CEB 104': 'CEB 104'
+    });
+
+    function resolveScheduleDataUtils(options) {
+        return options.scheduleDataUtils
+            || root.ScheduleDataUtils
+            || {};
+    }
+
+    function resolveDocument(options) {
+        return options.document || root.document || null;
+    }
+
+    function normalizeCourseCode(value) {
+        return String(value || '').trim().toUpperCase().replace(/\s+/g, ' ');
+    }
+
+    function formatClock(value) {
+        const [hourText, minuteText] = String(value || '').split(':');
+        const hour = Number(hourText);
+        const minute = Number(minuteText);
+        if (!Number.isFinite(hour) || !Number.isFinite(minute)) return String(value || '').trim();
+        const suffix = hour >= 12 ? 'PM' : 'AM';
+        const displayHour = hour % 12 || 12;
+        return `${displayHour}:${String(minute).padStart(2, '0')} ${suffix}`;
+    }
+
+    function formatTimeSlot(value) {
+        const [start, end] = String(value || '').split('-');
+        if (!start || !end) return String(value || '').trim();
+        return `${formatClock(start)} - ${formatClock(end)}`;
+    }
+
+    function getDisplayYear(year, quarter) {
+        const [startYearText] = String(year || DEFAULTS.year).split('-');
+        const startYear = Number(startYearText);
+        if (!Number.isFinite(startYear)) return '';
+        return quarter === 'fall' ? String(startYear) : String(startYear + 1);
+    }
+
+    function formatQuarterTitle(year, quarter) {
+        const quarterKey = String(quarter || DEFAULTS.quarter).toLowerCase();
+        return `${QUARTER_LABELS[quarterKey] || quarterKey} ${getDisplayYear(year, quarterKey)}`;
+    }
+
+    function normalizePublicScheduleRows(rows) {
+        return (Array.isArray(rows) ? rows : []).map((row) => ({
+            quarter: row.quarter,
+            day_pattern: row.day_pattern,
+            time_slot: row.time_slot,
+            section: row.section,
+            projected_enrollment: row.projected_enrollment,
+            course: {
+                code: row.course_code,
+                title: row.course_title,
+                default_credits: row.credits
+            },
+            faculty: {
+                name: row.instructor_name
+            },
+            room: {
+                room_code: row.room_code
+            }
+        }));
+    }
+
+    function createEmptySchedule(utils) {
+        if (typeof utils.createEmptyAcademicYearScheduleData === 'function') {
+            return utils.createEmptyAcademicYearScheduleData({
+                quarters: QUARTERS,
+                dayPatterns: DAY_PATTERNS.map((day) => day.id)
+            });
+        }
+
+        return QUARTERS.reduce((schedule, quarter) => {
+            schedule[quarter] = {
+                ONLINE: { async: [] },
+                ARRANGED: { arranged: [] },
+                MW: {},
+                TR: {}
+            };
+            return schedule;
+        }, {});
+    }
+
+    function buildScheduleFromPublicRows(rows, options = {}) {
+        const utils = resolveScheduleDataUtils(options);
+        const normalizedRows = normalizePublicScheduleRows(rows);
+
+        if (typeof utils.buildScheduleDataFromDatabaseRecords === 'function') {
+            return utils.buildScheduleDataFromDatabaseRecords(normalizedRows, {
+                quarters: QUARTERS,
+                dayPatterns: DAY_PATTERNS.map((day) => day.id),
+                normalizeCourseCode,
+                normalizeInstructor: (value) => String(value || '').trim() || 'TBD',
+                normalizeRoom: (value) => String(value || '').trim()
+            });
+        }
+
+        return createEmptySchedule(utils);
+    }
+
+    function getQuarterCourses(scheduleData, quarter, utils) {
+        const quarterData = scheduleData && scheduleData[quarter];
+        if (!quarterData) return [];
+        if (typeof utils.flattenQuarterData === 'function') {
+            return utils.flattenQuarterData(quarterData);
+        }
+
+        const courses = [];
+        Object.entries(quarterData).forEach(([day, dayData]) => {
+            if (!dayData || typeof dayData !== 'object') return;
+            Object.entries(dayData).forEach(([time, list]) => {
+                if (!Array.isArray(list)) return;
+                list.forEach((course) => courses.push({ ...course, day, time }));
+            });
+        });
+        return courses;
+    }
+
+    function countQuarterCourses(scheduleData, quarter, options = {}) {
+        return getQuarterCourses(scheduleData, quarter, resolveScheduleDataUtils(options)).length;
+    }
+
+    function setText(documentRef, id, value) {
+        const element = documentRef.getElementById(id);
+        if (element) element.textContent = value;
+    }
+
+    function clearElement(element) {
+        if (!element) return;
+        while (element.firstChild) {
+            element.removeChild(element.firstChild);
+        }
+    }
+
+    function createElement(documentRef, tagName, className, text) {
+        const element = documentRef.createElement(tagName);
+        if (className) element.className = className;
+        if (text !== undefined && text !== null) element.textContent = text;
+        return element;
+    }
+
+    function createCourseBlock(documentRef, course) {
+        const block = createElement(documentRef, 'article', 'public-course-block');
+
+        const code = createElement(documentRef, 'div', 'public-course-code', normalizeCourseCode(course.code));
+        const title = createElement(documentRef, 'div', 'public-course-title', String(course.name || course.title || 'Untitled course').trim());
+        const instructor = createElement(documentRef, 'div', 'public-course-meta', String(course.instructor || 'TBD').trim());
+        const details = [];
+        if (course.section) details.push(`Section ${course.section}`);
+        if (course.credits) details.push(`${course.credits} cr`);
+        if (course.enrollmentCap) details.push(`Cap ${course.enrollmentCap}`);
+        const section = createElement(documentRef, 'div', 'public-course-section', details.join(' | '));
+
+        block.appendChild(code);
+        block.appendChild(title);
+        block.appendChild(instructor);
+        if (details.length) block.appendChild(section);
+        return block;
+    }
+
+    function getCoursesForCell(scheduleData, quarter, day, time, room) {
+        const list = scheduleData?.[quarter]?.[day]?.[time];
+        if (!Array.isArray(list)) return [];
+        return list.filter((course) => String(course.room || '').trim() === room);
+    }
+
+    function getKnownRooms(scheduleData, quarter) {
+        const seen = new Set(ROOM_ORDER);
+        getQuarterCourses(scheduleData, quarter, { flattenQuarterData: null }).forEach((course) => {
+            const room = String(course.room || '').trim();
+            if (room && room !== 'ONLINE' && room !== 'ARRANGED' && room !== 'TBD') {
+                seen.add(room);
+            }
+        });
+        return Array.from(seen);
+    }
+
+    function renderQuarterTabs(state) {
+        const { documentRef, scheduleData, activeQuarter, year, utils, onQuarterChange } = state;
+        const tabs = documentRef.getElementById('publicQuarterTabs');
+        clearElement(tabs);
+
+        QUARTERS.forEach((quarter) => {
+            const button = createElement(documentRef, 'button', 'public-quarter-tab');
+            button.type = 'button';
+            button.setAttribute('role', 'tab');
+            button.setAttribute('aria-selected', quarter === activeQuarter ? 'true' : 'false');
+            button.dataset.quarter = quarter;
+            button.textContent = QUARTER_LABELS[quarter];
+
+            const yearSpan = createElement(documentRef, 'span', '', getDisplayYear(year, quarter));
+            button.appendChild(yearSpan);
+            button.title = `${formatQuarterTitle(year, quarter)} (${countQuarterCourses(scheduleData, quarter, { scheduleDataUtils: utils })} sections)`;
+            button.addEventListener('click', () => onQuarterChange(quarter));
+            tabs.appendChild(button);
+        });
+    }
+
+    function renderScheduleGrid(state) {
+        const { documentRef, scheduleData, activeQuarter } = state;
+        const grid = documentRef.getElementById('publicScheduleGrid');
+        clearElement(grid);
+
+        const rooms = getKnownRooms(scheduleData, activeQuarter);
+        grid.style.gridTemplateColumns = `104px repeat(${rooms.length}, minmax(132px, 1fr))`;
+
+        ['Time', ...rooms.map((room) => ROOM_LABELS[room] || room)].forEach((label) => {
+            grid.appendChild(createElement(documentRef, 'div', 'public-grid-header', label));
+        });
+
+        DAY_PATTERNS.forEach((day) => {
+            const divider = createElement(documentRef, 'div', 'public-day-divider', day.label);
+            grid.appendChild(divider);
+
+            TIME_SLOTS.forEach((time) => {
+                grid.appendChild(createElement(documentRef, 'div', 'public-time-slot', formatTimeSlot(time)));
+
+                rooms.forEach((room) => {
+                    const cell = createElement(documentRef, 'div', 'public-schedule-cell');
+                    const courses = getCoursesForCell(scheduleData, activeQuarter, day.id, time, room);
+                    courses.forEach((course) => cell.appendChild(createCourseBlock(documentRef, course)));
+                    grid.appendChild(cell);
+                });
+            });
+        });
+    }
+
+    function renderSpecialSections(state) {
+        const { documentRef, scheduleData, activeQuarter, utils } = state;
+        const container = documentRef.getElementById('publicSpecialSections');
+        clearElement(container);
+
+        const quarterData = scheduleData?.[activeQuarter] || {};
+        const onlineCourses = typeof utils.getOnlineCoursesForQuarter === 'function'
+            ? utils.getOnlineCoursesForQuarter(quarterData)
+            : (quarterData.ONLINE?.async || []);
+        const arrangedCourses = quarterData.ARRANGED?.arranged || [];
+
+        [
+            { title: 'Online', courses: onlineCourses },
+            { title: 'Arranged', courses: arrangedCourses }
+        ].forEach((group) => {
+            if (!group.courses.length) return;
+
+            const section = createElement(documentRef, 'section', 'public-special-group');
+            const heading = createElement(documentRef, 'div', 'public-special-heading');
+            heading.appendChild(createElement(documentRef, 'h3', '', group.title));
+            heading.appendChild(createElement(documentRef, 'span', 'public-summary', `${group.courses.length} sections`));
+
+            const list = createElement(documentRef, 'div', 'public-special-list');
+            group.courses.forEach((course) => list.appendChild(createCourseBlock(documentRef, course)));
+
+            section.appendChild(heading);
+            section.appendChild(list);
+            container.appendChild(section);
+        });
+    }
+
+    function renderEmptyState(state) {
+        const grid = state.documentRef.getElementById('publicScheduleGrid');
+        clearElement(grid);
+        grid.style.gridTemplateColumns = '1fr';
+        grid.appendChild(createElement(state.documentRef, 'div', 'public-empty', 'No public schedule rows are available for this quarter.'));
+        clearElement(state.documentRef.getElementById('publicSpecialSections'));
+    }
+
+    function renderErrorState(state, message) {
+        const grid = state.documentRef.getElementById('publicScheduleGrid');
+        clearElement(grid);
+        grid.style.gridTemplateColumns = '1fr';
+        grid.appendChild(createElement(state.documentRef, 'div', 'public-error', message || 'The public schedule could not be loaded.'));
+        clearElement(state.documentRef.getElementById('publicSpecialSections'));
+    }
+
+    function render(state) {
+        const quarterTitle = formatQuarterTitle(state.year, state.activeQuarter);
+        const count = countQuarterCourses(state.scheduleData, state.activeQuarter, { scheduleDataUtils: state.utils });
+        const countLabel = `${count} ${count === 1 ? 'section' : 'sections'}`;
+
+        setText(state.documentRef, 'publicAcademicYearLabel', `AY ${state.year}`);
+        setText(state.documentRef, 'publicQuarterLabel', quarterTitle);
+        setText(state.documentRef, 'publicScheduleTitle', quarterTitle);
+        setText(state.documentRef, 'publicScheduleSubtitle', `AY ${state.year}`);
+        setText(state.documentRef, 'publicSummary', countLabel);
+        setText(state.documentRef, 'publicPanelCount', countLabel);
+
+        renderQuarterTabs(state);
+        if (count === 0) {
+            renderEmptyState(state);
+            return;
+        }
+        renderScheduleGrid(state);
+        renderSpecialSections(state);
+    }
+
+    function setStatus(documentRef, text, state) {
+        const status = documentRef.getElementById('publicStatus');
+        if (!status) return;
+        status.textContent = text;
+        if (state) status.dataset.state = state;
+    }
+
+    function createPublicScheduleApp(options = {}) {
+        const documentRef = resolveDocument(options);
+        const utils = resolveScheduleDataUtils(options);
+        const year = options.year || DEFAULTS.year;
+        const programCode = options.programCode || DEFAULTS.programCode;
+        const getClient = options.getClient || (() => {
+            if (typeof root.getSupabaseClient === 'function') {
+                return root.getSupabaseClient();
+            }
+            return null;
+        });
+
+        const state = {
+            documentRef,
+            utils,
+            year,
+            programCode,
+            activeQuarter: options.quarter || DEFAULTS.quarter,
+            scheduleData: createEmptySchedule(utils),
+            onQuarterChange: (quarter) => {
+                state.activeQuarter = quarter;
+                render(state);
+            }
+        };
+
+        async function load() {
+            const client = getClient();
+            if (!client || typeof client.rpc !== 'function') {
+                throw new Error('Public schedule data service is not available.');
+            }
+
+            const { data, error } = await client.rpc('get_public_schedule', {
+                p_academic_year: year,
+                p_program_code: programCode,
+                p_quarter: null
+            });
+
+            if (error) throw error;
+            return buildScheduleFromPublicRows(data || [], { scheduleDataUtils: utils });
+        }
+
+        return {
+            state,
+            async init() {
+                if (!documentRef) return;
+                setStatus(documentRef, 'Loading', 'loading');
+                render(state);
+
+                try {
+                    state.scheduleData = await load();
+                    setStatus(documentRef, 'Live schedule', 'ready');
+                    render(state);
+                } catch (error) {
+                    setStatus(documentRef, 'Unavailable', 'error');
+                    renderErrorState(state, error.message || 'The public schedule could not be loaded.');
+                }
+            }
+        };
+    }
+
+    return {
+        DEFAULTS,
+        QUARTERS,
+        DAY_PATTERNS,
+        TIME_SLOTS,
+        ROOM_ORDER,
+        buildScheduleFromPublicRows,
+        countQuarterCourses,
+        createPublicScheduleApp,
+        formatQuarterTitle,
+        formatTimeSlot,
+        normalizePublicScheduleRows
+    };
+});

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -20,6 +20,7 @@
         programCode: 'ewu-design'
     });
 
+    const PUBLIC_YEARS = Object.freeze(['2026-27', '2025-26', '2024-25', '2023-24']);
     const QUARTERS = Object.freeze(['fall', 'winter', 'spring']);
     const QUARTER_LABELS = Object.freeze({
         fall: 'Fall',
@@ -168,6 +169,16 @@
     function formatQuarterTitle(year, quarter) {
         const quarterKey = String(quarter || DEFAULTS.quarter).toLowerCase();
         return `${QUARTER_LABELS[quarterKey] || quarterKey} ${getDisplayYear(year, quarterKey)}`;
+    }
+
+    function normalizePublicYear(value) {
+        const year = String(value || '').trim();
+        return PUBLIC_YEARS.includes(year) ? year : DEFAULTS.year;
+    }
+
+    function normalizePublicQuarter(value) {
+        const quarter = String(value || '').trim().toLowerCase();
+        return QUARTERS.includes(quarter) ? quarter : DEFAULTS.quarter;
     }
 
     function normalizePublicScheduleRows(rows) {
@@ -322,6 +333,30 @@
 
     function getKnownRooms(scheduleData, quarter) {
         return ROOM_ORDER;
+    }
+
+    function renderYearTabs(state) {
+        const { documentRef, year } = state;
+        const tabs = documentRef.getElementById('publicYearTabs');
+        clearElement(tabs);
+        if (!tabs) return;
+
+        PUBLIC_YEARS.forEach((publicYear) => {
+            const button = createElement(documentRef, 'button', 'public-year-tab');
+            button.type = 'button';
+            button.setAttribute('role', 'tab');
+            button.setAttribute('aria-selected', publicYear === year ? 'true' : 'false');
+            button.dataset.year = publicYear;
+            button.appendChild(createElement(documentRef, 'span', 'public-year-label', 'AY'));
+            button.appendChild(createElement(documentRef, 'span', 'public-year-value', publicYear));
+            button.title = `Academic year ${publicYear}`;
+            button.addEventListener('click', () => {
+                if (typeof state.onYearChange === 'function') {
+                    state.onYearChange(publicYear);
+                }
+            });
+            tabs.appendChild(button);
+        });
     }
 
     function renderQuarterTabs(state) {
@@ -491,6 +526,7 @@
         setText(state.documentRef, 'publicScheduleSubtitle', `AY ${state.year}`);
         setText(state.documentRef, 'publicPanelCount', countLabel);
 
+        renderYearTabs(state);
         renderQuarterTabs(state);
         renderFacultyLegend(state);
         if (count === 0) {
@@ -511,7 +547,6 @@
     function createPublicScheduleApp(options = {}) {
         const documentRef = resolveDocument(options);
         const utils = resolveScheduleDataUtils(options);
-        const year = options.year || DEFAULTS.year;
         const programCode = options.programCode || DEFAULTS.programCode;
         const getClient = options.getClient || (() => {
             if (typeof root.getSupabaseClient === 'function') {
@@ -519,24 +554,26 @@
             }
             return null;
         });
+        let loadRequestId = 0;
 
         const state = {
             documentRef,
             utils,
-            year,
+            year: normalizePublicYear(options.year || DEFAULTS.year),
             programCode,
-            activeQuarter: options.quarter || DEFAULTS.quarter,
-            scheduleData: createEmptySchedule(utils)
+            activeQuarter: normalizePublicQuarter(options.quarter || DEFAULTS.quarter),
+            scheduleData: createEmptySchedule(utils),
+            onYearChange: null
         };
 
-        async function load() {
+        async function load(yearToLoad) {
             const client = getClient();
             if (!client || typeof client.rpc !== 'function') {
                 throw new Error('Public schedule data service is not available.');
             }
 
             const { data, error } = await client.rpc('get_public_schedule', {
-                p_academic_year: year,
+                p_academic_year: yearToLoad,
                 p_program_code: programCode,
                 p_quarter: null
             });
@@ -545,27 +582,50 @@
             return buildScheduleFromPublicRows(data || [], { scheduleDataUtils: utils });
         }
 
+        async function loadSelectedYear() {
+            const requestId = loadRequestId + 1;
+            const yearToLoad = state.year;
+            loadRequestId = requestId;
+            state.scheduleData = createEmptySchedule(utils);
+            setStatus(documentRef, 'Loading', 'loading');
+            render(state);
+
+            try {
+                const scheduleData = await load(yearToLoad);
+                if (requestId !== loadRequestId) return;
+                state.scheduleData = scheduleData;
+                setStatus(documentRef, 'Live schedule', 'ready');
+                render(state);
+            } catch (error) {
+                if (requestId !== loadRequestId) return;
+                setStatus(documentRef, 'Unavailable', 'error');
+                renderErrorState(state, error.message || 'The public schedule could not be loaded.');
+            }
+        }
+
+        async function setYear(nextYear) {
+            const publicYear = normalizePublicYear(nextYear);
+            if (publicYear === state.year) return;
+            state.year = publicYear;
+            state.activeQuarter = DEFAULTS.quarter;
+            await loadSelectedYear();
+        }
+
+        state.onYearChange = setYear;
+
         return {
             state,
+            setYear,
             async init() {
                 if (!documentRef) return;
-                setStatus(documentRef, 'Loading', 'loading');
-                render(state);
-
-                try {
-                    state.scheduleData = await load();
-                    setStatus(documentRef, 'Live schedule', 'ready');
-                    render(state);
-                } catch (error) {
-                    setStatus(documentRef, 'Unavailable', 'error');
-                    renderErrorState(state, error.message || 'The public schedule could not be loaded.');
-                }
+                await loadSelectedYear();
             }
         };
     }
 
     return {
         DEFAULTS,
+        PUBLIC_YEARS,
         QUARTERS,
         DAY_PATTERNS,
         TIME_SLOTS,
@@ -579,6 +639,7 @@
         getFallbackFacultyColor,
         getFacultyInfo,
         formatTimeSlot,
+        normalizePublicYear,
         normalizePublicScheduleRows
     };
 });

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -31,16 +31,17 @@
         { id: 'TR', label: 'Tuesday / Thursday' }
     ]);
     const TIME_SLOTS = Object.freeze(['10:00-12:20', '13:00-15:20', '16:00-18:20']);
-    const ROOM_ORDER = Object.freeze(['206', '207', '209', '210', '212', 'CEB 102', 'CEB 104']);
+    const ROOM_ORDER = Object.freeze(['206', '209', '210', '212', 'CEB 102', 'CEB 104']);
     const ROOM_LABELS = Object.freeze({
-        '206': '206 UX Lab',
-        '207': '207 Media Lab',
-        '209': '209 Mac Lab',
-        '210': '210 Mac Lab',
-        '212': '212 Project Lab',
-        'CEB 102': 'CEB 102',
-        'CEB 104': 'CEB 104'
+        '206': 'UX Lab',
+        '209': 'Mac Lab 1',
+        '210': 'Mac Lab 2',
+        '212': 'Mac Lab 3',
+        'CEB 104': 'Mac Lab 4',
+        'CEB 102': 'Design Studio'
     });
+    const PUBLIC_ROOM_SET = new Set(ROOM_ORDER);
+    const PUBLIC_SPECIAL_ROOM_SET = new Set(['ONLINE', 'ARRANGED']);
     const FACULTY_COLORS = Object.freeze({
         'T.Masingale': { className: 'faculty-masingale', color: '#667eea', name: 'T.Masingale' },
         'S.Durr': { className: 'faculty-durr', color: '#e67e22', name: 'S.Durr' },
@@ -237,7 +238,16 @@
     }
 
     function countQuarterCourses(scheduleData, quarter, options = {}) {
-        return getQuarterCourses(scheduleData, quarter, resolveScheduleDataUtils(options)).length;
+        return getPublicQuarterCourses(scheduleData, quarter, resolveScheduleDataUtils(options)).length;
+    }
+
+    function isPubliclyVisibleCourse(course) {
+        const room = String(course?.room || '').trim().toUpperCase();
+        return PUBLIC_ROOM_SET.has(room) || PUBLIC_SPECIAL_ROOM_SET.has(room);
+    }
+
+    function getPublicQuarterCourses(scheduleData, quarter, utils) {
+        return getQuarterCourses(scheduleData, quarter, utils).filter(isPubliclyVisibleCourse);
     }
 
     function setText(documentRef, id, value) {
@@ -292,14 +302,7 @@
     }
 
     function getKnownRooms(scheduleData, quarter) {
-        const seen = new Set(ROOM_ORDER);
-        getQuarterCourses(scheduleData, quarter, { flattenQuarterData: null }).forEach((course) => {
-            const room = String(course.room || '').trim();
-            if (room && room !== 'ONLINE' && room !== 'ARRANGED' && room !== 'TBD') {
-                seen.add(room);
-            }
-        });
-        return Array.from(seen);
+        return ROOM_ORDER;
     }
 
     function renderQuarterTabs(state) {
@@ -388,7 +391,7 @@
     }
 
     function getFacultyLegendEntries(state) {
-        const courses = getQuarterCourses(state.scheduleData, state.activeQuarter, state.utils);
+        const courses = getPublicQuarterCourses(state.scheduleData, state.activeQuarter, state.utils);
         const summaries = new Map();
 
         courses.forEach((course) => {

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -41,6 +41,61 @@
         'CEB 104': 'Mac Lab 4',
         'CEB 102': 'Design Studio'
     });
+    const COURSE_CATALOG_PATH = 'data/course-catalog.json';
+    const COURSE_TITLE_OVERRIDES = Object.freeze({
+        'DESN 100': 'Drawing for Communication',
+        'DESN 200': 'Visual Thinking + Making',
+        'DESN 210': 'Design Lab',
+        'DESN 213': 'Photoshop',
+        'DESN 214': 'Illustrator',
+        'DESN 215': 'Indesign',
+        'DESN 216': 'Digital Foundations',
+        'DESN 217': 'Figma',
+        'DESN 243': 'Typography',
+        'DESN 263': 'Visual Communication Design',
+        'DESN 301': 'Visual Storytelling',
+        'DESN 305': 'Social Media Design and Management',
+        'DESN 325': 'Emergent Design',
+        'DESN 326': 'Introduction to Animation',
+        'DESN 335': 'Board Game Design',
+        'DESN 336': '3D Animation',
+        'DESN 338': 'User Experience Design 1',
+        'DESN 343': 'Typography 2',
+        'DESN 345': 'Digital Game Design',
+        'DESN 348': 'User Experience Design 2',
+        'DESN 350': 'Digital Photography',
+        'DESN 351': 'Advanced Photography',
+        'DESN 355': 'Motion Design',
+        'DESN 359': 'Histories of Design',
+        'DESN 360': 'Zine and Publication Design',
+        'DESN 365': 'Motion Design 2',
+        'DESN 366': 'Production Design',
+        'DESN 368': 'Code + Design 1',
+        'DESN 369': 'Web Development 1',
+        'DESN 374': 'AI + Design',
+        'DESN 375': 'Digital Video',
+        'DESN 378': 'Code + Design 2',
+        'DESN 379': 'Web Development 2',
+        'DESN 384': 'Digital Sound',
+        'DESN 396': 'Experimental Course',
+        'DESN 398': 'Seminar',
+        'DESN 399': 'Directed Study',
+        'DESN 401': 'Imaginary Worlds',
+        'DESN 446': '4D Animation',
+        'DESN 458': 'User Experience Design 3',
+        'DESN 463': 'Community-Driven Design',
+        'DESN 468': 'Code + Design 3',
+        'DESN 469': 'Web Development 3',
+        'DESN 480': 'Professional Practice',
+        'DESN 490': 'Senior Capstone',
+        'DESN 491': 'Senior Project',
+        'DESN 493': 'Portfolio Practice',
+        'DESN 495': 'Internship',
+        'DESN 496': 'Experimental',
+        'DESN 497': 'Workshop, Short Course, Conference, Seminar',
+        'DESN 498': 'Seminar',
+        'DESN 499': 'Directed Study'
+    });
     const PUBLIC_ROOM_SET = new Set(ROOM_ORDER);
     const PUBLIC_SPECIAL_ROOM_SET = new Set(['ONLINE', 'ARRANGED']);
     const FACULTY_COLORS = Object.freeze({
@@ -96,6 +151,65 @@
 
     function normalizeCourseCode(value) {
         return String(value || '').trim().toUpperCase().replace(/\s+/g, ' ');
+    }
+
+    function normalizeCatalogCourse(course) {
+        const code = normalizeCourseCode(course?.code);
+        if (!code) return null;
+        return {
+            code,
+            title: String(course?.title || '').trim(),
+            defaultCredits: Number(course?.defaultCredits ?? course?.default_credits)
+        };
+    }
+
+    function createCourseCatalogByCode(catalog) {
+        const byCode = {};
+        const courses = Array.isArray(catalog?.courses)
+            ? catalog.courses
+            : Array.isArray(catalog)
+                ? catalog
+                : [];
+
+        courses.forEach((course) => {
+            const normalized = normalizeCatalogCourse(course);
+            if (!normalized) return;
+            byCode[normalized.code] = normalized;
+        });
+
+        return byCode;
+    }
+
+    function normalizeCourseCatalogByCode(value) {
+        const byCode = {};
+        if (!value || typeof value !== 'object') return byCode;
+        Object.entries(value).forEach(([code, course]) => {
+            const normalized = normalizeCatalogCourse({
+                ...course,
+                code: course?.code || code
+            });
+            if (!normalized) return;
+            byCode[normalized.code] = normalized;
+        });
+        return byCode;
+    }
+
+    function getCanonicalCourseTitleByCode(courseCode, fallbackTitle = '', courseCatalogByCode = {}) {
+        const code = normalizeCourseCode(courseCode);
+        if (!code) return String(fallbackTitle || '').trim();
+        const overrideTitle = COURSE_TITLE_OVERRIDES[code];
+        if (overrideTitle) return overrideTitle;
+        const catalogTitle = String(courseCatalogByCode?.[code]?.title || '').trim();
+        if (catalogTitle) return catalogTitle;
+        return String(fallbackTitle || '').trim();
+    }
+
+    function getCanonicalCourseCreditsByCode(courseCode, fallbackCredits, courseCatalogByCode = {}) {
+        const code = normalizeCourseCode(courseCode);
+        const catalogCredits = Number(courseCatalogByCode?.[code]?.defaultCredits);
+        if (Number.isFinite(catalogCredits) && catalogCredits > 0) return catalogCredits;
+        const credits = Number(fallbackCredits);
+        return Number.isFinite(credits) && credits > 0 ? credits : 5;
     }
 
     function normalizeFacultyKey(value) {
@@ -181,7 +295,8 @@
         return QUARTERS.includes(quarter) ? quarter : DEFAULTS.quarter;
     }
 
-    function normalizePublicScheduleRows(rows) {
+    function normalizePublicScheduleRows(rows, options = {}) {
+        const courseCatalogByCode = options.courseCatalogByCode || {};
         return (Array.isArray(rows) ? rows : []).map((row) => ({
             quarter: row.quarter,
             day_pattern: row.day_pattern,
@@ -190,8 +305,8 @@
             projected_enrollment: row.projected_enrollment,
             course: {
                 code: row.course_code,
-                title: row.course_title,
-                default_credits: row.credits
+                title: getCanonicalCourseTitleByCode(row.course_code, row.course_title, courseCatalogByCode),
+                default_credits: getCanonicalCourseCreditsByCode(row.course_code, row.credits, courseCatalogByCode)
             },
             faculty: {
                 name: row.instructor_name
@@ -223,7 +338,9 @@
 
     function buildScheduleFromPublicRows(rows, options = {}) {
         const utils = resolveScheduleDataUtils(options);
-        const normalizedRows = normalizePublicScheduleRows(rows);
+        const normalizedRows = normalizePublicScheduleRows(rows, {
+            courseCatalogByCode: options.courseCatalogByCode || {}
+        });
 
         if (typeof utils.buildScheduleDataFromDatabaseRecords === 'function') {
             return utils.buildScheduleDataFromDatabaseRecords(normalizedRows, {
@@ -544,6 +661,32 @@
         if (state) status.dataset.state = state;
     }
 
+    async function loadCourseCatalog(options = {}) {
+        if (options.courseCatalogByCode) {
+            return normalizeCourseCatalogByCode(options.courseCatalogByCode);
+        }
+        if (options.courseCatalog) {
+            return createCourseCatalogByCode(options.courseCatalog);
+        }
+
+        const fetchCatalog = options.fetchCourseCatalog
+            || (typeof root.fetch === 'function'
+                ? (catalogPath) => root.fetch(catalogPath).then((response) => {
+                    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                    return response.json();
+                })
+                : null);
+
+        if (!fetchCatalog) return {};
+
+        try {
+            return createCourseCatalogByCode(await fetchCatalog(options.catalogPath || COURSE_CATALOG_PATH));
+        } catch (error) {
+            console.warn('Could not load public course catalog. Falling back to RPC course titles.', error);
+            return {};
+        }
+    }
+
     function createPublicScheduleApp(options = {}) {
         const documentRef = resolveDocument(options);
         const utils = resolveScheduleDataUtils(options);
@@ -562,9 +705,19 @@
             year: normalizePublicYear(options.year || DEFAULTS.year),
             programCode,
             activeQuarter: normalizePublicQuarter(options.quarter || DEFAULTS.quarter),
+            courseCatalogByCode: {},
             scheduleData: createEmptySchedule(utils),
             onYearChange: null
         };
+        let catalogPromise = null;
+
+        async function ensureCourseCatalogLoaded() {
+            if (!catalogPromise) {
+                catalogPromise = loadCourseCatalog(options);
+            }
+            state.courseCatalogByCode = await catalogPromise;
+            return state.courseCatalogByCode;
+        }
 
         async function load(yearToLoad) {
             const client = getClient();
@@ -572,6 +725,7 @@
                 throw new Error('Public schedule data service is not available.');
             }
 
+            const courseCatalogByCode = await ensureCourseCatalogLoaded();
             const { data, error } = await client.rpc('get_public_schedule', {
                 p_academic_year: yearToLoad,
                 p_program_code: programCode,
@@ -579,7 +733,10 @@
             });
 
             if (error) throw error;
-            return buildScheduleFromPublicRows(data || [], { scheduleDataUtils: utils });
+            return buildScheduleFromPublicRows(data || [], {
+                scheduleDataUtils: utils,
+                courseCatalogByCode
+            });
         }
 
         async function loadSelectedYear() {
@@ -632,12 +789,15 @@
         ROOM_ORDER,
         FACULTY_COLORS,
         buildScheduleFromPublicRows,
+        createCourseCatalogByCode,
         countQuarterCourses,
         createPublicScheduleApp,
         formatQuarterTitle,
+        getCanonicalCourseTitleByCode,
         getCanonicalFacultyName,
         getFallbackFacultyColor,
         getFacultyInfo,
+        loadCourseCatalog,
         formatTimeSlot,
         normalizePublicYear,
         normalizePublicScheduleRows

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -150,6 +150,14 @@
         return `${formatClock(start)} - ${formatClock(end)}`;
     }
 
+    function getTimeSlotParts(value) {
+        const [start, end] = String(value || '').split('-');
+        if (!start || !end) {
+            return { start: String(value || '').trim(), end: '' };
+        }
+        return { start: formatClock(start), end: formatClock(end) };
+    }
+
     function getDisplayYear(year, quarter) {
         const [startYearText] = String(year || DEFAULTS.year).split('-');
         const startYear = Number(startYearText);
@@ -295,6 +303,17 @@
         return block;
     }
 
+    function createTimeSlotElement(documentRef, time) {
+        const parts = getTimeSlotParts(time);
+        const slot = createElement(documentRef, 'div', 'public-time-slot');
+        slot.setAttribute('aria-label', parts.end ? `${parts.start} to ${parts.end}` : parts.start);
+        slot.appendChild(createElement(documentRef, 'span', 'public-time-start', parts.start));
+        if (parts.end) {
+            slot.appendChild(createElement(documentRef, 'span', 'public-time-end', parts.end));
+        }
+        return slot;
+    }
+
     function getCoursesForCell(scheduleData, quarter, day, time, room) {
         const list = scheduleData?.[quarter]?.[day]?.[time];
         if (!Array.isArray(list)) return [];
@@ -347,7 +366,7 @@
             grid.appendChild(divider);
 
             TIME_SLOTS.forEach((time) => {
-                grid.appendChild(createElement(documentRef, 'div', 'public-time-slot', formatTimeSlot(time)));
+                grid.appendChild(createTimeSlotElement(documentRef, time));
 
                 rooms.forEach((room) => {
                     const cell = createElement(documentRef, 'div', 'public-schedule-cell');

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -41,6 +41,46 @@
         'CEB 102': 'CEB 102',
         'CEB 104': 'CEB 104'
     });
+    const FACULTY_COLORS = Object.freeze({
+        'T.Masingale': { className: 'faculty-masingale', color: '#667eea', name: 'T.Masingale' },
+        'S.Durr': { className: 'faculty-durr', color: '#e67e22', name: 'S.Durr' },
+        'C.Manikoth': { className: 'faculty-manikoth', color: '#27ae60', name: 'C.Manikoth' },
+        'S.Mills': { className: 'faculty-mills', color: '#9b59b6', name: 'S.Mills' },
+        'M.Lybbert': { className: 'faculty-lybbert', color: '#e74c3c', name: 'M.Lybbert' },
+        'G.Hustrulid': { className: 'faculty-hustrulid', color: '#f39c12', name: 'G.Hustrulid' },
+        'A.Sopu': { className: 'faculty-sopu', color: '#3498db', name: 'A.Sopu' },
+        'E.Norris': { className: 'faculty-norris', color: '#1abc9c', name: 'E.Norris' },
+        'J.Braukmann': { className: 'faculty-braukmann', color: '#34495e', name: 'J.Braukmann' },
+        'S.Allison': { className: 'faculty-allison', color: '#d35400', name: 'S.Allison' },
+        'Barton/Pettigrew': { className: 'faculty-online', color: '#7f8c8d', name: 'Barton/Pettigrew' },
+        'Adjunct': { className: 'faculty-adjunct', color: '#95a5a6', name: 'Adjunct' },
+        'TBD': { className: 'faculty-tbd', color: '#bdc3c7', name: 'TBD' }
+    });
+    const FALLBACK_FACULTY_COLORS = Object.freeze([
+        '#0ea5e9',
+        '#14b8a6',
+        '#84cc16',
+        '#f97316',
+        '#ec4899',
+        '#8b5cf6',
+        '#64748b',
+        '#ca8a04'
+    ]);
+    const FACULTY_ALIASES = Object.freeze([
+        { canonical: 'T.Masingale', keys: ['tmasingale', 'tmasingal', 'travismasingale', 'masingale'] },
+        { canonical: 'S.Durr', keys: ['sdurr', 'sarahdurr', 'durr'] },
+        { canonical: 'C.Manikoth', keys: ['cmanikoth', 'colinmanikoth', 'manikoth'] },
+        { canonical: 'S.Mills', keys: ['smills', 'sarahmills', 'mills'] },
+        { canonical: 'M.Lybbert', keys: ['mlybbert', 'mattlybbert', 'lybbert'] },
+        { canonical: 'G.Hustrulid', keys: ['ghustrulid', 'ginahustrulid', 'hustrulid'] },
+        { canonical: 'A.Sopu', keys: ['asopu', 'arianasopu', 'sopu'] },
+        { canonical: 'E.Norris', keys: ['enorris', 'evannorris', 'norris'] },
+        { canonical: 'J.Braukmann', keys: ['jbraukmann', 'jessicabraukmann', 'braukmann'] },
+        { canonical: 'S.Allison', keys: ['sallison', 'scottallison', 'allison'] },
+        { canonical: 'Barton/Pettigrew', keys: ['bartonpettigrew', 'barton', 'pettigrew', 'online'] },
+        { canonical: 'Adjunct', keys: ['adjunct'] },
+        { canonical: 'TBD', keys: ['tbd'] }
+    ]);
 
     function resolveScheduleDataUtils(options) {
         return options.scheduleDataUtils
@@ -54,6 +94,43 @@
 
     function normalizeCourseCode(value) {
         return String(value || '').trim().toUpperCase().replace(/\s+/g, ' ');
+    }
+
+    function normalizeFacultyKey(value) {
+        return String(value || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    }
+
+    function getCanonicalFacultyName(value) {
+        const raw = String(value || '').trim();
+        if (!raw) return 'TBD';
+
+        const exact = FACULTY_COLORS[raw];
+        if (exact) return exact.name;
+
+        const compact = normalizeFacultyKey(raw);
+        const match = FACULTY_ALIASES.find((entry) => entry.keys.some((key) => compact.includes(key) || key.includes(compact)));
+        return match ? match.canonical : raw;
+    }
+
+    function getFallbackFacultyColor(name) {
+        const key = normalizeFacultyKey(name);
+        if (!key) return FACULTY_COLORS.TBD.color;
+        let hash = 0;
+        for (let index = 0; index < key.length; index += 1) {
+            hash = (hash * 31 + key.charCodeAt(index)) % 9973;
+        }
+        return FALLBACK_FACULTY_COLORS[hash % FALLBACK_FACULTY_COLORS.length];
+    }
+
+    function getFacultyInfo(value) {
+        const canonical = getCanonicalFacultyName(value);
+        const known = FACULTY_COLORS[canonical];
+        if (known) return known;
+        return {
+            className: 'faculty-generated',
+            color: getFallbackFacultyColor(canonical),
+            name: canonical || 'TBD'
+        };
     }
 
     function formatClock(value) {
@@ -183,11 +260,18 @@
     }
 
     function createCourseBlock(documentRef, course) {
-        const block = createElement(documentRef, 'article', 'public-course-block');
+        const facultyInfo = getFacultyInfo(course.instructor);
+        const block = createElement(documentRef, 'article', `public-course-block ${facultyInfo.className}`);
+        block.dataset.faculty = facultyInfo.name;
+        block.style.setProperty('--faculty-accent', facultyInfo.color);
 
         const code = createElement(documentRef, 'div', 'public-course-code', normalizeCourseCode(course.code));
         const title = createElement(documentRef, 'div', 'public-course-title', String(course.name || course.title || 'Untitled course').trim());
-        const instructor = createElement(documentRef, 'div', 'public-course-meta', String(course.instructor || 'TBD').trim());
+        const instructor = createElement(documentRef, 'div', 'public-course-meta');
+        const color = createElement(documentRef, 'span', 'public-faculty-dot');
+        color.style.backgroundColor = facultyInfo.color;
+        instructor.appendChild(color);
+        instructor.appendChild(documentRef.createTextNode(facultyInfo.name));
         const details = [];
         if (course.section) details.push(`Section ${course.section}`);
         if (course.credits) details.push(`${course.credits} cr`);
@@ -216,6 +300,31 @@
             }
         });
         return Array.from(seen);
+    }
+
+    function renderQuarterTabs(state) {
+        const { documentRef, scheduleData, activeQuarter, year } = state;
+        const tabs = documentRef.getElementById('publicQuarterTabs');
+        clearElement(tabs);
+
+        QUARTERS.forEach((quarter) => {
+            const button = createElement(documentRef, 'button', 'public-quarter-tab');
+            const quarterTitle = formatQuarterTitle(year, quarter);
+            const count = countQuarterCourses(scheduleData, quarter, { scheduleDataUtils: state.utils });
+            button.type = 'button';
+            button.setAttribute('role', 'tab');
+            button.setAttribute('aria-selected', quarter === activeQuarter ? 'true' : 'false');
+            button.dataset.quarter = quarter;
+            button.appendChild(createElement(documentRef, 'span', 'public-quarter-name', QUARTER_LABELS[quarter]));
+            button.appendChild(createElement(documentRef, 'span', 'public-quarter-year', getDisplayYear(year, quarter)));
+            button.appendChild(createElement(documentRef, 'span', 'public-quarter-count', `${count} ${count === 1 ? 'section' : 'sections'}`));
+            button.title = quarterTitle;
+            button.addEventListener('click', () => {
+                state.activeQuarter = quarter;
+                render(state);
+            });
+            tabs.appendChild(button);
+        });
     }
 
     function renderScheduleGrid(state) {
@@ -278,12 +387,68 @@
         });
     }
 
+    function getFacultyLegendEntries(state) {
+        const courses = getQuarterCourses(state.scheduleData, state.activeQuarter, state.utils);
+        const summaries = new Map();
+
+        courses.forEach((course) => {
+            const info = getFacultyInfo(course.instructor || 'TBD');
+            if (!summaries.has(info.name)) {
+                summaries.set(info.name, {
+                    name: info.name,
+                    className: info.className,
+                    color: info.color,
+                    sections: 0,
+                    credits: 0
+                });
+            }
+
+            const summary = summaries.get(info.name);
+            summary.sections += 1;
+            summary.credits += Number(course.credits) || 5;
+        });
+
+        return Array.from(summaries.values()).sort((a, b) => {
+            if (b.sections !== a.sections) return b.sections - a.sections;
+            return a.name.localeCompare(b.name);
+        });
+    }
+
+    function renderFacultyLegend(state) {
+        const legend = state.documentRef.getElementById('publicFacultyLegend');
+        clearElement(legend);
+        if (!legend) return;
+
+        const entries = getFacultyLegendEntries(state);
+        const header = createElement(state.documentRef, 'div', 'public-faculty-legend-header');
+        header.appendChild(createElement(state.documentRef, 'strong', '', 'Faculty key'));
+        header.appendChild(createElement(state.documentRef, 'span', '', `${formatQuarterTitle(state.year, state.activeQuarter)} | ${entries.length} faculty`));
+        legend.appendChild(header);
+
+        if (!entries.length) {
+            legend.appendChild(createElement(state.documentRef, 'div', 'public-faculty-legend-empty', 'No faculty assigned for this quarter yet.'));
+            return;
+        }
+
+        const list = createElement(state.documentRef, 'div', 'public-faculty-legend-list');
+        entries.forEach((entry) => {
+            const item = createElement(state.documentRef, 'div', `public-faculty-legend-item ${entry.className}`);
+            item.style.setProperty('--faculty-accent', entry.color);
+            item.appendChild(createElement(state.documentRef, 'span', 'public-faculty-swatch'));
+            item.appendChild(createElement(state.documentRef, 'span', 'public-faculty-name', entry.name));
+            item.appendChild(createElement(state.documentRef, 'span', 'public-faculty-meta', `${entry.sections} sec | ${entry.credits} cr`));
+            list.appendChild(item);
+        });
+        legend.appendChild(list);
+    }
+
     function renderEmptyState(state) {
         const grid = state.documentRef.getElementById('publicScheduleGrid');
         clearElement(grid);
         grid.style.gridTemplateColumns = '1fr';
         grid.appendChild(createElement(state.documentRef, 'div', 'public-empty', 'No public schedule rows are available for this quarter.'));
         clearElement(state.documentRef.getElementById('publicSpecialSections'));
+        renderFacultyLegend(state);
     }
 
     function renderErrorState(state, message) {
@@ -292,6 +457,7 @@
         grid.style.gridTemplateColumns = '1fr';
         grid.appendChild(createElement(state.documentRef, 'div', 'public-error', message || 'The public schedule could not be loaded.'));
         clearElement(state.documentRef.getElementById('publicSpecialSections'));
+        clearElement(state.documentRef.getElementById('publicFacultyLegend'));
     }
 
     function render(state) {
@@ -305,6 +471,8 @@
         setText(state.documentRef, 'publicScheduleSubtitle', `AY ${state.year}`);
         setText(state.documentRef, 'publicPanelCount', countLabel);
 
+        renderQuarterTabs(state);
+        renderFacultyLegend(state);
         if (count === 0) {
             renderEmptyState(state);
             return;
@@ -350,7 +518,7 @@
             const { data, error } = await client.rpc('get_public_schedule', {
                 p_academic_year: year,
                 p_program_code: programCode,
-                p_quarter: state.activeQuarter
+                p_quarter: null
             });
 
             if (error) throw error;
@@ -382,10 +550,14 @@
         DAY_PATTERNS,
         TIME_SLOTS,
         ROOM_ORDER,
+        FACULTY_COLORS,
         buildScheduleFromPublicRows,
         countQuarterCourses,
         createPublicScheduleApp,
         formatQuarterTitle,
+        getCanonicalFacultyName,
+        getFallbackFacultyColor,
+        getFacultyInfo,
         formatTimeSlot,
         normalizePublicScheduleRows
     };

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -273,6 +273,20 @@
         return { start: formatClock(start), end: formatClock(end) };
     }
 
+    function createTimeLabelElement(documentRef, className, value) {
+        const match = String(value || '').trim().match(/^(.+?)\s+(AM|PM)$/i);
+        const label = createElement(documentRef, 'span', className);
+
+        if (!match) {
+            label.appendChild(documentRef.createTextNode(String(value || '').trim()));
+            return label;
+        }
+
+        label.appendChild(createElement(documentRef, 'span', 'public-time-clock', match[1]));
+        label.appendChild(createElement(documentRef, 'span', 'public-time-period', match[2].toUpperCase()));
+        return label;
+    }
+
     function getDisplayYear(year, quarter) {
         const [startYearText] = String(year || DEFAULTS.year).split('-');
         const startYear = Number(startYearText);
@@ -435,9 +449,9 @@
         const parts = getTimeSlotParts(time);
         const slot = createElement(documentRef, 'div', 'public-time-slot');
         slot.setAttribute('aria-label', parts.end ? `${parts.start} to ${parts.end}` : parts.start);
-        slot.appendChild(createElement(documentRef, 'span', 'public-time-start', parts.start));
+        slot.appendChild(createTimeLabelElement(documentRef, 'public-time-start', parts.start));
         if (parts.end) {
-            slot.appendChild(createElement(documentRef, 'span', 'public-time-end', parts.end));
+            slot.appendChild(createTimeLabelElement(documentRef, 'public-time-end', parts.end));
         }
         return slot;
     }

--- a/public-schedule.html
+++ b/public-schedule.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>EWU Design Public Schedule</title>
+    <title>Program Command Public Schedule</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
@@ -20,26 +20,27 @@
     <div class="public-shell">
         <header class="public-header">
             <div class="public-header-copy">
-                <p class="public-eyebrow">EWU Design</p>
-                <h1>Program Schedule</h1>
-                <div class="public-meta" aria-label="Schedule context">
-                    <span id="publicAcademicYearLabel">AY 2026-27</span>
-                    <span id="publicQuarterLabel">Fall 2026</span>
-                </div>
+                <h1>Program Command</h1>
             </div>
-            <div class="public-status" id="publicStatus" role="status" aria-live="polite">Loading</div>
+            <a class="public-login-link" href="login.html">Login</a>
         </header>
 
         <main class="public-main">
-            <section class="public-toolbar" aria-label="Schedule controls">
-                <div class="public-quarter-tabs" id="publicQuarterTabs" role="tablist" aria-label="Quarter"></div>
-                <div class="public-summary" id="publicSummary">0 sections</div>
+            <section class="public-context" aria-label="Schedule context">
+                <div>
+                    <p class="public-eyebrow">Public schedule</p>
+                    <h2 id="publicScheduleTitle">Fall 2026</h2>
+                </div>
+                <div class="public-meta">
+                    <span id="publicAcademicYearLabel">AY 2026-27</span>
+                    <span id="publicQuarterLabel">Fall 2026</span>
+                    <span class="public-status" id="publicStatus" role="status" aria-live="polite">Loading</span>
+                </div>
             </section>
 
             <section class="public-schedule-panel" aria-labelledby="publicScheduleTitle">
                 <div class="public-panel-heading">
                     <div>
-                        <h2 id="publicScheduleTitle">Fall 2026</h2>
                         <p id="publicScheduleSubtitle">AY 2026-27</p>
                     </div>
                     <div class="public-panel-count" id="publicPanelCount">0 sections</div>

--- a/public-schedule.html
+++ b/public-schedule.html
@@ -40,8 +40,6 @@
 
             <section class="public-quarter-tabs" id="publicQuarterTabs" role="tablist" aria-label="Quarter"></section>
 
-            <section class="public-faculty-legend" id="publicFacultyLegend" aria-label="Faculty color key"></section>
-
             <section class="public-schedule-panel" aria-labelledby="publicScheduleTitle">
                 <div class="public-panel-heading">
                     <div>
@@ -55,6 +53,8 @@
             </section>
 
             <section class="public-special-sections" id="publicSpecialSections" aria-label="Additional sections"></section>
+
+            <section class="public-faculty-legend" id="publicFacultyLegend" aria-label="Faculty color key"></section>
         </main>
     </div>
 </body>

--- a/public-schedule.html
+++ b/public-schedule.html
@@ -5,9 +5,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Program Command Public Schedule</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/design-system.css">
     <link rel="stylesheet" href="css/public-schedule.css">
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -16,11 +13,15 @@
     <script src="pages/public-schedule.js"></script>
 </head>
 
-<body>
+<body class="foundry">
     <div class="public-shell">
         <header class="public-header">
             <div class="public-header-copy">
-                <h1>Program Command</h1>
+                <span class="public-header-mark" aria-hidden="true">PC</span>
+                <div>
+                    <p class="public-header-label">EWU Design</p>
+                    <h1>Program Command</h1>
+                </div>
             </div>
             <a class="public-login-link" href="login.html">Login</a>
         </header>

--- a/public-schedule.html
+++ b/public-schedule.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EWU Design Public Schedule</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/design-system.css">
+    <link rel="stylesheet" href="css/public-schedule.css">
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+    <script src="js/supabase-config.js"></script>
+    <script src="js/schedule-data-utils.js"></script>
+    <script src="pages/public-schedule.js"></script>
+</head>
+
+<body>
+    <div class="public-shell">
+        <header class="public-header">
+            <div class="public-header-copy">
+                <p class="public-eyebrow">EWU Design</p>
+                <h1>Program Schedule</h1>
+                <div class="public-meta" aria-label="Schedule context">
+                    <span id="publicAcademicYearLabel">AY 2026-27</span>
+                    <span id="publicQuarterLabel">Fall 2026</span>
+                </div>
+            </div>
+            <div class="public-status" id="publicStatus" role="status" aria-live="polite">Loading</div>
+        </header>
+
+        <main class="public-main">
+            <section class="public-toolbar" aria-label="Schedule controls">
+                <div class="public-quarter-tabs" id="publicQuarterTabs" role="tablist" aria-label="Quarter"></div>
+                <div class="public-summary" id="publicSummary">0 sections</div>
+            </section>
+
+            <section class="public-schedule-panel" aria-labelledby="publicScheduleTitle">
+                <div class="public-panel-heading">
+                    <div>
+                        <h2 id="publicScheduleTitle">Fall 2026</h2>
+                        <p id="publicScheduleSubtitle">AY 2026-27</p>
+                    </div>
+                    <div class="public-panel-count" id="publicPanelCount">0 sections</div>
+                </div>
+                <div class="public-grid-scroll">
+                    <div class="public-schedule-grid" id="publicScheduleGrid"></div>
+                </div>
+            </section>
+
+            <section class="public-special-sections" id="publicSpecialSections" aria-label="Additional sections"></section>
+        </main>
+    </div>
+</body>
+
+</html>

--- a/public-schedule.html
+++ b/public-schedule.html
@@ -38,6 +38,8 @@
                 </div>
             </section>
 
+            <section class="public-year-tabs" id="publicYearTabs" role="tablist" aria-label="Academic year"></section>
+
             <section class="public-quarter-tabs" id="publicQuarterTabs" role="tablist" aria-label="Quarter"></section>
 
             <section class="public-schedule-panel" aria-labelledby="publicScheduleTitle">

--- a/public-schedule.html
+++ b/public-schedule.html
@@ -38,6 +38,10 @@
                 </div>
             </section>
 
+            <section class="public-quarter-tabs" id="publicQuarterTabs" role="tablist" aria-label="Quarter"></section>
+
+            <section class="public-faculty-legend" id="publicFacultyLegend" aria-label="Faculty color key"></section>
+
             <section class="public-schedule-panel" aria-labelledby="publicScheduleTitle">
                 <div class="public-panel-heading">
                     <div>

--- a/scripts/check-data-freshness.js
+++ b/scripts/check-data-freshness.js
@@ -8,10 +8,10 @@ import { createClient } from '@supabase/supabase-js';
 const TABLE_CONFIG = [
   { table: 'academic_years', scope: 'department', timestampColumn: 'created_at' },
   { table: 'rooms', scope: 'department', timestampColumn: 'created_at' },
-  { table: 'courses', scope: 'department', timestampColumn: 'created_at' },
+  { table: 'courses', scope: 'department', timestampColumn: 'created_at', fingerprint: 'courses' },
   { table: 'faculty', scope: 'department', timestampColumn: 'created_at' },
   { table: 'scheduling_constraints', scope: 'department', timestampColumn: 'created_at' },
-  { table: 'scheduled_courses', scope: 'academic_year', timestampColumn: 'updated_at' },
+  { table: 'scheduled_courses', scope: 'academic_year', timestampColumn: 'updated_at', fingerprint: 'scheduled_courses' },
   { table: 'release_time', scope: 'academic_year', timestampColumn: 'created_at' }
 ];
 
@@ -57,6 +57,102 @@ function withScopeFilter(query, scope, scopeIds) {
     return query.eq('academic_year_id', scopeIds.academicYearId);
   }
   return query;
+}
+
+function normalizeText(value) {
+  return String(value || '').trim();
+}
+
+function normalizeNullableText(value) {
+  const normalized = normalizeText(value);
+  return normalized || null;
+}
+
+function pickEmbeddedRow(value) {
+  return Array.isArray(value) ? value[0] || null : value || null;
+}
+
+function hashContent(value) {
+  return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+async function fetchCourseFingerprint(client, scopeIds) {
+  const { data, error } = await client
+    .from('courses')
+    .select('code,title,default_credits,typical_cap,level')
+    .eq('department_id', scopeIds.departmentId)
+    .order('code');
+
+  if (error) throw new Error(`courses fingerprint failed: ${error.message}`);
+
+  const rows = (data || []).map((row) => ({
+    code: normalizeText(row.code).toUpperCase(),
+    title: normalizeText(row.title),
+    defaultCredits: Number(row.default_credits) || 0,
+    typicalCap: Number(row.typical_cap) || 0,
+    level: normalizeNullableText(row.level)
+  }));
+
+  return {
+    contentHash: hashContent(rows),
+    contentRows: rows.length
+  };
+}
+
+async function fetchScheduledCoursesFingerprint(client, scopeIds) {
+  const { data, error } = await client
+    .from('scheduled_courses')
+    .select(`
+      quarter,
+      day_pattern,
+      time_slot,
+      section,
+      projected_enrollment,
+      course:courses(code,title,default_credits),
+      faculty:faculty(name),
+      room:rooms(room_code)
+    `)
+    .eq('academic_year_id', scopeIds.academicYearId)
+    .order('quarter')
+    .order('day_pattern')
+    .order('time_slot')
+    .order('section');
+
+  if (error) throw new Error(`scheduled_courses fingerprint failed: ${error.message}`);
+
+  const rows = (data || []).map((row) => {
+    const course = pickEmbeddedRow(row.course);
+    const faculty = pickEmbeddedRow(row.faculty);
+    const room = pickEmbeddedRow(row.room);
+
+    return {
+      quarter: normalizeText(row.quarter).toLowerCase(),
+      dayPattern: normalizeNullableText(row.day_pattern),
+      timeSlot: normalizeNullableText(row.time_slot),
+      section: normalizeNullableText(row.section),
+      projectedEnrollment: Number(row.projected_enrollment) || 0,
+      courseCode: normalizeText(course?.code).toUpperCase(),
+      courseTitle: normalizeText(course?.title),
+      courseCredits: Number(course?.default_credits) || 0,
+      facultyName: normalizeNullableText(faculty?.name),
+      roomCode: normalizeNullableText(room?.room_code)
+    };
+  });
+
+  return {
+    contentHash: hashContent(rows),
+    contentRows: rows.length
+  };
+}
+
+async function fetchContentFingerprint(client, config, scopeIds) {
+  if (config.fingerprint === 'courses') {
+    return fetchCourseFingerprint(client, scopeIds);
+  }
+  if (config.fingerprint === 'scheduled_courses') {
+    return fetchScheduledCoursesFingerprint(client, scopeIds);
+  }
+  return {};
 }
 
 async function getDepartment(client, departmentCode) {
@@ -122,10 +218,15 @@ async function fetchTableDigest(client, config, scopeIds) {
     }
   }
 
+  const fingerprint = config.fingerprint
+    ? await fetchContentFingerprint(client, config, scopeIds)
+    : {};
+
   return {
     count: Number(countResult.count) || 0,
     latestChangeAt,
-    timestampColumn: config.timestampColumn || null
+    timestampColumn: config.timestampColumn || null,
+    ...fingerprint
   };
 }
 
@@ -188,6 +289,8 @@ function compareSnapshots(prod, dev) {
     let freshness = 'in-sync';
     if ((p.count || 0) !== (d.count || 0)) {
       freshness = countDelta > 0 ? 'dev-has-more' : 'prod-has-more';
+    } else if (p.contentHash && d.contentHash && p.contentHash !== d.contentHash) {
+      freshness = 'content-diff';
     } else if ((p.latestChangeAt || '') !== (d.latestChangeAt || '')) {
       if (prodDate && devDate) {
         freshness = prodDate > devDate ? 'prod-newer' : 'dev-newer';
@@ -202,6 +305,7 @@ function compareSnapshots(prod, dev) {
       production: p,
       dev: d,
       countDelta,
+      contentMatch: p.contentHash && d.contentHash ? p.contentHash === d.contentHash : null,
       freshness,
       inSync
     };
@@ -247,6 +351,7 @@ function printComparison(comparison, prodLabel, devLabel) {
     'Table'.padEnd(24),
     `${prodLabel} count`.padStart(12),
     `${devLabel} count`.padStart(12),
+    'Content'.padStart(10),
     'Freshness'.padStart(14),
     `${prodLabel} latest`.padStart(24),
     `${devLabel} latest`.padStart(24)
@@ -259,6 +364,7 @@ function printComparison(comparison, prodLabel, devLabel) {
       row.table.padEnd(24),
       String(row.production.count ?? 0).padStart(12),
       String(row.dev.count ?? 0).padStart(12),
+      (row.contentMatch === null ? '-' : row.contentMatch ? 'match' : 'diff').padStart(10),
       row.freshness.padStart(14),
       fmtDate(row.production.latestChangeAt).padStart(24),
       fmtDate(row.dev.latestChangeAt).padStart(24)

--- a/scripts/supabase-public-schedule-read.sql
+++ b/scripts/supabase-public-schedule-read.sql
@@ -31,11 +31,12 @@ DECLARE
     v_program_code TEXT := lower(btrim(coalesce(p_program_code, '')));
     v_quarter TEXT := nullif(lower(btrim(coalesce(p_quarter, ''))), '');
     v_department_code TEXT;
+    v_allowed_years CONSTANT TEXT[] := ARRAY['2026-27', '2025-26', '2024-25', '2023-24'];
     v_has_program_scope BOOLEAN := false;
 BEGIN
-    -- First public release is intentionally allowlisted. Future public years should
-    -- be added through an explicit publishing model, not broad anonymous table reads.
-    IF v_academic_year <> '2026-27' OR v_program_code <> 'ewu-design' THEN
+    -- Public releases are intentionally allowlisted. Future public years should be
+    -- added through an explicit publishing model, not broad anonymous table reads.
+    IF NOT (v_academic_year = ANY (v_allowed_years)) OR v_program_code <> 'ewu-design' THEN
         RETURN;
     END IF;
 
@@ -82,7 +83,7 @@ BEGIN
 
     IF NOT v_has_program_scope THEN
         -- Current production still uses the legacy department_id schema. Keep this
-        -- fallback narrow to EWU Design and AY 2026-27, matching the public allowlist.
+        -- fallback narrow to EWU Design and the explicit public year allowlist.
         RETURN QUERY
         SELECT
             ay.year::TEXT AS academic_year,

--- a/scripts/supabase-public-schedule-read.sql
+++ b/scripts/supabase-public-schedule-read.sql
@@ -1,0 +1,96 @@
+-- Public read-only schedule projection for the no-login schedule view.
+-- Idempotent: safe to run multiple times.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_public_schedule(
+    p_academic_year TEXT DEFAULT '2026-27',
+    p_program_code TEXT DEFAULT 'ewu-design',
+    p_quarter TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+    academic_year TEXT,
+    quarter TEXT,
+    day_pattern TEXT,
+    time_slot TEXT,
+    section TEXT,
+    course_code TEXT,
+    course_title TEXT,
+    credits INTEGER,
+    instructor_name TEXT,
+    room_code TEXT,
+    projected_enrollment INTEGER
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_academic_year TEXT := btrim(coalesce(p_academic_year, ''));
+    v_program_code TEXT := lower(btrim(coalesce(p_program_code, '')));
+    v_quarter TEXT := nullif(lower(btrim(coalesce(p_quarter, ''))), '');
+BEGIN
+    -- First public release is intentionally allowlisted. Future public years should
+    -- be added through an explicit publishing model, not broad anonymous table reads.
+    IF v_academic_year <> '2026-27' OR v_program_code <> 'ewu-design' THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        ay.year::TEXT AS academic_year,
+        sc.quarter::TEXT AS quarter,
+        sc.day_pattern::TEXT AS day_pattern,
+        sc.time_slot::TEXT AS time_slot,
+        sc.section::TEXT AS section,
+        coalesce(c.code, 'TBD')::TEXT AS course_code,
+        coalesce(c.title, 'TBD Course')::TEXT AS course_title,
+        coalesce(c.default_credits, 5)::INTEGER AS credits,
+        coalesce(f.name, 'TBD')::TEXT AS instructor_name,
+        coalesce(
+            r.room_code,
+            CASE
+                WHEN upper(coalesce(sc.day_pattern, '')) = 'ONLINE' THEN 'ONLINE'
+                WHEN upper(coalesce(sc.day_pattern, '')) = 'ARRANGED' THEN 'ARRANGED'
+                ELSE 'TBD'
+            END
+        )::TEXT AS room_code,
+        sc.projected_enrollment::INTEGER AS projected_enrollment
+    FROM public.scheduled_courses sc
+    JOIN public.academic_years ay
+      ON ay.id = sc.academic_year_id
+     AND ay.program_id = sc.program_id
+    JOIN public.programs p
+      ON p.id = sc.program_id
+    LEFT JOIN public.courses c
+      ON c.id = sc.course_id
+     AND c.program_id = sc.program_id
+    LEFT JOIN public.faculty f
+      ON f.id = sc.faculty_id
+     AND f.program_id = sc.program_id
+    LEFT JOIN public.rooms r
+      ON r.id = sc.room_id
+     AND r.program_id = sc.program_id
+    WHERE p.code = v_program_code
+      AND ay.year = v_academic_year
+      AND (v_quarter IS NULL OR lower(sc.quarter) = v_quarter)
+    ORDER BY
+        CASE lower(sc.quarter)
+            WHEN 'fall' THEN 1
+            WHEN 'winter' THEN 2
+            WHEN 'spring' THEN 3
+            ELSE 4
+        END,
+        sc.day_pattern NULLS LAST,
+        sc.time_slot NULLS LAST,
+        sc.section NULLS LAST,
+        c.code NULLS LAST;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_public_schedule(TEXT, TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_public_schedule(TEXT, TEXT, TEXT)
+TO anon, authenticated, service_role;
+
+COMMIT;

--- a/scripts/supabase-public-schedule-read.sql
+++ b/scripts/supabase-public-schedule-read.sql
@@ -30,10 +30,108 @@ DECLARE
     v_academic_year TEXT := btrim(coalesce(p_academic_year, ''));
     v_program_code TEXT := lower(btrim(coalesce(p_program_code, '')));
     v_quarter TEXT := nullif(lower(btrim(coalesce(p_quarter, ''))), '');
+    v_department_code TEXT;
+    v_has_program_scope BOOLEAN := false;
 BEGIN
     -- First public release is intentionally allowlisted. Future public years should
     -- be added through an explicit publishing model, not broad anonymous table reads.
     IF v_academic_year <> '2026-27' OR v_program_code <> 'ewu-design' THEN
+        RETURN;
+    END IF;
+
+    v_department_code := 'DESN';
+
+    SELECT
+        to_regclass('public.programs') IS NOT NULL
+        AND EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'academic_years'
+              AND column_name = 'program_id'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'scheduled_courses'
+              AND column_name = 'program_id'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'courses'
+              AND column_name = 'program_id'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'faculty'
+              AND column_name = 'program_id'
+        )
+        AND EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = 'rooms'
+              AND column_name = 'program_id'
+        )
+    INTO v_has_program_scope;
+
+    IF NOT v_has_program_scope THEN
+        -- Current production still uses the legacy department_id schema. Keep this
+        -- fallback narrow to EWU Design and AY 2026-27, matching the public allowlist.
+        RETURN QUERY
+        SELECT
+            ay.year::TEXT AS academic_year,
+            sc.quarter::TEXT AS quarter,
+            sc.day_pattern::TEXT AS day_pattern,
+            sc.time_slot::TEXT AS time_slot,
+            sc.section::TEXT AS section,
+            coalesce(c.code, 'TBD')::TEXT AS course_code,
+            coalesce(c.title, 'TBD Course')::TEXT AS course_title,
+            coalesce(c.default_credits, 5)::INTEGER AS credits,
+            coalesce(f.name, 'TBD')::TEXT AS instructor_name,
+            coalesce(
+                r.room_code,
+                CASE
+                    WHEN upper(coalesce(sc.day_pattern, '')) = 'ONLINE' THEN 'ONLINE'
+                    WHEN upper(coalesce(sc.day_pattern, '')) = 'ARRANGED' THEN 'ARRANGED'
+                    ELSE 'TBD'
+                END
+            )::TEXT AS room_code,
+            sc.projected_enrollment::INTEGER AS projected_enrollment
+        FROM public.scheduled_courses sc
+        JOIN public.academic_years ay
+          ON ay.id = sc.academic_year_id
+        JOIN public.departments d
+          ON d.id = ay.department_id
+        LEFT JOIN public.courses c
+          ON c.id = sc.course_id
+         AND c.department_id = d.id
+        LEFT JOIN public.faculty f
+          ON f.id = sc.faculty_id
+         AND f.department_id = d.id
+        LEFT JOIN public.rooms r
+          ON r.id = sc.room_id
+         AND r.department_id = d.id
+        WHERE d.code = v_department_code
+          AND ay.year = v_academic_year
+          AND (v_quarter IS NULL OR lower(sc.quarter) = v_quarter)
+        ORDER BY
+            CASE lower(sc.quarter)
+                WHEN 'fall' THEN 1
+                WHEN 'winter' THEN 2
+                WHEN 'spring' THEN 3
+                ELSE 4
+            END,
+            sc.day_pattern NULLS LAST,
+            sc.time_slot NULLS LAST,
+            sc.section NULLS LAST,
+            c.code NULLS LAST;
+
         RETURN;
     END IF;
 

--- a/scripts/supabase-sync-course-catalog.sql
+++ b/scripts/supabase-sync-course-catalog.sql
@@ -1,0 +1,126 @@
+-- Sync EWU Design course catalog metadata from data/course-catalog.json.
+-- Idempotent: updates existing DESN course rows without deleting or replacing IDs.
+
+BEGIN;
+
+CREATE TEMP TABLE canonical_course_catalog (
+    code TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    default_credits INTEGER NOT NULL,
+    typical_cap INTEGER NOT NULL,
+    level TEXT NOT NULL
+) ON COMMIT DROP;
+
+INSERT INTO canonical_course_catalog (code, title, default_credits, typical_cap, level)
+VALUES
+    ('DESN 100', 'Drawing for Communication', 5, 24, '100'),
+    ('DESN 200', 'Visual Thinking + Making', 5, 24, '200'),
+    ('DESN 216', 'Digital Foundations', 5, 24, '200'),
+    ('DESN 243', 'Typography', 5, 24, '200'),
+    ('DESN 263', 'Visual Communication Design', 5, 24, '200'),
+    ('DESN 213', 'Photoshop', 2, 24, '200'),
+    ('DESN 214', 'Illustrator', 2, 24, '200'),
+    ('DESN 215', 'InDesign', 2, 24, '200'),
+    ('DESN 217', 'Figma', 2, 24, '200'),
+    ('DESN 210', 'Design Lab', 2, 24, '200'),
+    ('DESN 368', 'Code + Design 1', 5, 24, '300'),
+    ('DESN 369', 'Web Development 1', 5, 24, '300'),
+    ('DESN 378', 'Code + Design 2', 5, 24, '300'),
+    ('DESN 379', 'Web Development 2', 5, 24, '300'),
+    ('DESN 325', 'Emergent Design', 5, 24, '300'),
+    ('DESN 374', 'AI + Design', 5, 24, '300'),
+    ('DESN 326', 'Introduction to Animation', 5, 24, '300'),
+    ('DESN 336', '3D Animation', 5, 24, '300'),
+    ('DESN 355', 'Motion Design', 5, 24, '300'),
+    ('DESN 365', 'Motion Design 2', 5, 24, '300'),
+    ('DESN 338', 'User Experience Design 1', 5, 24, '300'),
+    ('DESN 348', 'User Experience Design 2', 5, 24, '300'),
+    ('DESN 301', 'Visual Storytelling', 5, 24, '300'),
+    ('DESN 335', 'Board Game Design', 5, 24, '300'),
+    ('DESN 345', 'Digital Game Design', 5, 24, '300'),
+    ('DESN 343', 'Typography 2', 5, 24, '300'),
+    ('DESN 360', 'Zine and Publication Design', 5, 24, '300'),
+    ('DESN 350', 'Digital Photography', 5, 24, '300'),
+    ('DESN 351', 'Advanced Photography', 5, 24, '300'),
+    ('DESN 375', 'Digital Video', 5, 24, '300'),
+    ('DESN 384', 'Digital Sound', 5, 24, '300'),
+    ('DESN 359', 'Histories of Design', 5, 24, '300'),
+    ('DESN 305', 'Social Media Design and Management', 5, 24, '300'),
+    ('DESN 366', 'Production Design', 5, 24, '300'),
+    ('DESN 396', 'Experimental Course', 5, 24, '300'),
+    ('DESN 398', 'Seminar', 5, 24, '300'),
+    ('DESN 399', 'Directed Study', 5, 5, '300'),
+    ('DESN 468', 'Code + Design 3', 5, 24, '400'),
+    ('DESN 469', 'Web Development 3', 5, 24, '400'),
+    ('DESN 446', '4D Animation', 5, 24, '400'),
+    ('DESN 458', 'User Experience Design 3', 5, 24, '400'),
+    ('DESN 401', 'Imaginary Worlds', 5, 24, '400'),
+    ('DESN 463', 'Community-Driven Design', 5, 24, '400'),
+    ('DESN 480', 'Professional Practice', 5, 24, '400'),
+    ('DESN 490', 'Senior Capstone', 5, 24, '400'),
+    ('DESN 491', 'Senior Project', 5, 10, '400'),
+    ('DESN 493', 'Portfolio Practice', 2, 24, '400'),
+    ('DESN 495', 'Internship', 5, 15, '400'),
+    ('DESN 496', 'Experimental', 5, 24, '400'),
+    ('DESN 497', 'Workshop, Short Course, Conference, Seminar', 5, 24, '400'),
+    ('DESN 498', 'Seminar', 5, 24, '400'),
+    ('DESN 499', 'Directed Study', 5, 10, '400');
+
+UPDATE public.courses c
+SET
+    title = canonical_courses.title,
+    default_credits = canonical_courses.default_credits,
+    typical_cap = canonical_courses.typical_cap,
+    level = canonical_courses.level
+FROM canonical_course_catalog canonical_courses,
+     public.departments d
+WHERE d.id = c.department_id
+  AND d.code = 'DESN'
+  AND c.code = canonical_courses.code
+  AND (
+      c.title IS DISTINCT FROM canonical_courses.title
+      OR c.default_credits IS DISTINCT FROM canonical_courses.default_credits
+      OR c.typical_cap IS DISTINCT FROM canonical_courses.typical_cap
+      OR c.level IS DISTINCT FROM canonical_courses.level
+  );
+
+-- This should return zero rows after the update.
+SELECT
+    c.code,
+    c.title AS current_title,
+    canonical_courses.title AS canonical_title,
+    c.default_credits AS current_credits,
+    canonical_courses.default_credits AS canonical_credits,
+    c.typical_cap AS current_cap,
+    canonical_courses.typical_cap AS canonical_cap,
+    c.level AS current_level,
+    canonical_courses.level AS canonical_level
+FROM public.courses c
+JOIN public.departments d
+  ON d.id = c.department_id
+JOIN canonical_course_catalog canonical_courses
+  ON canonical_courses.code = c.code
+WHERE d.code = 'DESN'
+  AND (
+      c.title IS DISTINCT FROM canonical_courses.title
+      OR c.default_credits IS DISTINCT FROM canonical_courses.default_credits
+      OR c.typical_cap IS DISTINCT FROM canonical_courses.typical_cap
+      OR c.level IS DISTINCT FROM canonical_courses.level
+  )
+ORDER BY c.code;
+
+-- Existing rows are updated above. Missing rows are reported for review rather than
+-- auto-inserted so scheduled_courses IDs and tenant columns stay untouched.
+SELECT
+    canonical_courses.code AS missing_code,
+    canonical_courses.title AS missing_title
+FROM canonical_course_catalog canonical_courses
+CROSS JOIN public.departments d
+LEFT JOIN public.courses c
+  ON c.department_id = d.id
+ AND c.code = canonical_courses.code
+WHERE d.code = 'DESN'
+  AND c.id IS NULL
+ORDER BY canonical_courses.code;
+
+COMMIT;

--- a/tests/auth-editstate.integration.test.js
+++ b/tests/auth-editstate.integration.test.js
@@ -281,6 +281,26 @@ describe('Auth + Edit State Integration', () => {
         harness.cleanup();
     });
 
+    test('redirects signed-out users away from protected production routes', async () => {
+        const harness = loadAuthGuardHarness({
+            url: 'https://program-command.local/index.html',
+            session: null,
+            user: null,
+            canResult: false,
+            presenceService: null
+        });
+
+        await harness.triggerDomReady();
+
+        expect(harness.authService.getSession).toHaveBeenCalledTimes(1);
+        expect(harness.authService.getUser).not.toHaveBeenCalled();
+        expect(harness.location.replace).toHaveBeenCalledWith(
+            'login.html?next=%2Findex.html'
+        );
+
+        harness.cleanup();
+    });
+
     test('login timeout flow restores recovery draft after successful sign-in', async () => {
         localStorage.setItem(SESSION_RECOVERY_DRAFT_KEY, JSON.stringify({
             academicYear: '2026-27',

--- a/tests/dev-data-freshness-content.test.js
+++ b/tests/dev-data-freshness-content.test.js
@@ -1,0 +1,67 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+function writeSnapshot(dir, name, tableDigest) {
+    const filePath = path.join(dir, name);
+    const snapshot = {
+        label: name.replace('.json', ''),
+        generatedAt: '2026-04-30T00:00:00.000Z',
+        department: { code: 'DESN', id: 'dept-1', name: 'Design' },
+        academicYear: { id: 'ay-1', year: '2026-27', isActive: true },
+        checksum: name,
+        tables: {
+            courses: tableDigest
+        }
+    };
+    fs.writeFileSync(filePath, JSON.stringify(snapshot, null, 2));
+    return filePath;
+}
+
+describe('dev data freshness content comparison', () => {
+    test('flags content drift when counts and timestamps still match', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pc-freshness-'));
+        const prodSnapshot = writeSnapshot(dir, 'prod.json', {
+            count: 44,
+            latestChangeAt: '2026-04-01T00:00:00.000Z',
+            timestampColumn: 'created_at',
+            contentHash: 'prod-course-title-hash',
+            contentRows: 44
+        });
+        const devSnapshot = writeSnapshot(dir, 'dev.json', {
+            count: 44,
+            latestChangeAt: '2026-04-01T00:00:00.000Z',
+            timestampColumn: 'created_at',
+            contentHash: 'dev-course-title-hash',
+            contentRows: 44
+        });
+        const reportPath = path.join(dir, 'report.json');
+
+        const result = spawnSync(process.execPath, [
+            'scripts/check-data-freshness.js',
+            '--prod-snapshot',
+            prodSnapshot,
+            '--dev-snapshot',
+            devSnapshot,
+            '--output',
+            reportPath
+        ], {
+            cwd: path.resolve(__dirname, '..'),
+            encoding: 'utf8'
+        });
+
+        expect(result.status).toBe(2);
+        expect(result.stdout).toContain('content-diff');
+        expect(result.stdout).toContain('diff');
+
+        const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+        expect(report.rows).toHaveLength(1);
+        expect(report.rows[0]).toMatchObject({
+            table: 'courses',
+            freshness: 'content-diff',
+            contentMatch: false,
+            inSync: false
+        });
+    });
+});

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -77,6 +77,18 @@ describe('public schedule page', () => {
                 },
                 {
                     academic_year: '2026-27',
+                    quarter: 'fall',
+                    day_pattern: 'MW',
+                    time_slot: '10:00-12:20',
+                    section: '003',
+                    course_code: 'DESN 999',
+                    course_title: 'Hidden Media Lab Section',
+                    credits: 5,
+                    instructor_name: 'TBD',
+                    room_code: '207'
+                },
+                {
+                    academic_year: '2026-27',
                     quarter: 'winter',
                     day_pattern: 'TR',
                     time_slot: '10:00-12:20',
@@ -110,10 +122,17 @@ describe('public schedule page', () => {
         expect(document.getElementById('publicPanelCount').textContent).toBe('2 sections');
         expect(document.getElementById('publicStatus').textContent).toBe('Live schedule');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 368');
+        expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('DESN 999');
         expect(document.getElementById('publicSpecialSections').textContent).toContain('DESN 216');
         expect(document.querySelector('.public-course-block').className).toContain('faculty-masingale');
         expect(document.getElementById('publicFacultyLegend').textContent).toContain('T.Masingale');
         expect(document.getElementById('publicFacultyLegend').textContent).not.toMatch(/\bcr\b/i);
+
+        const headers = Array.from(document.querySelectorAll('.public-grid-header')).map((header) => header.textContent);
+        expect(headers).toEqual(['Time', 'UX Lab', 'Mac Lab 1', 'Mac Lab 2', 'Mac Lab 3', 'Design Studio', 'Mac Lab 4']);
+        expect(headers).not.toContain('207 Media Lab');
+        expect(headers).not.toContain('CEB 102');
+        expect(headers).not.toContain('CEB 104');
 
         document.querySelector('[data-quarter="winter"]').click();
 

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -183,4 +183,11 @@ describe('public schedule page', () => {
         expect(html).toContain('href="login.html"');
         expect(html).toContain('Program Command');
     });
+
+    test('places the faculty key below the schedule content', () => {
+        const html = fs.readFileSync(path.resolve(__dirname, '..', 'public-schedule.html'), 'utf8');
+
+        expect(html.indexOf('id="publicFacultyLegend"')).toBeGreaterThan(html.indexOf('id="publicSpecialSections"'));
+        expect(html.indexOf('id="publicFacultyLegend"')).toBeGreaterThan(html.indexOf('id="publicScheduleGrid"'));
+    });
 });

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -1,0 +1,118 @@
+const fs = require('fs');
+const path = require('path');
+const PublicSchedulePage = require('../pages/public-schedule.js');
+const ScheduleDataUtils = require('../js/schedule-data-utils.js');
+
+function setupDom() {
+    document.body.innerHTML = `
+        <div id="publicStatus"></div>
+        <span id="publicAcademicYearLabel"></span>
+        <span id="publicQuarterLabel"></span>
+        <div id="publicQuarterTabs"></div>
+        <div id="publicSummary"></div>
+        <h2 id="publicScheduleTitle"></h2>
+        <p id="publicScheduleSubtitle"></p>
+        <div id="publicPanelCount"></div>
+        <div id="publicScheduleGrid"></div>
+        <section id="publicSpecialSections"></section>
+    `;
+}
+
+function flushPromises() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('public schedule page', () => {
+    beforeEach(() => {
+        setupDom();
+    });
+
+    test('uses AY 2026-27 Fall as the default context', () => {
+        expect(PublicSchedulePage.DEFAULTS.year).toBe('2026-27');
+        expect(PublicSchedulePage.DEFAULTS.quarter).toBe('fall');
+        expect(PublicSchedulePage.formatQuarterTitle('2026-27', 'fall')).toBe('Fall 2026');
+    });
+
+    test('loads public schedule rows through the RPC and renders the Fall grid', async () => {
+        const rpc = jest.fn().mockResolvedValue({
+            data: [
+                {
+                    academic_year: '2026-27',
+                    quarter: 'fall',
+                    day_pattern: 'MW',
+                    time_slot: '10:00-12:20',
+                    section: '001',
+                    course_code: 'DESN 368',
+                    course_title: 'Code + Design 1',
+                    credits: 5,
+                    instructor_name: 'T. Masingale',
+                    room_code: '206',
+                    projected_enrollment: 24
+                },
+                {
+                    academic_year: '2026-27',
+                    quarter: 'fall',
+                    day_pattern: 'ONLINE',
+                    time_slot: 'async',
+                    section: '002',
+                    course_code: 'DESN 216',
+                    course_title: 'Digital Foundations',
+                    credits: 5,
+                    instructor_name: 'Barton/Pettigrew',
+                    room_code: 'ONLINE'
+                }
+            ],
+            error: null
+        });
+
+        const app = PublicSchedulePage.createPublicScheduleApp({
+            document,
+            scheduleDataUtils: ScheduleDataUtils,
+            getClient: () => ({ rpc })
+        });
+
+        await app.init();
+        await flushPromises();
+
+        expect(rpc).toHaveBeenCalledWith('get_public_schedule', {
+            p_academic_year: '2026-27',
+            p_program_code: 'ewu-design',
+            p_quarter: null
+        });
+        expect(document.getElementById('publicScheduleTitle').textContent).toBe('Fall 2026');
+        expect(document.getElementById('publicSummary').textContent).toBe('2 sections');
+        expect(document.getElementById('publicStatus').textContent).toBe('Live schedule');
+        expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 368');
+        expect(document.getElementById('publicSpecialSections').textContent).toContain('DESN 216');
+    });
+
+    test('shows an unavailable state when the public RPC fails', async () => {
+        const app = PublicSchedulePage.createPublicScheduleApp({
+            document,
+            scheduleDataUtils: ScheduleDataUtils,
+            getClient: () => ({
+                rpc: jest.fn().mockResolvedValue({
+                    data: null,
+                    error: { message: 'permission denied' }
+                })
+            })
+        });
+
+        await app.init();
+        await flushPromises();
+
+        expect(document.getElementById('publicStatus').textContent).toBe('Unavailable');
+        expect(document.getElementById('publicScheduleGrid').textContent).toContain('permission denied');
+    });
+
+    test('public HTML does not load protected editor/auth scripts or save controls', () => {
+        const html = fs.readFileSync(path.resolve(__dirname, '..', 'public-schedule.html'), 'utf8');
+
+        expect(html).not.toContain('auth-guard.js');
+        expect(html).not.toContain('auth-service.js');
+        expect(html).not.toContain('dirty-state-tracker.js');
+        expect(html).not.toMatch(/save/i);
+        expect(html).not.toMatch(/import/i);
+        expect(html).not.toMatch(/Add Course/i);
+    });
+});

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -8,6 +8,7 @@ function setupDom() {
         <div id="publicStatus"></div>
         <span id="publicAcademicYearLabel"></span>
         <span id="publicQuarterLabel"></span>
+        <div id="publicYearTabs"></div>
         <div id="publicQuarterTabs"></div>
         <section id="publicFacultyLegend"></section>
         <h2 id="publicScheduleTitle"></h2>
@@ -30,6 +31,7 @@ describe('public schedule page', () => {
     test('uses AY 2026-27 Fall as the default context', () => {
         expect(PublicSchedulePage.DEFAULTS.year).toBe('2026-27');
         expect(PublicSchedulePage.DEFAULTS.quarter).toBe('fall');
+        expect(PublicSchedulePage.PUBLIC_YEARS).toEqual(['2026-27', '2025-26', '2024-25', '2023-24']);
         expect(PublicSchedulePage.formatQuarterTitle('2026-27', 'fall')).toBe('Fall 2026');
     });
 
@@ -121,6 +123,8 @@ describe('public schedule page', () => {
         expect(document.getElementById('publicScheduleTitle').textContent).toBe('Fall 2026');
         expect(document.getElementById('publicPanelCount').textContent).toBe('2 sections');
         expect(document.getElementById('publicStatus').textContent).toBe('Live schedule');
+        expect(document.querySelector('[data-year="2026-27"]').getAttribute('aria-selected')).toBe('true');
+        expect(document.getElementById('publicYearTabs').textContent).toContain('2023-24');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 368');
         expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('DESN 999');
         expect(document.getElementById('publicSpecialSections').textContent).toContain('DESN 216');
@@ -146,6 +150,69 @@ describe('public schedule page', () => {
         expect(document.querySelector('.public-course-block').className).toContain('faculty-manikoth');
         expect(document.getElementById('publicFacultyLegend').textContent).toContain('C.Manikoth');
         expect(document.getElementById('publicFacultyLegend').textContent).not.toMatch(/\bcr\b/i);
+    });
+
+    test('reloads public schedule rows when an allowed academic year is selected', async () => {
+        const rpc = jest.fn()
+            .mockResolvedValueOnce({
+                data: [
+                    {
+                        academic_year: '2026-27',
+                        quarter: 'fall',
+                        day_pattern: 'MW',
+                        time_slot: '10:00-12:20',
+                        section: '001',
+                        course_code: 'DESN 368',
+                        course_title: 'Code + Design 1',
+                        credits: 5,
+                        instructor_name: 'T. Masingale',
+                        room_code: '206',
+                        projected_enrollment: 24
+                    }
+                ],
+                error: null
+            })
+            .mockResolvedValueOnce({
+                data: [
+                    {
+                        academic_year: '2025-26',
+                        quarter: 'fall',
+                        day_pattern: 'TR',
+                        time_slot: '13:00-15:20',
+                        section: '001',
+                        course_code: 'DESN 263',
+                        course_title: 'Typography',
+                        credits: 5,
+                        instructor_name: 'S.Durr',
+                        room_code: '209',
+                        projected_enrollment: 22
+                    }
+                ],
+                error: null
+            });
+
+        const app = PublicSchedulePage.createPublicScheduleApp({
+            document,
+            scheduleDataUtils: ScheduleDataUtils,
+            getClient: () => ({ rpc })
+        });
+
+        await app.init();
+
+        document.querySelector('[data-year="2025-26"]').click();
+        await flushPromises();
+        await flushPromises();
+
+        expect(rpc).toHaveBeenLastCalledWith('get_public_schedule', {
+            p_academic_year: '2025-26',
+            p_program_code: 'ewu-design',
+            p_quarter: null
+        });
+        expect(document.getElementById('publicAcademicYearLabel').textContent).toBe('AY 2025-26');
+        expect(document.getElementById('publicScheduleTitle').textContent).toBe('Fall 2025');
+        expect(document.querySelector('[data-year="2025-26"]').getAttribute('aria-selected')).toBe('true');
+        expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 263');
+        expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('DESN 368');
     });
 
     test('shows an unavailable state when the public RPC fails', async () => {

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -134,6 +134,11 @@ describe('public schedule page', () => {
         expect(headers).not.toContain('CEB 102');
         expect(headers).not.toContain('CEB 104');
 
+        const timeSlot = document.querySelector('.public-time-slot');
+        expect(timeSlot.getAttribute('aria-label')).toBe('10:00 AM to 12:20 PM');
+        expect(timeSlot.querySelector('.public-time-start').textContent).toBe('10:00 AM');
+        expect(timeSlot.querySelector('.public-time-end').textContent).toBe('12:20 PM');
+
         document.querySelector('[data-quarter="winter"]').click();
 
         expect(document.getElementById('publicScheduleTitle').textContent).toBe('Winter 2027');

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -49,6 +49,40 @@ describe('public schedule page', () => {
         expect(PublicSchedulePage.getFallbackFacultyColor('M.Breen')).toBe(breen.color);
     });
 
+    test('uses canonical course titles instead of stale Supabase titles', () => {
+        const scheduleData = PublicSchedulePage.buildScheduleFromPublicRows([
+            {
+                academic_year: '2026-27',
+                quarter: 'fall',
+                day_pattern: 'MW',
+                time_slot: '10:00-12:20',
+                section: '001',
+                course_code: 'DESN 368',
+                course_title: 'Interaction Design',
+                credits: 5,
+                instructor_name: 'T. Masingale',
+                room_code: '206',
+                projected_enrollment: 24
+            },
+            {
+                academic_year: '2026-27',
+                quarter: 'spring',
+                day_pattern: 'TR',
+                time_slot: '10:00-12:20',
+                section: '001',
+                course_code: 'DESN 379',
+                course_title: 'Advanced Data Visualization',
+                credits: 5,
+                instructor_name: 'C.Manikoth',
+                room_code: '206',
+                projected_enrollment: 24
+            }
+        ], { scheduleDataUtils: ScheduleDataUtils });
+
+        expect(scheduleData.fall.MW['10:00-12:20'][0].name).toBe('Code + Design 1');
+        expect(scheduleData.spring.TR['10:00-12:20'][0].name).toBe('Web Development 2');
+    });
+
     test('loads public schedule rows through the RPC and renders the Fall grid', async () => {
         const rpc = jest.fn().mockResolvedValue({
             data: [
@@ -59,7 +93,7 @@ describe('public schedule page', () => {
                     time_slot: '10:00-12:20',
                     section: '001',
                     course_code: 'DESN 368',
-                    course_title: 'Code + Design 1',
+                    course_title: 'Interaction Design',
                     credits: 5,
                     instructor_name: 'T. Masingale',
                     room_code: '206',
@@ -96,7 +130,7 @@ describe('public schedule page', () => {
                     time_slot: '10:00-12:20',
                     section: '001',
                     course_code: 'DESN 379',
-                    course_title: 'Web Development 2',
+                    course_title: 'Advanced Data Visualization',
                     credits: 5,
                     instructor_name: 'C.Manikoth',
                     room_code: '206',
@@ -126,6 +160,8 @@ describe('public schedule page', () => {
         expect(document.querySelector('[data-year="2026-27"]').getAttribute('aria-selected')).toBe('true');
         expect(document.getElementById('publicYearTabs').textContent).toContain('2023-24');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 368');
+        expect(document.getElementById('publicScheduleGrid').textContent).toContain('Code + Design 1');
+        expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('Interaction Design');
         expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('DESN 999');
         expect(document.getElementById('publicSpecialSections').textContent).toContain('DESN 216');
         expect(document.querySelector('.public-course-block').className).toContain('faculty-masingale');
@@ -147,6 +183,8 @@ describe('public schedule page', () => {
 
         expect(document.getElementById('publicScheduleTitle').textContent).toBe('Winter 2027');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 379');
+        expect(document.getElementById('publicScheduleGrid').textContent).toContain('Web Development 2');
+        expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('Advanced Data Visualization');
         expect(document.querySelector('.public-course-block').className).toContain('faculty-manikoth');
         expect(document.getElementById('publicFacultyLegend').textContent).toContain('C.Manikoth');
         expect(document.getElementById('publicFacultyLegend').textContent).not.toMatch(/\bcr\b/i);
@@ -181,7 +219,7 @@ describe('public schedule page', () => {
                         time_slot: '13:00-15:20',
                         section: '001',
                         course_code: 'DESN 263',
-                        course_title: 'Typography',
+                        course_title: 'User Experience Design I',
                         credits: 5,
                         instructor_name: 'S.Durr',
                         room_code: '209',
@@ -212,6 +250,8 @@ describe('public schedule page', () => {
         expect(document.getElementById('publicScheduleTitle').textContent).toBe('Fall 2025');
         expect(document.querySelector('[data-year="2025-26"]').getAttribute('aria-selected')).toBe('true');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 263');
+        expect(document.getElementById('publicScheduleGrid').textContent).toContain('Visual Communication Design');
+        expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('User Experience Design I');
         expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('DESN 368');
     });
 

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -8,6 +8,8 @@ function setupDom() {
         <div id="publicStatus"></div>
         <span id="publicAcademicYearLabel"></span>
         <span id="publicQuarterLabel"></span>
+        <div id="publicQuarterTabs"></div>
+        <section id="publicFacultyLegend"></section>
         <h2 id="publicScheduleTitle"></h2>
         <p id="publicScheduleSubtitle"></p>
         <div id="publicPanelCount"></div>
@@ -29,6 +31,20 @@ describe('public schedule page', () => {
         expect(PublicSchedulePage.DEFAULTS.year).toBe('2026-27');
         expect(PublicSchedulePage.DEFAULTS.quarter).toBe('fall');
         expect(PublicSchedulePage.formatQuarterTitle('2026-27', 'fall')).toBe('Fall 2026');
+    });
+
+    test('maps known and unmapped faculty to stable color-coded blocks', () => {
+        expect(PublicSchedulePage.getFacultyInfo('T. Masingale')).toMatchObject({
+            className: 'faculty-masingale',
+            color: '#667eea',
+            name: 'T.Masingale'
+        });
+
+        const breen = PublicSchedulePage.getFacultyInfo('M.Breen');
+        expect(breen.className).toBe('faculty-generated');
+        expect(breen.name).toBe('M.Breen');
+        expect(breen.color).toMatch(/^#[0-9a-f]{6}$/i);
+        expect(PublicSchedulePage.getFallbackFacultyColor('M.Breen')).toBe(breen.color);
     });
 
     test('loads public schedule rows through the RPC and renders the Fall grid', async () => {
@@ -58,6 +74,19 @@ describe('public schedule page', () => {
                     credits: 5,
                     instructor_name: 'Barton/Pettigrew',
                     room_code: 'ONLINE'
+                },
+                {
+                    academic_year: '2026-27',
+                    quarter: 'winter',
+                    day_pattern: 'TR',
+                    time_slot: '10:00-12:20',
+                    section: '001',
+                    course_code: 'DESN 379',
+                    course_title: 'Web Development 2',
+                    credits: 5,
+                    instructor_name: 'C.Manikoth',
+                    room_code: '206',
+                    projected_enrollment: 24
                 }
             ],
             error: null
@@ -75,13 +104,22 @@ describe('public schedule page', () => {
         expect(rpc).toHaveBeenCalledWith('get_public_schedule', {
             p_academic_year: '2026-27',
             p_program_code: 'ewu-design',
-            p_quarter: 'fall'
+            p_quarter: null
         });
         expect(document.getElementById('publicScheduleTitle').textContent).toBe('Fall 2026');
         expect(document.getElementById('publicPanelCount').textContent).toBe('2 sections');
         expect(document.getElementById('publicStatus').textContent).toBe('Live schedule');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 368');
         expect(document.getElementById('publicSpecialSections').textContent).toContain('DESN 216');
+        expect(document.querySelector('.public-course-block').className).toContain('faculty-masingale');
+        expect(document.getElementById('publicFacultyLegend').textContent).toContain('T.Masingale');
+
+        document.querySelector('[data-quarter="winter"]').click();
+
+        expect(document.getElementById('publicScheduleTitle').textContent).toBe('Winter 2027');
+        expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 379');
+        expect(document.querySelector('.public-course-block').className).toContain('faculty-manikoth');
+        expect(document.getElementById('publicFacultyLegend').textContent).toContain('C.Manikoth');
     });
 
     test('shows an unavailable state when the public RPC fails', async () => {

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -113,6 +113,7 @@ describe('public schedule page', () => {
         expect(document.getElementById('publicSpecialSections').textContent).toContain('DESN 216');
         expect(document.querySelector('.public-course-block').className).toContain('faculty-masingale');
         expect(document.getElementById('publicFacultyLegend').textContent).toContain('T.Masingale');
+        expect(document.getElementById('publicFacultyLegend').textContent).not.toMatch(/\bcr\b/i);
 
         document.querySelector('[data-quarter="winter"]').click();
 
@@ -120,6 +121,7 @@ describe('public schedule page', () => {
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 379');
         expect(document.querySelector('.public-course-block').className).toContain('faculty-manikoth');
         expect(document.getElementById('publicFacultyLegend').textContent).toContain('C.Manikoth');
+        expect(document.getElementById('publicFacultyLegend').textContent).not.toMatch(/\bcr\b/i);
     });
 
     test('shows an unavailable state when the public RPC fails', async () => {

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -8,8 +8,6 @@ function setupDom() {
         <div id="publicStatus"></div>
         <span id="publicAcademicYearLabel"></span>
         <span id="publicQuarterLabel"></span>
-        <div id="publicQuarterTabs"></div>
-        <div id="publicSummary"></div>
         <h2 id="publicScheduleTitle"></h2>
         <p id="publicScheduleSubtitle"></p>
         <div id="publicPanelCount"></div>
@@ -77,10 +75,10 @@ describe('public schedule page', () => {
         expect(rpc).toHaveBeenCalledWith('get_public_schedule', {
             p_academic_year: '2026-27',
             p_program_code: 'ewu-design',
-            p_quarter: null
+            p_quarter: 'fall'
         });
         expect(document.getElementById('publicScheduleTitle').textContent).toBe('Fall 2026');
-        expect(document.getElementById('publicSummary').textContent).toBe('2 sections');
+        expect(document.getElementById('publicPanelCount').textContent).toBe('2 sections');
         expect(document.getElementById('publicStatus').textContent).toBe('Live schedule');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 368');
         expect(document.getElementById('publicSpecialSections').textContent).toContain('DESN 216');
@@ -114,5 +112,16 @@ describe('public schedule page', () => {
         expect(html).not.toMatch(/save/i);
         expect(html).not.toMatch(/import/i);
         expect(html).not.toMatch(/Add Course/i);
+        expect(html).not.toMatch(/Copy to Next Year/i);
+        expect(html).not.toMatch(/Settings/i);
+    });
+
+    test('public HTML exposes only the login link as navigation', () => {
+        const html = fs.readFileSync(path.resolve(__dirname, '..', 'public-schedule.html'), 'utf8');
+
+        const anchors = html.match(/<a\b/gi) || [];
+        expect(anchors).toHaveLength(1);
+        expect(html).toContain('href="login.html"');
+        expect(html).toContain('Program Command');
     });
 });

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -298,6 +298,18 @@ describe('public schedule page', () => {
         expect(html).toContain('Program Command');
     });
 
+    test('public HTML and CSS use the Foundry surface contract', () => {
+        const html = fs.readFileSync(path.resolve(__dirname, '..', 'public-schedule.html'), 'utf8');
+        const css = fs.readFileSync(path.resolve(__dirname, '..', 'css', 'public-schedule.css'), 'utf8');
+
+        expect(html).toContain('<body class="foundry">');
+        expect(html).not.toContain('fonts.googleapis.com');
+        expect(css).toContain('--f-bg: #F7F7F8;');
+        expect(css).toContain('--f-mono: "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;');
+        expect(css).toContain('.public-status::before');
+        expect(css).toContain('border-left: 4px solid var(--faculty-accent');
+    });
+
     test('places the faculty key below the schedule content', () => {
         const html = fs.readFileSync(path.resolve(__dirname, '..', 'public-schedule.html'), 'utf8');
 

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -176,8 +176,10 @@ describe('public schedule page', () => {
 
         const timeSlot = document.querySelector('.public-time-slot');
         expect(timeSlot.getAttribute('aria-label')).toBe('10:00 AM to 12:20 PM');
-        expect(timeSlot.querySelector('.public-time-start').textContent).toBe('10:00 AM');
-        expect(timeSlot.querySelector('.public-time-end').textContent).toBe('12:20 PM');
+        expect(timeSlot.querySelector('.public-time-start .public-time-clock').textContent).toBe('10:00');
+        expect(timeSlot.querySelector('.public-time-start .public-time-period').textContent).toBe('AM');
+        expect(timeSlot.querySelector('.public-time-end .public-time-clock').textContent).toBe('12:20');
+        expect(timeSlot.querySelector('.public-time-end .public-time-period').textContent).toBe('PM');
 
         document.querySelector('[data-quarter="winter"]').click();
 

--- a/tests/supabase-config.environments.test.js
+++ b/tests/supabase-config.environments.test.js
@@ -1,0 +1,165 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const repoRoot = path.resolve(__dirname, '..');
+const configPath = path.join(repoRoot, 'js', 'supabase-config.js');
+const configSource = fs.readFileSync(configPath, 'utf8');
+
+function createStorage(initialValues = {}) {
+    const values = new Map(Object.entries(initialValues));
+
+    return {
+        getItem: jest.fn((key) => values.get(key) || null),
+        setItem: jest.fn((key, value) => {
+            values.set(key, String(value));
+        }),
+        removeItem: jest.fn((key) => {
+            values.delete(key);
+        })
+    };
+}
+
+function runSupabaseConfig({
+    href = 'http://127.0.0.1:3000/index.html',
+    localStorageValues = {},
+    sessionStorageValues = {},
+    windowConfig = {}
+} = {}) {
+    const listeners = {};
+    const supabaseSdk = {
+        createClient: jest.fn((url, anonKey, options) => ({ url, anonKey, options }))
+    };
+    const currentLocation = new URL(href);
+    const context = {
+        URL,
+        URLSearchParams,
+        console: {
+            log: jest.fn(),
+            warn: jest.fn(),
+            error: jest.fn()
+        },
+        document: {
+            addEventListener: jest.fn((eventName, callback) => {
+                listeners[eventName] = callback;
+            })
+        },
+        location: currentLocation,
+        localStorage: createStorage(localStorageValues),
+        sessionStorage: createStorage(sessionStorageValues),
+        PROGRAM_COMMAND_SUPABASE_CONFIG: windowConfig,
+        supabase: supabaseSdk
+    };
+    context.window = context;
+
+    vm.runInNewContext(configSource, context, { filename: configPath });
+
+    return { context, listeners, supabaseSdk };
+}
+
+describe('Supabase environment config', () => {
+    test('localhost app pages default to the develop project and require a local key', () => {
+        const { context, supabaseSdk } = runSupabaseConfig();
+
+        expect(context.window.getSupabaseEnvironment()).toBe('develop');
+        expect(context.window.getSupabaseEnvironmentConfig()).toMatchObject({
+            name: 'develop',
+            projectRef: 'cstcwplvioheazoghkgf',
+            url: 'https://cstcwplvioheazoghkgf.supabase.co',
+            anonKeyConfigured: false
+        });
+        expect(context.window.isSupabaseConfigured()).toBe(false);
+        expect(context.window.initSupabase()).toBeNull();
+        expect(supabaseSdk.createClient).not.toHaveBeenCalled();
+    });
+
+    test('the public schedule defaults to production even on localhost', () => {
+        const { context, supabaseSdk } = runSupabaseConfig({
+            href: 'http://127.0.0.1:3000/public-schedule.html'
+        });
+
+        const client = context.window.initSupabase();
+
+        expect(context.window.getSupabaseEnvironment()).toBe('production');
+        expect(context.window.getSupabaseEnvironmentConfig()).toMatchObject({
+            name: 'production',
+            projectRef: 'ohnrhjxcjkrdtudpzjgn',
+            url: 'https://ohnrhjxcjkrdtudpzjgn.supabase.co',
+            anonKeyConfigured: true
+        });
+        expect(client.url).toBe('https://ohnrhjxcjkrdtudpzjgn.supabase.co');
+        expect(supabaseSdk.createClient).toHaveBeenCalledTimes(1);
+    });
+
+    test('localhost can override the develop anon key from browser storage', () => {
+        const { context, supabaseSdk } = runSupabaseConfig({
+            localStorageValues: {
+                'programCommand.supabase.develop.anonKey': 'develop-anon-key'
+            }
+        });
+
+        const client = context.window.initSupabase();
+
+        expect(context.window.isSupabaseConfigured()).toBe(true);
+        expect(client).toMatchObject({
+            url: 'https://cstcwplvioheazoghkgf.supabase.co',
+            anonKey: 'develop-anon-key'
+        });
+        expect(supabaseSdk.createClient).toHaveBeenCalledWith(
+            'https://cstcwplvioheazoghkgf.supabase.co',
+            'develop-anon-key',
+            expect.objectContaining({
+                auth: expect.objectContaining({
+                    persistSession: true
+                })
+            })
+        );
+    });
+
+    test('deployed hosts default to the production project', () => {
+        const { context, supabaseSdk } = runSupabaseConfig({
+            href: 'https://sicxz.github.io/program-command/public-schedule.html'
+        });
+
+        const client = context.window.initSupabase();
+
+        expect(context.window.getSupabaseEnvironment()).toBe('production');
+        expect(context.window.getSupabaseEnvironmentConfig()).toMatchObject({
+            name: 'production',
+            projectRef: 'ohnrhjxcjkrdtudpzjgn',
+            url: 'https://ohnrhjxcjkrdtudpzjgn.supabase.co',
+            anonKeyConfigured: true
+        });
+        expect(client.url).toBe('https://ohnrhjxcjkrdtudpzjgn.supabase.co');
+        expect(supabaseSdk.createClient).toHaveBeenCalledTimes(1);
+    });
+
+    test('query params can force production while testing on localhost', () => {
+        const { context } = runSupabaseConfig({
+            href: 'http://127.0.0.1:3000/index.html?supabaseEnv=production'
+        });
+
+        expect(context.window.getSupabaseEnvironment()).toBe('production');
+        expect(context.window.getSupabaseEnvironmentConfig()).toMatchObject({
+            projectRef: 'ohnrhjxcjkrdtudpzjgn',
+            url: 'https://ohnrhjxcjkrdtudpzjgn.supabase.co',
+            anonKeyConfigured: true
+        });
+    });
+
+    test('the browser helper persists local environment overrides', () => {
+        const { context } = runSupabaseConfig();
+
+        expect(context.window.ProgramCommandSupabase.setEnvironment('production')).toBe(true);
+        expect(context.localStorage.setItem).toHaveBeenCalledWith(
+            'programCommand.supabase.environment',
+            'production'
+        );
+
+        expect(context.window.ProgramCommandSupabase.setDevelopAnonKey('develop-anon-key')).toBe(true);
+        expect(context.localStorage.setItem).toHaveBeenCalledWith(
+            'programCommand.supabase.develop.anonKey',
+            'develop-anon-key'
+        );
+    });
+});

--- a/tests/supabase-course-catalog-sync.test.js
+++ b/tests/supabase-course-catalog-sync.test.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadSql() {
+    return fs.readFileSync(
+        path.resolve(__dirname, '..', 'scripts', 'supabase-sync-course-catalog.sql'),
+        'utf8'
+    );
+}
+
+describe('course catalog Supabase sync script', () => {
+    test('updates existing DESN courses from the canonical catalog without replacing rows', () => {
+        const sql = loadSql();
+
+        expect(sql).toMatch(/UPDATE public\.courses c/i);
+        expect(sql).toMatch(/JOIN public\.departments d/i);
+        expect(sql).toMatch(/WHERE d\.code = 'DESN'/i);
+        expect(sql).toMatch(/c\.code = canonical_courses\.code/i);
+        expect(sql).not.toMatch(/DELETE FROM public\.courses/i);
+        expect(sql).not.toMatch(/TRUNCATE/i);
+    });
+
+    test('contains current public-schedule course titles that were stale in Supabase', () => {
+        const sql = loadSql();
+
+        expect(sql).toContain("('DESN 368', 'Code + Design 1', 5, 24, '300')");
+        expect(sql).toContain("('DESN 369', 'Web Development 1', 5, 24, '300')");
+        expect(sql).toContain("('DESN 379', 'Web Development 2', 5, 24, '300')");
+        expect(sql).toContain("('DESN 491', 'Senior Project', 5, 10, '400')");
+    });
+
+    test('ends with a mismatch verification query', () => {
+        const sql = loadSql();
+
+        expect(sql).toMatch(/SELECT\s+c\.code,\s+c\.title AS current_title,\s+canonical_courses\.title AS canonical_title/is);
+        expect(sql).toMatch(/ORDER BY c\.code/i);
+        expect(sql).toMatch(/COMMIT;/i);
+    });
+});

--- a/tests/supabase-public-schedule-read.test.js
+++ b/tests/supabase-public-schedule-read.test.js
@@ -7,14 +7,15 @@ function loadMigrationSql() {
 }
 
 describe('public schedule read migration contract', () => {
-    test('defines a security definer RPC allowlisted to AY 2026-27 Design', () => {
+    test('defines a security definer RPC allowlisted to published Design years', () => {
         const sql = loadMigrationSql();
 
         expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.get_public_schedule/i);
         expect(sql).toMatch(/p_academic_year TEXT DEFAULT '2026-27'/i);
         expect(sql).toMatch(/p_program_code TEXT DEFAULT 'ewu-design'/i);
         expect(sql).toMatch(/SECURITY DEFINER/i);
-        expect(sql).toMatch(/v_academic_year <> '2026-27'/i);
+        expect(sql).toMatch(/v_allowed_years CONSTANT TEXT\[\] := ARRAY\['2026-27', '2025-26', '2024-25', '2023-24'\]/i);
+        expect(sql).toMatch(/NOT \(v_academic_year = ANY \(v_allowed_years\)\)/i);
         expect(sql).toMatch(/v_program_code <> 'ewu-design'/i);
     });
 

--- a/tests/supabase-public-schedule-read.test.js
+++ b/tests/supabase-public-schedule-read.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadMigrationSql() {
+    const filePath = path.resolve(__dirname, '..', 'scripts', 'supabase-public-schedule-read.sql');
+    return fs.readFileSync(filePath, 'utf8');
+}
+
+describe('public schedule read migration contract', () => {
+    test('defines a security definer RPC allowlisted to AY 2026-27 Design', () => {
+        const sql = loadMigrationSql();
+
+        expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.get_public_schedule/i);
+        expect(sql).toMatch(/p_academic_year TEXT DEFAULT '2026-27'/i);
+        expect(sql).toMatch(/p_program_code TEXT DEFAULT 'ewu-design'/i);
+        expect(sql).toMatch(/SECURITY DEFINER/i);
+        expect(sql).toMatch(/v_academic_year <> '2026-27'/i);
+        expect(sql).toMatch(/v_program_code <> 'ewu-design'/i);
+    });
+
+    test('returns only schedule display fields without audit or identifier columns', () => {
+        const sql = loadMigrationSql();
+
+        expect(sql).toMatch(/RETURNS TABLE \(/i);
+        expect(sql).toMatch(/academic_year TEXT/i);
+        expect(sql).toMatch(/course_code TEXT/i);
+        expect(sql).toMatch(/instructor_name TEXT/i);
+        expect(sql).toMatch(/room_code TEXT/i);
+        expect(sql).not.toMatch(/\bid UUID\b/i);
+        expect(sql).not.toMatch(/\bupdated_by\b/i);
+        expect(sql).not.toMatch(/\bcreated_by\b/i);
+        expect(sql).not.toMatch(/\bconfig JSONB\b/i);
+    });
+
+    test('grants anonymous execute only and does not grant anon table access', () => {
+        const sql = loadMigrationSql();
+
+        expect(sql).toMatch(/REVOKE ALL ON FUNCTION public\.get_public_schedule\(TEXT, TEXT, TEXT\) FROM PUBLIC/i);
+        expect(sql).toMatch(/GRANT EXECUTE ON FUNCTION public\.get_public_schedule\(TEXT, TEXT, TEXT\)\s+TO anon, authenticated, service_role/i);
+        expect(sql).not.toMatch(/GRANT\s+(SELECT|INSERT|UPDATE|DELETE|ALL).*TO\s+anon/i);
+        expect(sql).not.toMatch(/CREATE POLICY .* TO anon/i);
+    });
+
+    test('keeps the query scoped through program and academic year', () => {
+        const sql = loadMigrationSql();
+
+        expect(sql).toMatch(/JOIN public\.programs p/i);
+        expect(sql).toMatch(/p\.code = v_program_code/i);
+        expect(sql).toMatch(/ay\.year = v_academic_year/i);
+        expect(sql).toMatch(/ay\.program_id = sc\.program_id/i);
+        expect(sql).toMatch(/c\.program_id = sc\.program_id/i);
+        expect(sql).toMatch(/f\.program_id = sc\.program_id/i);
+        expect(sql).toMatch(/r\.program_id = sc\.program_id/i);
+    });
+});

--- a/tests/supabase-public-schedule-read.test.js
+++ b/tests/supabase-public-schedule-read.test.js
@@ -41,9 +41,11 @@ describe('public schedule read migration contract', () => {
         expect(sql).not.toMatch(/CREATE POLICY .* TO anon/i);
     });
 
-    test('keeps the query scoped through program and academic year', () => {
+    test('keeps the tenantized query scoped through program and academic year', () => {
         const sql = loadMigrationSql();
 
+        expect(sql).toMatch(/information_schema\.columns/i);
+        expect(sql).toMatch(/v_has_program_scope/i);
         expect(sql).toMatch(/JOIN public\.programs p/i);
         expect(sql).toMatch(/p\.code = v_program_code/i);
         expect(sql).toMatch(/ay\.year = v_academic_year/i);
@@ -51,5 +53,18 @@ describe('public schedule read migration contract', () => {
         expect(sql).toMatch(/c\.program_id = sc\.program_id/i);
         expect(sql).toMatch(/f\.program_id = sc\.program_id/i);
         expect(sql).toMatch(/r\.program_id = sc\.program_id/i);
+    });
+
+    test('falls back to the legacy department schema used by current production', () => {
+        const sql = loadMigrationSql();
+
+        expect(sql).toMatch(/IF NOT v_has_program_scope THEN/i);
+        expect(sql).toMatch(/v_department_code := 'DESN'/i);
+        expect(sql).toMatch(/JOIN public\.departments d/i);
+        expect(sql).toMatch(/d\.id = ay\.department_id/i);
+        expect(sql).toMatch(/d\.code = v_department_code/i);
+        expect(sql).toMatch(/c\.department_id = d\.id/i);
+        expect(sql).toMatch(/f\.department_id = d\.id/i);
+        expect(sql).toMatch(/r\.department_id = d\.id/i);
     });
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,24 @@
+import { cpSync, existsSync } from 'fs';
+import { resolve } from 'path';
 import { defineConfig } from 'vite';
 
+const staticRuntimeDirs = ['css', 'js', 'pages', 'data', 'department-profiles'];
+
+function copyStaticRuntimeDirs() {
+    return {
+        name: 'copy-static-runtime-dirs',
+        closeBundle() {
+            staticRuntimeDirs.forEach((dir) => {
+                const source = resolve(__dirname, dir);
+                if (!existsSync(source)) return;
+                cpSync(source, resolve(__dirname, 'dist', dir), { recursive: true });
+            });
+        }
+    };
+}
+
 export default defineConfig({
+    plugins: [copyStaticRuntimeDirs()],
     server: {
         port: 3000,
         proxy: {
@@ -12,6 +30,13 @@ export default defineConfig({
     },
     build: {
         outDir: 'dist',
-        emptyOutDir: true
+        emptyOutDir: true,
+        rollupOptions: {
+            input: {
+                main: resolve(__dirname, 'index.html'),
+                login: resolve(__dirname, 'login.html'),
+                publicSchedule: resolve(__dirname, 'public-schedule.html')
+            }
+        }
     }
 });


### PR DESCRIPTION
## Summary
- Adds a no-login public schedule page for Program Command
- Defaults the public view to AY 2026-27 Fall and lets visitors switch Fall/Winter/Spring plus recent academic years
- Routes the public schedule to the production Supabase read endpoint while keeping localhost app pages environment-aware
- Applies the Foundry visual system to the public schedule surface
- Keeps the public page view-only with only Program Command + Login navigation

## Verification
- npm test -- tests/public-schedule.test.js tests/supabase-config.environments.test.js --runInBand
- npm run build
- Browser check: public page shows LIVE SCHEDULE from production data
