### PR TITLE
feat(ci): forbidden-path guard for autopilot safety files (U5)

### DIFF
--- a/.github/workflows/guard-forbidden-paths.yml
+++ b/.github/workflows/guard-forbidden-paths.yml
@@ -1,0 +1,44 @@
+name: Guard Forbidden Paths
+
+# Fails when a PR touches safety files that autopilot must never change
+# (.github/workflows/**, ci.yml, js/supabase-config.js, .env*, Supabase SQL).
+# The only override is the human-applied "allow-forbidden-paths" label, which
+# an agent cannot self-apply. Logic lives in scripts/check-forbidden-paths.cjs
+# (unit-tested in tests/guard-forbidden-paths.test.js).
+
+on:
+  pull_request:
+    branches: [main]
+    # Re-run when the label is added/removed so the override takes effect
+    # without needing a new commit.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  guard-forbidden-paths:
+    name: guard-forbidden-paths
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute changed files
+        run: |
+          set -euo pipefail
+          git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" > changed_files.txt
+          echo "Changed files in this PR:"
+          cat changed_files.txt
+
+      - name: Run forbidden-path guard
+        env:
+          ALLOW_FORBIDDEN_PATHS: ${{ contains(github.event.pull_request.labels.*.name, 'allow-forbidden-paths') }}
+        run: |
+          set -euo pipefail
+          mapfile -t files < changed_files.txt
+          node scripts/check-forbidden-paths.cjs "${files[@]}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,20 @@
 ## Autopilot Defaults
 
 Autopilot mode (persistent): Work through repo issues in priority order and do not wait for my supervision. Finish each issue as far as possible (code, tests/checks, commit, push), then move to the next. Make reasonable technical and UX decisions. Only interrupt me for blockers requiring my decision, credentials/access, destructive operations, or ambiguous scope with major consequences.
+
+## Trunk & Safety Rules
+
+These are hard rules, not defaults. The repo is trunk-based on a single `main`.
+
+- **Target `main`.** Open PRs against `main` only. Do not use, push to, or open PRs against `develop`.
+- **Short-lived branches.** One focused change per branch/PR. Merged branches are auto-deleted.
+- **Never deploy production.** Production publishes only by a human running the manual `Deploy Pages` workflow. Do not trigger `workflow_dispatch` on `deploy-pages.yml` or otherwise publish.
+- **Never edit forbidden paths.** Do not add, modify, or delete any of the following — a required CI check (`guard-forbidden-paths`) will fail your PR, and only a human can clear it by applying the `allow-forbidden-paths` label:
+  - `.github/workflows/**` — including **creating new workflow files** (no adding a fresh auto-deploy workflow).
+  - `ci.yml`
+  - `js/supabase-config.js`
+  - `.env*`
+  - Supabase policy / migration SQL (`*.sql`).
+- **Do not touch production Supabase, RLS policies, the editor allowlist, or branch-protection rulesets.** These are human-only controls.
+
+If a task genuinely requires changing a forbidden path, stop and surface it to the maintainer rather than working around the guard.

--- a/scripts/check-forbidden-paths.cjs
+++ b/scripts/check-forbidden-paths.cjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Forbidden-path guard (Forward Operating Model plan, Unit 5).
+ *
+ * Fails when a pull request adds or modifies a "safety" file that agents
+ * must never touch. The override is human-applied (a PR label surfaced to
+ * the CLI as ALLOW_FORBIDDEN_PATHS) — an agent cannot self-clear the gate.
+ *
+ * Logic lives here (not inline in YAML) so it is unit-testable:
+ * see tests/guard-forbidden-paths.test.js.
+ *
+ * CLI usage:
+ *   node scripts/check-forbidden-paths.cjs <changed-file> [<changed-file> ...]
+ *   ALLOW_FORBIDDEN_PATHS=true node scripts/check-forbidden-paths.cjs <files...>
+ */
+
+const FORBIDDEN_RULES = [
+  {
+    name: '.github/workflows/** (incl. new files)',
+    test: (p) => p.startsWith('.github/workflows/'),
+  },
+  {
+    name: 'ci.yml',
+    test: (p) => p === 'ci.yml' || p.endsWith('/ci.yml'),
+  },
+  {
+    name: 'js/supabase-config.js',
+    test: (p) => p === 'js/supabase-config.js',
+  },
+  {
+    name: '.env*',
+    test: (p) => /(^|\/)\.env(\..+)?$/.test(p),
+  },
+  {
+    name: 'Supabase policy / SQL',
+    test: (p) => p.endsWith('.sql'),
+  },
+];
+
+function normalize(p) {
+  return String(p).trim().replace(/^\.\//, '');
+}
+
+function findForbidden(paths) {
+  const hits = [];
+  for (const raw of paths) {
+    const path = normalize(raw);
+    if (!path) continue;
+    const rule = FORBIDDEN_RULES.find((r) => r.test(path));
+    if (rule) hits.push({ path, rule: rule.name });
+  }
+  return hits;
+}
+
+function isOverridden() {
+  const v = String(process.env.ALLOW_FORBIDDEN_PATHS || '').toLowerCase();
+  return v === 'true' || v === '1';
+}
+
+module.exports = { findForbidden, FORBIDDEN_RULES };
+
+if (require.main === module) {
+  const files = process.argv.slice(2);
+  const hits = findForbidden(files);
+
+  if (hits.length === 0) {
+    console.log('guard-forbidden-paths: OK — no safety files touched.');
+    process.exit(0);
+  }
+
+  console.log('guard-forbidden-paths: this PR touches protected safety files:');
+  for (const hit of hits) {
+    console.log(`  - ${hit.path}  (rule: ${hit.rule})`);
+  }
+
+  if (isOverridden()) {
+    console.log(
+      '\nguard-forbidden-paths: human override label present — allowing.'
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    '\nguard-forbidden-paths: FAILED. These paths are off-limits to autopilot.\n' +
+      'A human must review and apply the "allow-forbidden-paths" label to merge.'
+  );
+  process.exit(1);
+}

--- a/tests/guard-forbidden-paths.test.js
+++ b/tests/guard-forbidden-paths.test.js
@@ -1,0 +1,65 @@
+const { findForbidden, FORBIDDEN_RULES } = require('../scripts/check-forbidden-paths.cjs');
+
+describe('forbidden-path guard', () => {
+  test('flags any file under .github/workflows/, including newly created ones', () => {
+    expect(findForbidden(['.github/workflows/deploy-pages.yml'])).toHaveLength(1);
+    // The "add a new auto-deploy workflow" bypass must also be caught.
+    expect(findForbidden(['.github/workflows/sneaky-autodeploy.yml'])).toHaveLength(1);
+  });
+
+  test('flags ci.yml wherever it lives', () => {
+    expect(findForbidden(['.github/workflows/ci.yml'])).toHaveLength(1);
+    expect(findForbidden(['ci.yml'])).toHaveLength(1);
+  });
+
+  test('flags the Supabase config', () => {
+    expect(findForbidden(['js/supabase-config.js'])).toHaveLength(1);
+  });
+
+  test('flags env files', () => {
+    expect(findForbidden(['.env'])).toHaveLength(1);
+    expect(findForbidden(['.env.production'])).toHaveLength(1);
+    expect(findForbidden(['.env.local'])).toHaveLength(1);
+  });
+
+  test('flags Supabase policy / SQL files', () => {
+    expect(findForbidden(['scripts/phase0-policy-hardening.sql'])).toHaveLength(1);
+    expect(findForbidden(['scripts/supabase-public-schedule-read.sql'])).toHaveLength(1);
+  });
+
+  test('allows ordinary application code and docs', () => {
+    expect(
+      findForbidden([
+        'js/db-service.js',
+        'pages/schedule-builder.js',
+        'docs/ORIENT.html',
+        'css/docs.css',
+        'README.md',
+      ])
+    ).toEqual([]);
+  });
+
+  test('normalizes a leading ./ so it cannot be used to evade matching', () => {
+    expect(findForbidden(['./js/supabase-config.js'])).toHaveLength(1);
+    expect(findForbidden(['./.github/workflows/ci.yml'])).toHaveLength(1);
+  });
+
+  test('reports the matched rule name for each offender', () => {
+    const hits = findForbidden(['js/supabase-config.js', '.env']);
+    expect(hits).toHaveLength(2);
+    for (const hit of hits) {
+      expect(typeof hit.path).toBe('string');
+      expect(typeof hit.rule).toBe('string');
+      expect(hit.rule.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('ignores blank lines and whitespace in the changed-file list', () => {
+    expect(findForbidden(['', '   ', 'js/db-service.js'])).toEqual([]);
+  });
+
+  test('exposes the rule set for documentation/inspection', () => {
+    expect(Array.isArray(FORBIDDEN_RULES)).toBe(true);
+    expect(FORBIDDEN_RULES.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 **Unit 5** of the Forward Operating Model plan — an enforced (not just documented) guard so autopilot cannot modify production-safety files. Adds a CI check + the matching `AGENTS.md` rules.

## How it works

- **`scripts/check-forbidden-paths.cjs`** — the matcher, kept out of YAML so it's unit-testable. Forbidden set:
  - `.github/workflows/**` — **including newly created files** (closes the "add a fresh auto-deploy workflow" bypass)
  - `ci.yml`
  - `js/supabase-config.js`
  - `.env*`
  - `*.sql` (Supabase policy / migrations)
- **`.github/workflows/guard-forbidden-paths.yml`** — diffs `base..head`, runs the matcher, and maps the human-applied `allow-forbidden-paths` label to the override. Re-runs on label add/remove so clearing the gate doesn't need a new commit.
- **Override is human-only.** The label is the sole way to pass a PR that touches a forbidden path; an agent cannot self-apply it. Authorship isn't sniffed (spoofable) — instead *all* forbidden-path changes are gated and a human consciously clears them, which is the plan's stated fallback.
- **`AGENTS.md`** — hard Trunk & Safety Rules: target `main`, short-lived branches, never deploy prod, never edit forbidden paths.

## Test plan

- [x] `npx jest tests/guard-forbidden-paths.test.js` — 10/10 pass (new-workflow bypass, `./` normalization, env/sql/config matches, clean app code, blank-line handling).
- [x] CLI exit codes verified locally: clean → 0, forbidden → 1, forbidden + `ALLOW_FORBIDDEN_PATHS=true` → 0.
- [ ] CI `test` + `onboarding` green.

## Follow-up after merge (needs maintainer)

Add `guard-forbidden-paths` to the `protect-main` ruleset's **required status checks**. It can only be made required once it has run at least once on `main` (workflows for `pull_request` run from the base branch, so this guard does not run against its own introducing PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
