### PR TITLE
feat(public): admin-set default term for the public schedule

### DIFF
--- a/js/academic-year-setup.js
+++ b/js/academic-year-setup.js
@@ -508,6 +508,88 @@ function copyPreviousYear(options = {}) {
     }
 }
 
+const PUBLIC_TERM_PROGRAM_CODE = 'ewu-design';
+
+function setPublicTermStatus(message, isError = false) {
+    const node = document.getElementById('publicTermStatus');
+    if (!node) return;
+    node.textContent = message || '';
+    node.style.color = isError ? '#cf222e' : '';
+}
+
+function getTermSupabaseClient() {
+    if (typeof window === 'undefined' || typeof window.getSupabaseClient !== 'function') {
+        return null;
+    }
+    try {
+        return window.getSupabaseClient();
+    } catch (error) {
+        return null;
+    }
+}
+
+function labelForQuarter(quarter) {
+    const value = String(quarter || '').toLowerCase();
+    return value ? value.charAt(0).toUpperCase() + value.slice(1) : '';
+}
+
+async function loadPublicTerm() {
+    const yearSelect = document.getElementById('publicTermYear');
+    const quarterSelect = document.getElementById('publicTermQuarter');
+    if (!yearSelect || !quarterSelect) return;
+
+    const client = getTermSupabaseClient();
+    if (!client || typeof client.rpc !== 'function') {
+        setPublicTermStatus('Sign in on the deployed site to manage the public default.');
+        return;
+    }
+
+    setPublicTermStatus('Loading current default…');
+    try {
+        const { data, error } = await client.rpc('get_public_current_term', {
+            p_program_code: PUBLIC_TERM_PROGRAM_CODE
+        });
+        if (error) throw error;
+        const row = Array.isArray(data) ? data[0] : data;
+        if (row) {
+            if (row.academic_year) yearSelect.value = row.academic_year;
+            if (row.quarter) quarterSelect.value = String(row.quarter).toLowerCase();
+        }
+        setPublicTermStatus('');
+    } catch (error) {
+        setPublicTermStatus(`Could not load current default: ${error?.message || error}`, true);
+    }
+}
+
+async function savePublicTerm() {
+    const button = document.getElementById('savePublicTermBtn');
+    const yearSelect = document.getElementById('publicTermYear');
+    const quarterSelect = document.getElementById('publicTermQuarter');
+    if (!yearSelect || !quarterSelect) return;
+
+    const client = getTermSupabaseClient();
+    if (!client || typeof client.rpc !== 'function') {
+        setPublicTermStatus('Supabase is not available. Open this page on the deployed site while signed in.', true);
+        return;
+    }
+
+    if (button) button.disabled = true;
+    setPublicTermStatus('Saving…');
+    try {
+        const { error } = await client.rpc('set_public_current_term', {
+            p_program_code: PUBLIC_TERM_PROGRAM_CODE,
+            p_academic_year: yearSelect.value,
+            p_quarter: quarterSelect.value
+        });
+        if (error) throw error;
+        setPublicTermStatus(`Public schedule now opens to ${labelForQuarter(quarterSelect.value)} ${yearSelect.value}.`);
+    } catch (error) {
+        setPublicTermStatus(`Save failed: ${error?.message || error}`, true);
+    } finally {
+        if (button) button.disabled = false;
+    }
+}
+
 function wireEvents() {
     document.getElementById('academicYearSelect').addEventListener('change', (event) => {
         setActiveYear(event.target.value);
@@ -535,6 +617,11 @@ function wireEvents() {
         if (action === 'edit') startEdit(recordId);
         if (action === 'delete') deleteRecord(recordId);
     });
+
+    const savePublicTermBtn = document.getElementById('savePublicTermBtn');
+    if (savePublicTermBtn) {
+        savePublicTermBtn.addEventListener('click', savePublicTerm);
+    }
 }
 
 function init() {
@@ -543,6 +630,7 @@ function init() {
     wireEvents();
     renderYearData();
     resetForm();
+    loadPublicTerm();
 }
 
 init();

--- a/pages/academic-year-setup.html
+++ b/pages/academic-year-setup.html
@@ -49,6 +49,28 @@
                 </div>
             </section>
 
+            <section class="panel public-term-panel">
+                <h2>Public Schedule Default</h2>
+                <p class="panel-help">Pick the term the public, no-login schedule opens to. Saving updates the live site immediately for every visitor.</p>
+                <div class="control-row">
+                    <label for="publicTermYear">Academic Year</label>
+                    <select id="publicTermYear">
+                        <option value="2026-27">2026-27</option>
+                        <option value="2025-26">2025-26</option>
+                        <option value="2024-25">2024-25</option>
+                        <option value="2023-24">2023-24</option>
+                    </select>
+                    <label for="publicTermQuarter">Quarter</label>
+                    <select id="publicTermQuarter">
+                        <option value="fall">Fall</option>
+                        <option value="winter">Winter</option>
+                        <option value="spring">Spring</option>
+                    </select>
+                    <button id="savePublicTermBtn" type="button">Save default</button>
+                </div>
+                <p id="publicTermStatus" class="panel-help" role="status" aria-live="polite"></p>
+            </section>
+
             <section class="panel adjunct-planning">
                 <h2>Adjunct Planning (Credits)</h2>
                 <p class="panel-help">Set expected adjunct credits needed per quarter for this academic year.</p>

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -733,6 +733,29 @@
             return state.courseCatalogByCode;
         }
 
+        async function loadCurrentTerm() {
+            // Reads the admin-configured public default term. Resilient by design:
+            // if the RPC is missing (migration not yet applied) or errors, we keep
+            // the hardcoded DEFAULTS so the page never breaks.
+            const client = getClient();
+            if (!client || typeof client.rpc !== 'function') return null;
+
+            try {
+                const { data, error } = await client.rpc('get_public_current_term', {
+                    p_program_code: programCode
+                });
+                if (error) return null;
+                const row = Array.isArray(data) ? data[0] : data;
+                if (!row) return null;
+                return {
+                    year: normalizePublicYear(row.academic_year),
+                    quarter: normalizePublicQuarter(row.quarter)
+                };
+            } catch (termError) {
+                return null;
+            }
+        }
+
         async function load(yearToLoad) {
             const client = getClient();
             if (!client || typeof client.rpc !== 'function') {
@@ -789,6 +812,11 @@
             setYear,
             async init() {
                 if (!documentRef) return;
+                const term = await loadCurrentTerm();
+                if (term) {
+                    state.year = term.year;
+                    state.activeQuarter = term.quarter;
+                }
                 await loadSelectedYear();
             }
         };

--- a/scripts/supabase-current-term-setting.sql
+++ b/scripts/supabase-current-term-setting.sql
@@ -1,0 +1,131 @@
+-- Public default term: which academic year + quarter the no-login public schedule
+-- shows first. Read anonymously by public-schedule.html; written by an authenticated
+-- chair from Academic Year Setup. Idempotent: safe to run multiple times.
+--
+-- Mirrors the access model of get_public_schedule (SECURITY DEFINER + explicit
+-- allowlists + REVOKE/GRANT). The settings table itself is never read or written
+-- directly by clients; all access flows through the two functions below.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.public_schedule_settings (
+    program_code TEXT PRIMARY KEY,
+    current_academic_year TEXT NOT NULL DEFAULT '2026-27',
+    current_quarter TEXT NOT NULL DEFAULT 'fall',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by UUID
+);
+
+-- Lock the table down: no direct client access. The SECURITY DEFINER functions
+-- below are the only sanctioned read/write path.
+ALTER TABLE public.public_schedule_settings ENABLE ROW LEVEL SECURITY;
+
+-- Seed the EWU Design default if it is not already present.
+INSERT INTO public.public_schedule_settings (program_code, current_academic_year, current_quarter)
+VALUES ('ewu-design', '2026-27', 'fall')
+ON CONFLICT (program_code) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Anonymous read: the public default term for a program, with safe fallback.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.get_public_current_term(
+    p_program_code TEXT DEFAULT 'ewu-design'
+)
+RETURNS TABLE (
+    academic_year TEXT,
+    quarter TEXT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_program_code TEXT := lower(btrim(coalesce(p_program_code, '')));
+    v_allowed_years CONSTANT TEXT[] := ARRAY['2026-27', '2025-26', '2024-25', '2023-24'];
+    v_allowed_quarters CONSTANT TEXT[] := ARRAY['fall', 'winter', 'spring'];
+    v_found BOOLEAN := false;
+BEGIN
+    -- Public surface is intentionally allowlisted to EWU Design (matches
+    -- get_public_schedule). Anything else returns the safe default below.
+    IF v_program_code = 'ewu-design' THEN
+        RETURN QUERY
+        SELECT
+            CASE WHEN s.current_academic_year = ANY (v_allowed_years)
+                 THEN s.current_academic_year ELSE '2026-27' END::TEXT,
+            CASE WHEN lower(s.current_quarter) = ANY (v_allowed_quarters)
+                 THEN lower(s.current_quarter) ELSE 'fall' END::TEXT
+        FROM public.public_schedule_settings s
+        WHERE s.program_code = v_program_code;
+
+        GET DIAGNOSTICS v_found = ROW_COUNT;
+        IF v_found THEN
+            RETURN;
+        END IF;
+    END IF;
+
+    -- Fallback when no row exists or the program is not public.
+    RETURN QUERY SELECT '2026-27'::TEXT, 'fall'::TEXT;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Authenticated write: validate then upsert the public default term.
+-- Restricted to signed-in users; the page is itself behind the auth guard.
+-- Tightening this to admin-only is a follow-up once a SQL-side role check exists.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.set_public_current_term(
+    p_program_code TEXT,
+    p_academic_year TEXT,
+    p_quarter TEXT
+)
+RETURNS public.public_schedule_settings
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_program_code TEXT := lower(btrim(coalesce(p_program_code, '')));
+    v_year TEXT := btrim(coalesce(p_academic_year, ''));
+    v_quarter TEXT := lower(btrim(coalesce(p_quarter, '')));
+    v_allowed_years CONSTANT TEXT[] := ARRAY['2026-27', '2025-26', '2024-25', '2023-24'];
+    v_allowed_quarters CONSTANT TEXT[] := ARRAY['fall', 'winter', 'spring'];
+    v_row public.public_schedule_settings;
+BEGIN
+    IF auth.uid() IS NULL THEN
+        RAISE EXCEPTION 'Not authorized: sign in to set the public term.';
+    END IF;
+    IF v_program_code <> 'ewu-design' THEN
+        RAISE EXCEPTION 'Unknown program code: %', p_program_code;
+    END IF;
+    IF NOT (v_year = ANY (v_allowed_years)) THEN
+        RAISE EXCEPTION 'Academic year % is not in the public allowlist.', p_academic_year;
+    END IF;
+    IF NOT (v_quarter = ANY (v_allowed_quarters)) THEN
+        RAISE EXCEPTION 'Quarter % must be fall, winter, or spring.', p_quarter;
+    END IF;
+
+    INSERT INTO public.public_schedule_settings AS s
+        (program_code, current_academic_year, current_quarter, updated_at, updated_by)
+    VALUES (v_program_code, v_year, v_quarter, now(), auth.uid())
+    ON CONFLICT (program_code) DO UPDATE
+        SET current_academic_year = EXCLUDED.current_academic_year,
+            current_quarter = EXCLUDED.current_quarter,
+            updated_at = now(),
+            updated_by = auth.uid()
+    RETURNING * INTO v_row;
+
+    RETURN v_row;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.get_public_current_term(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_public_current_term(TEXT)
+TO anon, authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.set_public_current_term(TEXT, TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.set_public_current_term(TEXT, TEXT, TEXT)
+TO authenticated, service_role;
+
+COMMIT;

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -193,43 +193,44 @@ describe('public schedule page', () => {
     });
 
     test('reloads public schedule rows when an allowed academic year is selected', async () => {
-        const rpc = jest.fn()
-            .mockResolvedValueOnce({
-                data: [
-                    {
-                        academic_year: '2026-27',
-                        quarter: 'fall',
-                        day_pattern: 'MW',
-                        time_slot: '10:00-12:20',
-                        section: '001',
-                        course_code: 'DESN 368',
-                        course_title: 'Code + Design 1',
-                        credits: 5,
-                        instructor_name: 'T. Masingale',
-                        room_code: '206',
-                        projected_enrollment: 24
-                    }
-                ],
-                error: null
-            })
-            .mockResolvedValueOnce({
-                data: [
-                    {
-                        academic_year: '2025-26',
-                        quarter: 'fall',
-                        day_pattern: 'TR',
-                        time_slot: '13:00-15:20',
-                        section: '001',
-                        course_code: 'DESN 263',
-                        course_title: 'User Experience Design I',
-                        credits: 5,
-                        instructor_name: 'S.Durr',
-                        room_code: '209',
-                        projected_enrollment: 22
-                    }
-                ],
-                error: null
-            });
+        const fallRow = {
+            academic_year: '2026-27',
+            quarter: 'fall',
+            day_pattern: 'MW',
+            time_slot: '10:00-12:20',
+            section: '001',
+            course_code: 'DESN 368',
+            course_title: 'Code + Design 1',
+            credits: 5,
+            instructor_name: 'T. Masingale',
+            room_code: '206',
+            projected_enrollment: 24
+        };
+        const priorYearRow = {
+            academic_year: '2025-26',
+            quarter: 'fall',
+            day_pattern: 'TR',
+            time_slot: '13:00-15:20',
+            section: '001',
+            course_code: 'DESN 263',
+            course_title: 'User Experience Design I',
+            credits: 5,
+            instructor_name: 'S.Durr',
+            room_code: '209',
+            projected_enrollment: 22
+        };
+        // Keyed by RPC name so the init term-read does not consume the schedule
+        // response sequence: get_public_current_term resolves first, then the
+        // schedule load resolves per requested academic year.
+        const rpc = jest.fn((name, args = {}) => {
+            if (name === 'get_public_current_term') {
+                return Promise.resolve({ data: [{ academic_year: '2026-27', quarter: 'fall' }], error: null });
+            }
+            if (args.p_academic_year === '2025-26') {
+                return Promise.resolve({ data: [priorYearRow], error: null });
+            }
+            return Promise.resolve({ data: [fallRow], error: null });
+        });
 
         const app = PublicSchedulePage.createPublicScheduleApp({
             document,
@@ -274,6 +275,93 @@ describe('public schedule page', () => {
 
         expect(document.getElementById('publicStatus').textContent).toBe('Unavailable');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('permission denied');
+    });
+
+    test('opens to the admin-configured public default term', async () => {
+        const rpc = jest.fn((name) => {
+            if (name === 'get_public_current_term') {
+                return Promise.resolve({ data: [{ academic_year: '2025-26', quarter: 'winter' }], error: null });
+            }
+            return Promise.resolve({
+                data: [
+                    {
+                        academic_year: '2025-26',
+                        quarter: 'winter',
+                        day_pattern: 'MW',
+                        time_slot: '10:00-12:20',
+                        section: '001',
+                        course_code: 'DESN 368',
+                        course_title: 'Code + Design 1',
+                        credits: 5,
+                        instructor_name: 'T. Masingale',
+                        room_code: '206',
+                        projected_enrollment: 24
+                    }
+                ],
+                error: null
+            });
+        });
+
+        const app = PublicSchedulePage.createPublicScheduleApp({
+            document,
+            scheduleDataUtils: ScheduleDataUtils,
+            getClient: () => ({ rpc })
+        });
+
+        await app.init();
+        await flushPromises();
+
+        expect(rpc).toHaveBeenCalledWith('get_public_current_term', { p_program_code: 'ewu-design' });
+        expect(rpc).toHaveBeenCalledWith('get_public_schedule', {
+            p_academic_year: '2025-26',
+            p_program_code: 'ewu-design',
+            p_quarter: null
+        });
+        expect(document.getElementById('publicScheduleTitle').textContent).toBe('Winter 2026');
+        expect(document.querySelector('[data-year="2025-26"]').getAttribute('aria-selected')).toBe('true');
+        expect(document.querySelector('[data-quarter="winter"]').getAttribute('aria-selected')).toBe('true');
+    });
+
+    test('falls back to Fall 2026 when the public term RPC is unavailable', async () => {
+        const rpc = jest.fn((name) => {
+            if (name === 'get_public_current_term') {
+                return Promise.resolve({ data: null, error: { message: 'function does not exist' } });
+            }
+            return Promise.resolve({
+                data: [
+                    {
+                        academic_year: '2026-27',
+                        quarter: 'fall',
+                        day_pattern: 'MW',
+                        time_slot: '10:00-12:20',
+                        section: '001',
+                        course_code: 'DESN 368',
+                        course_title: 'Code + Design 1',
+                        credits: 5,
+                        instructor_name: 'T. Masingale',
+                        room_code: '206',
+                        projected_enrollment: 24
+                    }
+                ],
+                error: null
+            });
+        });
+
+        const app = PublicSchedulePage.createPublicScheduleApp({
+            document,
+            scheduleDataUtils: ScheduleDataUtils,
+            getClient: () => ({ rpc })
+        });
+
+        await app.init();
+        await flushPromises();
+
+        expect(document.getElementById('publicScheduleTitle').textContent).toBe('Fall 2026');
+        expect(rpc).toHaveBeenLastCalledWith('get_public_schedule', {
+            p_academic_year: '2026-27',
+            p_program_code: 'ewu-design',
+            p_quarter: null
+        });
     });
 
     test('public HTML does not load protected editor/auth scripts or save controls', () => {

--- a/tests/supabase-current-term-setting.test.js
+++ b/tests/supabase-current-term-setting.test.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadMigrationSql() {
+    const filePath = path.resolve(__dirname, '..', 'scripts', 'supabase-current-term-setting.sql');
+    return fs.readFileSync(filePath, 'utf8');
+}
+
+describe('public default term migration contract', () => {
+    test('creates the settings table with a program_code key and RLS enabled', () => {
+        const sql = loadMigrationSql();
+        expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS public\.public_schedule_settings/i);
+        expect(sql).toMatch(/program_code TEXT PRIMARY KEY/i);
+        expect(sql).toMatch(/ALTER TABLE public\.public_schedule_settings ENABLE ROW LEVEL SECURITY/i);
+    });
+
+    test('seeds the EWU Design default without clobbering an existing row', () => {
+        const sql = loadMigrationSql();
+        expect(sql).toMatch(/INSERT INTO public\.public_schedule_settings/i);
+        expect(sql).toMatch(/ON CONFLICT \(program_code\) DO NOTHING/i);
+    });
+
+    test('defines an anon-readable get_public_current_term with allowlist + fallback', () => {
+        const sql = loadMigrationSql();
+        expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.get_public_current_term\(/i);
+        expect(sql).toMatch(/SECURITY DEFINER/i);
+        expect(sql).toMatch(/RETURN QUERY SELECT '2026-27'::TEXT, 'fall'::TEXT/i);
+        expect(sql).toMatch(/GRANT EXECUTE ON FUNCTION public\.get_public_current_term\(TEXT\)[\s\S]*?TO anon, authenticated, service_role/i);
+    });
+
+    test('defines an authenticated-only set_public_current_term that validates input', () => {
+        const sql = loadMigrationSql();
+        expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.set_public_current_term\(/i);
+        expect(sql).toMatch(/auth\.uid\(\) IS NULL/i);
+        expect(sql).toMatch(/is not in the public allowlist/i);
+        expect(sql).toMatch(/ON CONFLICT \(program_code\) DO UPDATE/i);
+        expect(sql).toMatch(/GRANT EXECUTE ON FUNCTION public\.set_public_current_term\(TEXT, TEXT, TEXT\)[\s\S]*?TO authenticated, service_role/i);
+        // Write access must never be granted to anon.
+        expect(sql).not.toMatch(/GRANT EXECUTE ON FUNCTION public\.set_public_current_term\(TEXT, TEXT, TEXT\)[\s\S]*?TO anon/i);
+    });
+});


### PR DESCRIPTION
## What
Adds a configurable **current term** (academic year + quarter) that the public schedule opens to, replacing the hardcoded Fall 2026 default. Set from **Academic Year Setup → Public Schedule Default**.

> **Stacked on #256** (base = `feat/public-landing-entry-point`). Merge #256 first; this diff then collapses to just the term feature.

## Changes
- `scripts/supabase-current-term-setting.sql`: `public_schedule_settings` table + anon-readable `get_public_current_term` and authenticated `set_public_current_term` RPCs (allowlisted, `SECURITY DEFINER`), mirroring the `get_public_schedule` access model.
- `public-schedule.js`: reads the term on load; **falls back to Fall 2026** if the RPC is absent (pre-migration) or errors — safe before the migration runs.
- `academic-year-setup`: new panel (year + quarter + Save) writing via the RPC.
- Tests: 2 public-page term tests + a SQL contract test; updated the sequential-mock RPC test.

## ⚠️ Required manual steps
1. **Run `scripts/supabase-current-term-setting.sql` against the production Supabase project.** I can't apply SQL to the DB; until then the public page shows Fall 2026.
2. The `.sql` is an **autopilot-forbidden path** → this PR needs the `allow-forbidden-paths` label + admin merge (same flow as #255).

## Notes
- Write RPC requires an authenticated session; the page is itself behind the auth guard. Tightening to admin-only (SQL-side role check) is a follow-up.
- The admin panel only works against **production** while signed in (local dev routes to the `develop` Supabase project, which has no anon key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)