### PR TITLE
feat(public): year dropdown limited to 2026-27 + 2025-26

### DIFF
--- a/css/public-schedule.css
+++ b/css/public-schedule.css
@@ -233,11 +233,40 @@ body {
 }
 
 .public-year-tabs {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 8px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
     padding: 10px 10px 0;
     border-bottom: 0;
+}
+
+.public-year-select-label {
+    font-family: var(--public-mono);
+    font-size: 11px;
+    font-weight: 850;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    color: var(--public-muted);
+}
+
+.public-year-select {
+    min-height: 34px;
+    padding: 6px 28px 6px 10px;
+    border: 1px solid var(--public-line);
+    border-radius: 0;
+    background: #ffffff;
+    color: var(--public-black);
+    font-family: var(--public-mono);
+    font-size: 12px;
+    font-weight: 850;
+    letter-spacing: 0;
+    cursor: pointer;
+}
+
+.public-year-select:focus-visible {
+    outline: none;
+    border-color: var(--public-accent);
+    box-shadow: inset 3px 0 0 var(--public-accent);
 }
 
 .public-quarter-tabs {
@@ -700,10 +729,6 @@ body {
 
     .public-main {
         padding: 16px 0 28px;
-    }
-
-    .public-year-tabs {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
     .public-quarter-tabs {

--- a/pages/academic-year-setup.html
+++ b/pages/academic-year-setup.html
@@ -57,8 +57,6 @@
                     <select id="publicTermYear">
                         <option value="2026-27">2026-27</option>
                         <option value="2025-26">2025-26</option>
-                        <option value="2024-25">2024-25</option>
-                        <option value="2023-24">2023-24</option>
                     </select>
                     <label for="publicTermQuarter">Quarter</label>
                     <select id="publicTermQuarter">

--- a/pages/public-schedule.js
+++ b/pages/public-schedule.js
@@ -20,7 +20,7 @@
         programCode: 'ewu-design'
     });
 
-    const PUBLIC_YEARS = Object.freeze(['2026-27', '2025-26', '2024-25', '2023-24']);
+    const PUBLIC_YEARS = Object.freeze(['2026-27', '2025-26']);
     const QUARTERS = Object.freeze(['fall', 'winter', 'spring']);
     const QUARTER_LABELS = Object.freeze({
         fall: 'Fall',
@@ -468,26 +468,34 @@
 
     function renderYearTabs(state) {
         const { documentRef, year } = state;
-        const tabs = documentRef.getElementById('publicYearTabs');
-        clearElement(tabs);
-        if (!tabs) return;
+        const container = documentRef.getElementById('publicYearTabs');
+        if (!container) return;
+        clearElement(container);
+
+        const label = createElement(documentRef, 'label', 'public-year-select-label', 'Academic year');
+        label.setAttribute('for', 'publicYearSelect');
+
+        const select = createElement(documentRef, 'select', 'public-year-select');
+        select.id = 'publicYearSelect';
+        select.setAttribute('aria-label', 'Academic year');
 
         PUBLIC_YEARS.forEach((publicYear) => {
-            const button = createElement(documentRef, 'button', 'public-year-tab');
-            button.type = 'button';
-            button.setAttribute('role', 'tab');
-            button.setAttribute('aria-selected', publicYear === year ? 'true' : 'false');
-            button.dataset.year = publicYear;
-            button.appendChild(createElement(documentRef, 'span', 'public-year-label', 'AY'));
-            button.appendChild(createElement(documentRef, 'span', 'public-year-value', publicYear));
-            button.title = `Academic year ${publicYear}`;
-            button.addEventListener('click', () => {
-                if (typeof state.onYearChange === 'function') {
-                    state.onYearChange(publicYear);
-                }
-            });
-            tabs.appendChild(button);
+            const option = createElement(documentRef, 'option', '', `AY ${publicYear}`);
+            option.value = publicYear;
+            option.dataset.year = publicYear;
+            if (publicYear === year) option.selected = true;
+            select.appendChild(option);
         });
+        select.value = year;
+
+        select.addEventListener('change', (event) => {
+            if (typeof state.onYearChange === 'function') {
+                state.onYearChange(event.target.value);
+            }
+        });
+
+        container.appendChild(label);
+        container.appendChild(select);
     }
 
     function renderQuarterTabs(state) {

--- a/public-schedule.html
+++ b/public-schedule.html
@@ -39,7 +39,7 @@
                 </div>
             </section>
 
-            <section class="public-year-tabs" id="publicYearTabs" role="tablist" aria-label="Academic year"></section>
+            <section class="public-year-tabs" id="publicYearTabs" aria-label="Academic year"></section>
 
             <section class="public-quarter-tabs" id="publicQuarterTabs" role="tablist" aria-label="Quarter"></section>
 

--- a/tests/public-schedule.test.js
+++ b/tests/public-schedule.test.js
@@ -31,7 +31,7 @@ describe('public schedule page', () => {
     test('uses AY 2026-27 Fall as the default context', () => {
         expect(PublicSchedulePage.DEFAULTS.year).toBe('2026-27');
         expect(PublicSchedulePage.DEFAULTS.quarter).toBe('fall');
-        expect(PublicSchedulePage.PUBLIC_YEARS).toEqual(['2026-27', '2025-26', '2024-25', '2023-24']);
+        expect(PublicSchedulePage.PUBLIC_YEARS).toEqual(['2026-27', '2025-26']);
         expect(PublicSchedulePage.formatQuarterTitle('2026-27', 'fall')).toBe('Fall 2026');
     });
 
@@ -157,8 +157,9 @@ describe('public schedule page', () => {
         expect(document.getElementById('publicScheduleTitle').textContent).toBe('Fall 2026');
         expect(document.getElementById('publicPanelCount').textContent).toBe('2 sections');
         expect(document.getElementById('publicStatus').textContent).toBe('Live schedule');
-        expect(document.querySelector('[data-year="2026-27"]').getAttribute('aria-selected')).toBe('true');
-        expect(document.getElementById('publicYearTabs').textContent).toContain('2023-24');
+        expect(document.getElementById('publicYearSelect').value).toBe('2026-27');
+        expect(document.getElementById('publicYearTabs').textContent).toContain('2025-26');
+        expect(document.getElementById('publicYearTabs').textContent).not.toContain('2023-24');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 368');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('Code + Design 1');
         expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('Interaction Design');
@@ -240,7 +241,9 @@ describe('public schedule page', () => {
 
         await app.init();
 
-        document.querySelector('[data-year="2025-26"]').click();
+        const yearSelect = document.getElementById('publicYearSelect');
+        yearSelect.value = '2025-26';
+        yearSelect.dispatchEvent(new Event('change'));
         await flushPromises();
         await flushPromises();
 
@@ -251,7 +254,7 @@ describe('public schedule page', () => {
         });
         expect(document.getElementById('publicAcademicYearLabel').textContent).toBe('AY 2025-26');
         expect(document.getElementById('publicScheduleTitle').textContent).toBe('Fall 2025');
-        expect(document.querySelector('[data-year="2025-26"]').getAttribute('aria-selected')).toBe('true');
+        expect(document.getElementById('publicYearSelect').value).toBe('2025-26');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('DESN 263');
         expect(document.getElementById('publicScheduleGrid').textContent).toContain('Visual Communication Design');
         expect(document.getElementById('publicScheduleGrid').textContent).not.toContain('User Experience Design I');
@@ -318,7 +321,7 @@ describe('public schedule page', () => {
             p_quarter: null
         });
         expect(document.getElementById('publicScheduleTitle').textContent).toBe('Winter 2026');
-        expect(document.querySelector('[data-year="2025-26"]').getAttribute('aria-selected')).toBe('true');
+        expect(document.getElementById('publicYearSelect').value).toBe('2025-26');
         expect(document.querySelector('[data-quarter="winter"]').getAttribute('aria-selected')).toBe('true');
     });
 


### PR DESCRIPTION
## What
The public schedule's year selector becomes a **small dropdown** (was four tabs) and offers only the current year **2026-27** and **2025-26**.

## Why
Per request: the only other year available on the public view should be 2025-26, via a small dropdown.

## Changes
- `public-schedule.js`: `PUBLIC_YEARS` → `['2026-27','2025-26']`; year tabs replaced with a `<select>` (`#publicYearSelect`). Unknown years still clamp to the default.
- `public-schedule.css`: dropdown styling; dropped the now-dead grid rules for the tab layout.
- `academic-year-setup.html`: the Public Schedule Default year picker narrowed to the same two years.
- `public-schedule.test.js`: updated year assertions (select value vs tab aria-selected).

## Notes
- The `get_public_schedule` SQL allowlist still lists the older years — harmless, since the frontend no longer requests them. Narrowing it is an optional follow-up (forbidden-path migration).
- No forbidden paths in this PR. All tracked tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)