### PR TITLE
feat(schedule-builder): UI/UX audit Phases A–E — data safety + accessibility + copy + brand + keyboard drag-drop

### DIFF
--- a/css/schedule-builder.css
+++ b/css/schedule-builder.css
@@ -581,8 +581,10 @@ body {
     position: absolute;
     top: 4px;
     right: 4px;
-    width: 20px;
-    height: 20px;
+    min-width: 24px;
+    min-height: 24px;
+    width: 24px;
+    height: 24px;
     border: none;
     background: rgba(255,255,255,0.8);
     color: #dc3545;
@@ -590,14 +592,18 @@ body {
     cursor: pointer;
     font-size: 14px;
     line-height: 1;
-    opacity: 0;
+    /* Visible at low opacity at rest so the affordance is discoverable;
+       full opacity when the parent card is hovered or has keyboard focus. */
+    opacity: 0.35;
     transition: opacity 0.2s;
     display: flex;
     align-items: center;
     justify-content: center;
 }
 
-.course-block:hover .course-delete-btn {
+.course-block:hover .course-delete-btn,
+.course-block:focus-within .course-delete-btn,
+.course-delete-btn:focus-visible {
     opacity: 1;
 }
 
@@ -1660,10 +1666,21 @@ body {
     cursor: pointer;
     color: var(--text-secondary);
     line-height: 1;
+    /* WCAG 2.2 target size — at least 24×24. */
+    min-width: 32px;
+    min-height: 32px;
+    width: 32px;
+    height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 6px;
 }
 
-.modal-close:hover {
+.modal-close:hover,
+.modal-close:focus-visible {
     color: var(--text-primary);
+    background: rgba(15, 23, 42, 0.06);
 }
 
 .form-group {
@@ -2272,9 +2289,12 @@ body {
     color: var(--text-secondary);
     cursor: pointer;
     transition: all 0.2s;
+    min-height: 28px;
+    min-width: 28px;
 }
 
-.btn-small:hover {
+.btn-small:hover,
+.btn-small:focus-visible {
     background: var(--bg-primary);
     border-color: var(--primary-color);
     color: var(--primary-color);
@@ -2605,6 +2625,22 @@ body {
         flex-direction: column;
         align-items: flex-start;
     }
+}
+
+/* ============================================
+   PHASE B — ACCESSIBILITY FLOOR (required-field markers + focus rings)
+   ============================================ */
+
+.form-required-legend {
+    margin: 0 0 12px;
+    font-size: 12px;
+    color: var(--text-secondary, #475569);
+}
+
+.form-required-mark {
+    color: #b91c1c;
+    margin-left: 2px;
+    font-weight: 700;
 }
 
 /* ============================================

--- a/css/schedule-builder.css
+++ b/css/schedule-builder.css
@@ -2625,6 +2625,50 @@ body {
 }
 
 /* ============================================
+   PHASE E — KEYBOARD DRAG-AND-DROP
+   Pick-up / drop using Enter+Space; Tab between cells; Escape cancels.
+   ============================================ */
+
+.sr-only {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+/* Focusable cards announce themselves on Tab. */
+.course-block:focus-visible,
+.unassigned-item:focus-visible {
+    outline: 3px solid var(--brand-focus-ring);
+    outline-offset: 2px;
+}
+
+/* Picked card — clear "I am currently held" affordance. */
+.course-block.kbd-picked,
+.unassigned-item.kbd-picked {
+    outline: 3px solid var(--primary-color);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 6px var(--brand-focus-ring);
+}
+
+/* Cells are tabbable while pickup is active so Tab cycles through targets. */
+body.kbd-pickup-active .schedule-cell {
+    cursor: copy;
+    box-shadow: inset 0 0 0 1px var(--brand-focus-ring);
+}
+
+body.kbd-pickup-active .schedule-cell:focus-visible {
+    outline: 3px solid var(--primary-color);
+    outline-offset: -2px;
+    background: rgba(161, 0, 34, 0.04);
+}
+
+/* ============================================
    PHASE C — REVEAL SEQUENCE + COPY POLISH
    Inline Step-2 anchor + helper-text styling moved out of inline styles.
    ============================================ */

--- a/css/schedule-builder.css
+++ b/css/schedule-builder.css
@@ -2606,3 +2606,103 @@ body {
         align-items: flex-start;
     }
 }
+
+/* ============================================
+   PHASE A — DATA SAFETY UI
+   Dirty pill on the action bar + persistent error banner for recoverable
+   failures (corrupt draft, save errors). Toned to be visible without
+   competing with the primary action bar.
+   ============================================ */
+
+.action-bar-attribution[data-state="dirty"] {
+    color: #8a4a00;
+    background: #fff7e6;
+    border: 1px solid #facc8a;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-weight: 600;
+    display: inline-block;
+}
+
+.action-bar-attribution[data-state="pristine"] {
+    color: var(--text-secondary, #475569);
+    font-style: italic;
+}
+
+.action-bar-attribution[data-state="saved"] {
+    color: var(--text-secondary, #475569);
+}
+
+button[aria-busy="true"] {
+    opacity: 0.75;
+    cursor: progress;
+}
+
+.builder-recoverable-error {
+    position: fixed;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%) translateY(-16px);
+    z-index: 1100;
+    max-width: 560px;
+    width: calc(100vw - 32px);
+    background: #fff;
+    border: 1px solid #dc2626;
+    border-left: 4px solid #dc2626;
+    border-radius: 10px;
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.14);
+    padding: 14px 18px;
+    display: none;
+    flex-direction: column;
+    gap: 10px;
+    font-size: 14px;
+    line-height: 1.4;
+    color: #1f2937;
+}
+
+.builder-recoverable-error.visible {
+    display: flex;
+    transform: translateX(-50%) translateY(0);
+}
+
+.builder-recoverable-error__message {
+    font-weight: 500;
+}
+
+.builder-recoverable-error__actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    flex-wrap: wrap;
+}
+
+.builder-recoverable-error__btn {
+    background: white;
+    border: 1px solid var(--border-color, #d1d5db);
+    color: #1f2937;
+    padding: 6px 12px;
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+    min-height: 28px;
+}
+
+.builder-recoverable-error__btn:hover {
+    background: #f3f4f6;
+}
+
+.builder-recoverable-error__btn--dismiss {
+    background: #1f2937;
+    color: white;
+    border-color: #1f2937;
+}
+
+.builder-recoverable-error__btn--dismiss:hover {
+    background: #111827;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .builder-recoverable-error {
+        transition: none !important;
+    }
+}

--- a/css/schedule-builder.css
+++ b/css/schedule-builder.css
@@ -2628,6 +2628,28 @@ body {
 }
 
 /* ============================================
+   PHASE C — REVEAL SEQUENCE + COPY POLISH
+   Inline Step-2 anchor + helper-text styling moved out of inline styles.
+   ============================================ */
+
+.controls-step-badge--inline {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.helper-text--faculty-panel {
+    margin-bottom: 16px;
+    color: #6b7280;
+    font-size: 13px;
+}
+
+.section-header-actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+}
+
+/* ============================================
    PHASE B — ACCESSIBILITY FLOOR (required-field markers + focus rings)
    ============================================ */
 

--- a/css/schedule-builder.css
+++ b/css/schedule-builder.css
@@ -1,7 +1,12 @@
 /* Schedule Builder Styles */
 :root {
-    --primary-color: #b7142e;
-    --primary-dark: #8f1024;
+    /* EWU Design brand red — aligned with css/design-system.css and CLAUDE.md.
+       Previously this file ran on #b7142e / #8f1024, which read as off-brand
+       next to the rest of Program Command. */
+    --primary-color: #a10022;
+    --primary-dark: #760019;
+    --brand-focus-ring: rgba(161, 0, 34, 0.22);
+    --brand-shadow: rgba(161, 0, 34, 0.28);
     --secondary-color: #0969da;
     --success-color: #16a34a;
     --warning-color: #d97706;
@@ -21,15 +26,15 @@
 }
 
 :focus-visible {
-    outline: 3px solid rgba(15, 118, 110, 0.35);
+    outline: 3px solid var(--brand-focus-ring);
     outline-offset: 2px;
 }
 
 body {
     font-family: 'Sora', 'Avenir Next', 'Segoe UI', sans-serif;
     background:
-        radial-gradient(1200px 700px at 0% -10%, rgba(15, 118, 110, 0.08), transparent 55%),
-        radial-gradient(1100px 600px at 100% -8%, rgba(245, 158, 11, 0.08), transparent 55%),
+        radial-gradient(1200px 700px at 0% -10%, rgba(161, 0, 34, 0.06), transparent 55%),
+        radial-gradient(1100px 600px at 100% -8%, rgba(15, 23, 42, 0.04), transparent 55%),
         var(--bg-primary);
     color: var(--text-primary);
     line-height: 1.6;
@@ -41,17 +46,21 @@ body {
     padding: 20px;
 }
 
-/* Header */
+/* Header
+ * NOTE: program-command-dashboard-theme.css overrides this with a charcoal
+ * command-bar gradient and !important — that's the canonical look across
+ * Program Command. The base styles below stay in case the theme is removed,
+ * but the brand red is the accent the theme expects, not teal. */
 .builder-header {
     background:
-        linear-gradient(120deg, rgba(15, 118, 110, 0.96) 0%, rgba(21, 94, 89, 0.98) 100%),
+        linear-gradient(120deg, #a10022 0%, #760019 100%),
         repeating-linear-gradient(45deg, rgba(255,255,255,0.05) 0 10px, transparent 10px 20px);
     color: white;
     padding: 30px;
     border-radius: 20px;
     margin-bottom: 24px;
     position: relative;
-    box-shadow: 0 10px 30px rgba(15, 118, 110, 0.22);
+    box-shadow: 0 10px 30px var(--brand-shadow);
 }
 
 .builder-header-top {
@@ -217,7 +226,7 @@ body {
 .control-group select:focus {
     outline: none;
     border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
+    box-shadow: 0 0 0 3px var(--brand-focus-ring);
 }
 
 /* Buttons */
@@ -235,7 +244,7 @@ body {
 
 .btn-primary:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(15, 118, 110, 0.32);
+    box-shadow: 0 6px 16px var(--brand-shadow);
 }
 
 .btn-secondary {
@@ -1536,7 +1545,7 @@ body {
 
 .recommendation-item:hover {
     border-color: var(--primary-color);
-    box-shadow: 0 2px 6px rgba(245, 158, 11, 0.15);
+    box-shadow: 0 2px 6px var(--brand-focus-ring);
 }
 
 .recommendation-item input[type="checkbox"] {
@@ -1708,7 +1717,7 @@ body {
 .form-group input:focus {
     outline: none;
     border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
+    box-shadow: 0 0 0 3px var(--brand-focus-ring);
 }
 
 .modal-actions {
@@ -1720,21 +1729,9 @@ body {
     border-top: 1px solid var(--border-color);
 }
 
-/* Small button for sidebar */
-.btn-small {
-    padding: 4px 10px;
-    font-size: 12px;
-    background: var(--primary-color);
-    color: white;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: background 0.2s;
-}
-
-.btn-small:hover {
-    background: #d97706;
-}
+/* (.btn-small canonical definition lives further down. The earlier duplicate
+   with a solid-red bg and amber hover was deleted in Phase D — it was clearly
+   a copy-paste from a different surface and broke the ladder.) */
 
 /* Faculty Preferences Modal Styles */
 .preferences-grid {
@@ -1804,7 +1801,7 @@ body {
 .form-group textarea:focus {
     outline: none;
     border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
+    box-shadow: 0 0 0 3px var(--brand-focus-ring);
 }
 
 /* Constraint Indicators for Add Course Modal */
@@ -1844,7 +1841,7 @@ body {
 
 .btn-ai:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(15, 118, 110, 0.3);
+    box-shadow: 0 6px 16px var(--brand-shadow);
 }
 
 .btn-settings {
@@ -1894,7 +1891,7 @@ body {
 .api-key-input-group input:focus {
     outline: none;
     border-color: var(--primary-color);
-    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
+    box-shadow: 0 0 0 3px var(--brand-focus-ring);
 }
 
 /* API Key Status */
@@ -2569,7 +2566,7 @@ body {
 .scenario-table input[type="number"]:focus {
     outline: none;
     border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.12);
+    box-shadow: 0 0 0 2px var(--brand-focus-ring);
 }
 
 .scenario-value {

--- a/js/auth-guard.js
+++ b/js/auth-guard.js
@@ -160,6 +160,9 @@
             node = document.createElement('div');
             node.id = 'editConflictNotice';
             node.className = 'edit-conflict-notice';
+            node.setAttribute('role', 'status');
+            node.setAttribute('aria-live', 'polite');
+            node.setAttribute('aria-atomic', 'true');
             document.body.appendChild(node);
         }
 
@@ -228,6 +231,8 @@
             banner = document.createElement('div');
             banner.id = 'editLockWarningBanner';
             banner.className = 'edit-lock-warning-banner';
+            banner.setAttribute('role', 'alert');
+            banner.setAttribute('aria-live', 'assertive');
             banner.innerHTML = `
                 <div class=\"edit-lock-warning-message\" id=\"editLockWarningMessage\"></div>
                 <div class=\"edit-lock-warning-actions\">
@@ -481,8 +486,15 @@
                 color: #7a4b00;
                 font-size: 12px;
                 font-weight: 700;
-                padding: 4px 10px;
+                padding: 6px 14px;
                 cursor: pointer;
+                /* WCAG 2.2 target size — at least 24x24. */
+                min-height: 28px;
+                min-width: 28px;
+            }
+            .edit-lock-btn:focus-visible {
+                outline: 2px solid #1a73e8;
+                outline-offset: 2px;
             }
             .edit-lock-btn.danger {
                 border-color: #b45309;

--- a/pages/schedule-builder.html
+++ b/pages/schedule-builder.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Schedule Builder - Design Scheduler</title>
+    <title>Draft Schedule Builder · Program Command</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
@@ -56,8 +56,8 @@
             <button id="generateBtn" class="btn-primary" onclick="handleLoadAndAnalyze()">
                 Load & Analyze
             </button>
-            <button class="btn-secondary" onclick="window.location.href='pamcam-playground.html'">
-                PamCam Lab
+            <button class="btn-secondary" type="button" onclick="window.location.href='pamcam-playground.html'" title="Experimental scheduling tools (PamCam)">
+                Experimental tools
             </button>
             <button class="btn-secondary" onclick="window.location.href='academic-year-setup.html'">
                 AY Setup
@@ -65,14 +65,14 @@
         </div>
 
         <!-- Faculty Selection Panel -->
-        <div class="faculty-selection-panel">
+        <div class="faculty-selection-panel" id="facultySelectionPanel" style="display: none;">
             <button class="faculty-panel-toggle" onclick="toggleFacultyPanel()" aria-expanded="true" aria-controls="facultyPanelContent">
                 <span><span aria-hidden="true">👥 </span>Faculty Selection for Next Year</span>
                 <span class="toggle-icon" aria-hidden="true">▼</span>
             </button>
             <div class="faculty-panel-content" id="facultyPanelContent">
-                <p class="helper-text" style="margin-bottom: 16px; color: #6b7280; font-size: 13px;">
-                    Select which faculty will be available for the next academic year. Full-time faculty (professors, lecturers) are prioritized; adjuncts serve as placeholders when full-time faculty are unavailable.
+                <p class="helper-text helper-text--faculty-panel">
+                    Check off the faculty available next year. Full-time faculty (professors, lecturers) are assigned first; adjuncts fill remaining gaps.
                 </p>
                 <div id="facultySelectionContainer">
                     <p style="color: #6b7280; text-align: center; padding: 20px;">Loading faculty data...</p>
@@ -81,7 +81,7 @@
         </div>
 
         <!-- Predictive Faculty Build Panel -->
-        <div class="build-scenario-panel">
+        <div class="build-scenario-panel" id="buildScenarioPanel" style="display: none;">
             <div class="scenario-header">
                 <div>
                     <h2>Predictive Faculty Build</h2>
@@ -140,7 +140,7 @@
         </div>
 
         <!-- Summary Cards -->
-        <div class="summary-cards" id="summaryCards">
+        <div class="summary-cards" id="summaryCards" style="display: none;">
             <div class="summary-card">
                 <div class="card-icon">📚</div>
                 <div class="card-value" id="totalSections">--</div>
@@ -280,8 +280,11 @@
             <!-- Schedule Grid View -->
             <div class="grid-section">
                 <div class="section-header">
-                    <h2 id="gridTitle">Schedule Grid - Fall 2026</h2>
-                    <div style="display: flex; gap: 12px; align-items: center;">
+                    <div>
+                        <span class="controls-step-badge controls-step-badge--inline">Step 2</span>
+                        <h2 id="gridTitle" style="display:inline-block;margin-left:8px;">Schedule Grid - Fall 2026</h2>
+                    </div>
+                    <div class="section-header-actions">
                         <button class="btn-add-course" onclick="openAddCourseModal()">+ Add Course</button>
                         <div class="view-toggle">
                             <button class="view-btn active" onclick="setView('grid')" id="gridViewBtn">Grid View</button>
@@ -327,14 +330,14 @@
 
         <!-- Empty State -->
         <div class="empty-state" id="emptyState">
-            <div class="empty-icon">📅</div>
-            <h2>Ready to Build Your Schedule</h2>
-            <p>Select an academic year and quarter, then click "Generate Schedule" to get AI-powered recommendations based on:</p>
+            <div class="empty-icon" aria-hidden="true">📅</div>
+            <h2>Ready to build your draft</h2>
+            <p>Pick a year to copy from and a target year, then click <strong>Load &amp; Analyze</strong>. We'll pull last year's schedule and surface what needs your attention:</p>
             <ul class="features-list">
-                <li>📊 3+ years of enrollment history</li>
-                <li>🔗 Prerequisite flow patterns</li>
-                <li>👨‍🏫 Historical faculty assignments</li>
-                <li>📈 Course demand predictions</li>
+                <li><span aria-hidden="true">📊 </span>Courses trending over capacity</li>
+                <li><span aria-hidden="true">🔗 </span>Prerequisite gaps in next year's draft</li>
+                <li><span aria-hidden="true">👨‍🏫 </span>Faculty who taught each course last time</li>
+                <li><span aria-hidden="true">📈 </span>Sections to add, hold, or cut</li>
             </ul>
         </div>
 
@@ -345,23 +348,23 @@
                 <div class="action-bar-subtitle">Save the builder draft, export to the main scheduler, or go straight to workload review.</div>
                 <div class="action-bar-attribution" id="saveAttributionLabel">Last saved by -- at --</div>
             </div>
-            <button class="btn-secondary" onclick="saveDraft()">
-                💾 Save Draft
+            <button class="btn-secondary" type="button" onclick="saveDraft()" title="Save a local draft in this browser only">
+                <span aria-hidden="true">💾 </span>Save local draft
             </button>
-            <button class="btn-primary" onclick="saveToDatabase()" id="saveToCloudBtn">
-                ☁️ Save to Cloud
+            <button class="btn-secondary" type="button" onclick="saveToDatabase()" id="saveToCloudBtn" title="Publish to the shared Supabase database">
+                <span aria-hidden="true">☁️ </span>Publish to cloud
             </button>
-            <button class="btn-ai" onclick="evaluateWithAI()">
-                ✨ Evaluate with AI
+            <button class="btn-ai" type="button" onclick="evaluateWithAI()">
+                <span aria-hidden="true">✨ </span>Evaluate with AI
             </button>
-            <button class="btn-secondary" onclick="exportJSON()">
-                📥 Export JSON
+            <button class="btn-secondary" type="button" onclick="exportJSON()">
+                <span aria-hidden="true">📥 </span>Export JSON
             </button>
-            <button class="btn-primary" onclick="exportToEditor()">
+            <button class="btn-secondary" type="button" onclick="exportToEditor()">
                 Open in Main Schedule →
             </button>
-            <button class="btn-primary" onclick="openWorkloadReview()">
-                👥 Make Workloads →
+            <button class="btn-primary" type="button" onclick="openWorkloadReview()">
+                <span aria-hidden="true">👥 </span>Review Workloads →
             </button>
             <button class="btn-settings" type="button" onclick="openApiSettingsModal()" title="AI Settings" aria-label="AI Settings">
                 <span aria-hidden="true">⚙️</span>
@@ -557,7 +560,7 @@
             </div>
             <div class="ai-results-loading" id="aiResultsLoading" style="display: none;">
                 <div class="loading-spinner"></div>
-                <p>Analyzing schedule with ChatGPT...</p>
+                <p>Analyzing schedule with AI…</p>
             </div>
             <div class="ai-results-content" id="aiResultsContent">
                 <!-- Health Score -->

--- a/pages/schedule-builder.html
+++ b/pages/schedule-builder.html
@@ -66,9 +66,9 @@
 
         <!-- Faculty Selection Panel -->
         <div class="faculty-selection-panel">
-            <button class="faculty-panel-toggle" onclick="toggleFacultyPanel()">
-                <span>👥 Faculty Selection for Next Year</span>
-                <span class="toggle-icon">▼</span>
+            <button class="faculty-panel-toggle" onclick="toggleFacultyPanel()" aria-expanded="true" aria-controls="facultyPanelContent">
+                <span><span aria-hidden="true">👥 </span>Faculty Selection for Next Year</span>
+                <span class="toggle-icon" aria-hidden="true">▼</span>
             </button>
             <div class="faculty-panel-content" id="facultyPanelContent">
                 <p class="helper-text" style="margin-bottom: 16px; color: #6b7280; font-size: 13px;">
@@ -363,52 +363,53 @@
             <button class="btn-primary" onclick="openWorkloadReview()">
                 👥 Make Workloads →
             </button>
-            <button class="btn-settings" onclick="openApiSettingsModal()" title="API Settings">
-                ⚙️
+            <button class="btn-settings" type="button" onclick="openApiSettingsModal()" title="AI Settings" aria-label="AI Settings">
+                <span aria-hidden="true">⚙️</span>
             </button>
         </div>
 
         <!-- Toast Notification -->
-        <div class="toast" id="toast">
+        <div class="toast" id="toast" role="status" aria-live="polite" aria-atomic="true">
             <span id="toastMessage"></span>
         </div>
 
         <!-- Add Course Modal -->
         <div class="modal-overlay" id="addCourseModal">
-            <div class="modal">
+            <div class="modal" role="dialog" aria-modal="true" aria-labelledby="addCourseModalTitle">
                 <div class="modal-header">
-                    <h2 class="modal-title">Add Course to Schedule</h2>
-                    <button class="modal-close" onclick="closeAddCourseModal()">&times;</button>
+                    <h2 class="modal-title" id="addCourseModalTitle">Add Course to Schedule</h2>
+                    <button class="modal-close" type="button" onclick="closeAddCourseModal()" aria-label="Close Add Course dialog">&times;</button>
                 </div>
                 <form id="addCourseForm" onsubmit="handleAddCourse(event)">
+                    <p class="form-required-legend"><span aria-hidden="true">*</span> Required field</p>
                     <div class="form-group">
-                        <label for="addCourseCode">Course</label>
-                        <select id="addCourseCode" required>
+                        <label for="addCourseCode">Course <span aria-hidden="true" class="form-required-mark">*</span></label>
+                        <select id="addCourseCode" required aria-required="true">
                             <option value="">Select a course...</option>
                         </select>
                     </div>
                     <div class="form-group">
-                        <label for="addCourseSection">Section</label>
-                        <input type="text" id="addCourseSection" placeholder="001" maxlength="3" required>
+                        <label for="addCourseSection">Section <span aria-hidden="true" class="form-required-mark">*</span></label>
+                        <input type="text" id="addCourseSection" placeholder="001" maxlength="3" required aria-required="true">
                     </div>
                     <div class="form-group">
-                        <label for="addCourseDays">Days</label>
-                        <select id="addCourseDays" required>
+                        <label for="addCourseDays">Days <span aria-hidden="true" class="form-required-mark">*</span></label>
+                        <select id="addCourseDays" required aria-required="true">
                             <option value="MW">Monday/Wednesday</option>
                             <option value="TR">Tuesday/Thursday</option>
                         </select>
                     </div>
                     <div class="form-group">
-                        <label for="addCourseTime">Time</label>
-                        <select id="addCourseTime" required>
+                        <label for="addCourseTime">Time <span aria-hidden="true" class="form-required-mark">*</span></label>
+                        <select id="addCourseTime" required aria-required="true">
                             <option value="10:00-12:20">10:00 AM - 12:20 PM</option>
                             <option value="13:00-15:20">1:00 PM - 3:20 PM</option>
                             <option value="16:00-18:20">4:00 PM - 6:20 PM</option>
                         </select>
                     </div>
                     <div class="form-group">
-                        <label for="addCourseRoom">Room</label>
-                        <select id="addCourseRoom" required>
+                        <label for="addCourseRoom">Room <span aria-hidden="true" class="form-required-mark">*</span></label>
+                        <select id="addCourseRoom" required aria-required="true">
                             <optgroup label="Catalyst (Spokane)">
                                 <option value="206">206 - UX Lab</option>
                                 <option value="209">209 - Mac Lab</option>
@@ -437,10 +438,10 @@
 
         <!-- Faculty Preferences Modal -->
         <div class="modal-overlay" id="facultyPreferencesModal">
-            <div class="modal" style="max-width: 600px;">
+            <div class="modal" style="max-width: 600px;" role="dialog" aria-modal="true" aria-labelledby="facultyPreferencesModalTitle">
                 <div class="modal-header">
-                    <h2 class="modal-title">Faculty Preferences</h2>
-                    <button class="modal-close" onclick="closeFacultyPreferencesModal()">&times;</button>
+                    <h2 class="modal-title" id="facultyPreferencesModalTitle">Faculty Preferences</h2>
+                    <button class="modal-close" type="button" onclick="closeFacultyPreferencesModal()" aria-label="Close Faculty Preferences dialog">&times;</button>
                 </div>
                 <form id="facultyPreferencesForm" onsubmit="handleSaveFacultyPreferences(event)">
                     <div class="form-group">
@@ -524,17 +525,17 @@
 
         <!-- API Settings Modal -->
         <div class="modal-overlay" id="apiSettingsModal">
-            <div class="modal" style="max-width: 500px;">
+            <div class="modal" style="max-width: 500px;" role="dialog" aria-modal="true" aria-labelledby="apiSettingsModalTitle">
                 <div class="modal-header">
-                    <h2 class="modal-title">AI API Settings (OpenAI or Claude)</h2>
-                    <button class="modal-close" onclick="closeApiSettingsModal()">&times;</button>
+                    <h2 class="modal-title" id="apiSettingsModalTitle">AI Settings</h2>
+                    <button class="modal-close" type="button" onclick="closeApiSettingsModal()" aria-label="Close AI Settings dialog">&times;</button>
                 </div>
                 <div class="modal-body">
                     <div class="form-group">
                         <label for="apiKeyInput">API Key</label>
                         <div class="api-key-input-group">
                             <input type="password" id="apiKeyInput" placeholder="sk-... or sk-ant-..." autocomplete="off">
-                            <button type="button" class="btn-small" onclick="toggleApiKeyVisibility()">👁️</button>
+                            <button type="button" class="btn-small" onclick="toggleApiKeyVisibility()" aria-label="Show or hide API key"><span aria-hidden="true">👁️</span></button>
                         </div>
                         <p class="helper-text">Use either <a href="https://platform.openai.com/api-keys" target="_blank">OpenAI API keys</a> or <a href="https://console.anthropic.com/settings/keys" target="_blank">Anthropic API keys</a></p>
                     </div>
@@ -637,8 +638,10 @@
         function toggleFacultyPanel() {
             const content = document.getElementById('facultyPanelContent');
             const toggle = document.querySelector('.faculty-panel-toggle');
+            const willCollapse = !content.classList.contains('collapsed');
             content.classList.toggle('collapsed');
             toggle.classList.toggle('collapsed');
+            toggle.setAttribute('aria-expanded', willCollapse ? 'false' : 'true');
         }
         
         // Initialize when DOM is ready

--- a/pages/schedule-builder.html
+++ b/pages/schedule-builder.html
@@ -310,7 +310,7 @@
             <div class="sidebar-panel">
                 <div class="panel-section">
                     <h3>Unassigned Courses</h3>
-                    <p class="helper-text">Drag courses to the grid to assign time slots</p>
+                    <p class="helper-text">Drag courses to the grid to assign time slots, or press <kbd>Enter</kbd>/<kbd>Space</kbd> to pick up and <kbd>Tab</kbd> to a target cell.</p>
                     <div class="unassigned-list" id="unassignedList">
                         <!-- Dynamically populated -->
                     </div>
@@ -375,6 +375,9 @@
         <div class="toast" id="toast" role="status" aria-live="polite" aria-atomic="true">
             <span id="toastMessage"></span>
         </div>
+
+        <!-- Phase E — Keyboard-pickup announcer (visually hidden, read by SR) -->
+        <div id="kbdPickupAnnouncer" class="sr-only" role="status" aria-live="polite" aria-atomic="true"></div>
 
         <!-- Add Course Modal -->
         <div class="modal-overlay" id="addCourseModal">

--- a/pages/schedule-builder.js
+++ b/pages/schedule-builder.js
@@ -885,9 +885,11 @@ async function handleLoadAndAnalyze() {
         // Render analysis results
         renderAnalysisDashboard(analysisResults);
 
-        // Hide loading, show analysis dashboard
+        // Hide loading, show analysis dashboard + the post-data panels that
+        // start hidden so the empty state can shine on first load.
         document.getElementById('loadingContainer').style.display = 'none';
         document.getElementById('analysisDashboard').style.display = 'block';
+        revealPostDataPanels();
 
         // Auto-save placements after loading so they're preserved for future use
         updatePlacementsFromSchedule(sourceYear);
@@ -1278,6 +1280,7 @@ async function handleGenerate() {
         document.getElementById('projectedDemandSection').style.display = 'block';
         document.getElementById('builderContent').style.display = 'grid';
         document.getElementById('actionBar').style.display = 'flex';
+        revealPostDataPanels();
 
         // Update titles
         document.getElementById('gridTitle').textContent = `Schedule Grid - ${activeQuarter} ${targetYear}`;
@@ -2643,6 +2646,7 @@ function loadDraft() {
         document.getElementById('projectedDemandSection').style.display = 'block';
         document.getElementById('builderContent').style.display = 'grid';
         document.getElementById('actionBar').style.display = 'flex';
+        revealPostDataPanels();
 
         document.getElementById('gridTitle').textContent = `Schedule Grid - ${currentSchedule.quarter} ${currentSchedule.year}`;
         document.getElementById('demandQuarterYear').textContent = `${currentSchedule.quarter} ${currentSchedule.year}`;
@@ -3266,6 +3270,21 @@ async function withSaveButtonBusy(buttonId, busyLabel, action) {
         button.removeAttribute('aria-busy');
         button.innerHTML = originalLabel;
     }
+}
+
+/**
+ * Phase C — reveal the panels that ship hidden so the empty state can lead on
+ * first load. Idempotent; safe to call multiple times. Triggered from
+ * handleLoadAndAnalyze, handleGenerate, and loadDraft success paths.
+ */
+function revealPostDataPanels() {
+    const ids = ['facultySelectionPanel', 'buildScenarioPanel', 'summaryCards'];
+    ids.forEach((id) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        // Use the element's natural display rather than guessing flex/grid/block.
+        el.style.display = '';
+    });
 }
 
 /**

--- a/pages/schedule-builder.js
+++ b/pages/schedule-builder.js
@@ -68,6 +68,13 @@ const FACULTY_BUILD_STORAGE_KEY = 'faculty_build_scenario_v1';
 const FACULTY_PREFERENCES_LOCAL_KEY = 'faculty_preferences_local_v1';
 const SAVE_ATTRIBUTION_STORAGE_KEY = 'schedule_builder_last_save_attribution_v1';
 
+// Phase A — Data safety: track unsaved edits so we can warn before unload
+// and tell the user (via the attribution label) that their work is not on the
+// server yet. Cleared on successful saveDraft / saveToDatabase. Set by every
+// mutation site (drop/swap/delete/add/apply-recommendations/generate).
+let isDirty = false;
+let dirtyTrackingReady = false;
+
 const DEFAULT_FACULTY_BUILD_SCENARIO = {
     faculty: [
         { name: 'Travis Masingale', included: true, annualCredits: 31, inloadCredits: 5, desn499PerQuarter: 2 },
@@ -134,7 +141,24 @@ function formatSaveAttributionDate(isoString) {
 function setSaveAttributionLabel(userLabel, savedAt) {
     const label = document.getElementById('saveAttributionLabel');
     if (!label) return;
-    label.textContent = `Last saved by ${userLabel || '--'} at ${formatSaveAttributionDate(savedAt)}`;
+
+    // Dirty wins — always tell the user their work isn't safe yet.
+    if (isDirty) {
+        label.textContent = 'Unsaved changes — Save to Cloud to commit, or Save Draft to keep them in this browser.';
+        label.dataset.state = 'dirty';
+        return;
+    }
+
+    // No save state for this year yet — produce a real empty-state sentence
+    // instead of "Last saved by -- at --".
+    if (!userLabel || !savedAt) {
+        label.textContent = 'Not yet saved to cloud — your edits live only in this browser.';
+        label.dataset.state = 'pristine';
+        return;
+    }
+
+    label.textContent = `Last saved by ${userLabel} at ${formatSaveAttributionDate(savedAt)}`;
+    label.dataset.state = 'saved';
 }
 
 function readSaveAttributionState() {
@@ -157,7 +181,7 @@ function writeSaveAttributionState(state) {
 function refreshSaveAttributionLabelForYear(targetYear) {
     const state = readSaveAttributionState();
     if (!state || state.year !== targetYear) {
-        setSaveAttributionLabel('--', null);
+        setSaveAttributionLabel(null, null);
         return;
     }
     setSaveAttributionLabel(state.userLabel, state.savedAt);
@@ -672,6 +696,10 @@ document.addEventListener('DOMContentLoaded', async function() {
         initializeFacultyBuildScenario();
         loadDraft();
 
+        // Phase A — warn before unload if the user has unsaved edits.
+        // Safe to attach unconditionally; the listener early-returns when not dirty.
+        attachBeforeUnloadGuard();
+
         const activeYear = document.getElementById('academicYear')?.value || '2026-27';
         refreshSaveAttributionLabelForYear(activeYear);
         const academicYearSelect = document.getElementById('academicYear');
@@ -703,6 +731,15 @@ function extractCoursesFromProgramCommandDraft(academicYear) {
         parsed = JSON.parse(raw);
     } catch (error) {
         console.warn(`Could not parse Program Command schedule draft for ${academicYear}:`, error);
+        showErrorBanner(
+            `The Program Command draft for ${academicYear} could not be parsed and was skipped. The builder will fall back to workload-data.json. Open the main scheduler to regenerate, or copy a different source year.`,
+            {
+                actions: [{
+                    label: 'Open main scheduler',
+                    onClick: () => { window.location.href = '../program-command.html'; }
+                }]
+            }
+        );
         return [];
     }
 
@@ -958,6 +995,9 @@ function applySelectedRecommendations() {
         }
     });
 
+    if (appliedCount > 0) {
+        markDirty();
+    }
     showToast(`Applied ${appliedCount} recommendations`);
 
     // Re-run analysis to update dashboard
@@ -1253,6 +1293,10 @@ async function handleGenerate() {
 
         // Auto-save placements after generation for future preservation
         updatePlacementsFromSchedule(previousYear);
+
+        // A freshly generated schedule lives only in memory until the user saves —
+        // mark dirty so the action bar tells them and beforeunload guards it.
+        markDirty();
 
         showToast(`Generated schedule for ${targetYear} based on ${previousYear} (${sourceSchedule.sourceLabel}) (${totalSections} total sections)`);
         updateScenarioAssignmentSummary();
@@ -2242,6 +2286,7 @@ function deleteCourse(courseCode, section, day, time, room) {
     const index = courses.findIndex(c => c.courseCode === courseCode && c.section === section);
     if (index > -1) {
         courses.splice(index, 1);
+        markDirty();
         showToast(`${courseCode}-${section} removed from schedule`);
         renderScheduleGrid();
         renderUnassignedList();
@@ -2322,6 +2367,8 @@ function handleDrop(e, toDay, toTime, toRoom) {
             if (!assignedCourses[toKey]) assignedCourses[toKey] = [];
             assignedCourses[toKey].push(movedCourse);
 
+            markDirty();
+
             // Re-render
             renderScheduleGrid();
             renderUnassignedList();
@@ -2336,6 +2383,7 @@ function handleDrop(e, toDay, toTime, toRoom) {
         }
     } catch (err) {
         console.error('Drop error:', err);
+        showToast('Drop failed — see console for details', 'error');
     }
 }
 
@@ -2548,12 +2596,24 @@ function saveDraft() {
         facultyBuildScenario: facultyBuildScenario
     };
 
-    localStorage.setItem('scheduleBuilderDraft', JSON.stringify(draft));
-    
+    try {
+        localStorage.setItem('scheduleBuilderDraft', JSON.stringify(draft));
+    } catch (error) {
+        console.error('Local draft save error:', error);
+        showToast('Could not save draft — browser storage may be full or disabled', 'error');
+        showErrorBanner('We could not save the local draft. Try freeing browser storage, or use "Save to Cloud" instead. Your edits are still in memory until you reload.', {
+            actions: [{ label: 'Dismiss', onClick: clearErrorBanner }]
+        });
+        return;
+    }
+
     // Also save placements for future use
     const targetYear = document.getElementById('academicYear')?.value || currentSchedule.year;
     updatePlacementsFromSchedule(targetYear);
-    
+
+    // The draft is now persisted in localStorage — for our purposes the in-memory
+    // state matches a saved snapshot. Cloud is a separate axis.
+    clearDirty();
     showToast('Draft saved successfully');
 }
 
@@ -2594,9 +2654,27 @@ function loadDraft() {
         renderFacultySummary();
         renderQuarterTabs();
 
+        // Loaded state matches what was last persisted — not dirty.
+        clearDirty();
         showToast('Draft loaded');
     } catch (error) {
         console.error('Error loading draft:', error);
+        showToast('Could not load your saved draft', 'error');
+        showErrorBanner(
+            'Your saved draft could not be loaded — it may be corrupt or from an older version. Your in-memory schedule has not been changed.',
+            {
+                actions: [
+                    {
+                        label: 'Discard draft',
+                        onClick: () => {
+                            try { localStorage.removeItem('scheduleBuilderDraft'); } catch (_) { /* noop */ }
+                            clearErrorBanner();
+                            showToast('Local draft discarded');
+                        }
+                    }
+                ]
+            }
+        );
     }
 }
 
@@ -2760,52 +2838,65 @@ async function saveToDatabase() {
         return;
     }
 
-    try {
-        showToast('Saving to database...');
-        const userAttribution = await resolveCurrentUserAttribution();
+    return withSaveButtonBusy('saveToCloudBtn', '☁️ Saving…', async () => {
+        try {
+            showToast('Saving to database…');
+            const userAttribution = await resolveCurrentUserAttribution();
 
-        // Initialize database service
-        await dbService.initialize();
+            // Initialize database service
+            await dbService.initialize();
 
-        const targetYear = document.getElementById('academicYear')?.value || currentSchedule.year;
+            const targetYear = document.getElementById('academicYear')?.value || currentSchedule.year;
 
-        // Get or create academic year
-        const yearRecord = await dbService.getOrCreateYear(targetYear);
-        if (!yearRecord) {
-            showToast('Failed to get academic year', 'error');
-            return;
+            // Get or create academic year
+            const yearRecord = await dbService.getOrCreateYear(targetYear);
+            if (!yearRecord) {
+                showToast('Failed to get academic year', 'error');
+                showErrorBanner(`Save failed for ${targetYear}: could not resolve the academic year record. Your edits are still in memory; retry, or contact an admin if it persists.`);
+                return;
+            }
+
+            const quarterSchedules = getAllQuarterSchedulesForSave();
+            const records = await buildYearScopedScheduleSyncRecords(quarterSchedules);
+            const recordsWithUserContext = records.map((record) => ({
+                ...record,
+                updated_by: userAttribution.id
+            }));
+            const syncResult = await dbService.syncScheduledCoursesForAcademicYear(yearRecord.id, recordsWithUserContext);
+
+            if (!syncResult) {
+                showToast('Error saving to database', 'error');
+                showErrorBanner(`Save failed for ${targetYear}: the database sync did not return a result. Your edits are still in memory; retry, or save a local draft to preserve them.`);
+                return;
+            }
+
+            const updatedCount = Number(syncResult.updated_count || 0);
+            const insertedCount = Number(syncResult.inserted_count || 0);
+            const deletedCount = Number(syncResult.deleted_count || 0);
+            const savedAt = new Date().toISOString();
+            writeSaveAttributionState({
+                year: targetYear,
+                userId: userAttribution.id,
+                userLabel: userAttribution.label,
+                savedAt
+            });
+            // clearDirty() first so the label renders the saved state, not the
+            // dirty state, when setSaveAttributionLabel inspects isDirty.
+            clearDirty();
+            setSaveAttributionLabel(userAttribution.label, savedAt);
+            clearErrorBanner();
+            showToast(`Saved ${targetYear}: ${updatedCount} updated, ${insertedCount} inserted, ${deletedCount} removed`);
+
+        } catch (error) {
+            console.error('Database save error:', error);
+            const friendly = buildDatabaseSaveErrorMessage(error);
+            showToast(friendly, 'error');
+            // Surface the same message persistently so it can't be missed in a
+            // 3-second toast window. Errors here often need user follow-up
+            // (auth, RLS, network).
+            showErrorBanner(friendly);
         }
-
-        const quarterSchedules = getAllQuarterSchedulesForSave();
-        const records = await buildYearScopedScheduleSyncRecords(quarterSchedules);
-        const recordsWithUserContext = records.map((record) => ({
-            ...record,
-            updated_by: userAttribution.id
-        }));
-        const syncResult = await dbService.syncScheduledCoursesForAcademicYear(yearRecord.id, recordsWithUserContext);
-
-        if (!syncResult) {
-            showToast('Error saving to database', 'error');
-            return;
-        }
-
-        const updatedCount = Number(syncResult.updated_count || 0);
-        const insertedCount = Number(syncResult.inserted_count || 0);
-        const deletedCount = Number(syncResult.deleted_count || 0);
-        const savedAt = new Date().toISOString();
-        writeSaveAttributionState({
-            year: targetYear,
-            userId: userAttribution.id,
-            userLabel: userAttribution.label,
-            savedAt
-        });
-        setSaveAttributionLabel(userAttribution.label, savedAt);
-        showToast(`Saved ${targetYear}: ${updatedCount} updated, ${insertedCount} inserted, ${deletedCount} removed`);
-
-    } catch (error) {
-        console.error('Database save error:', error);
-        showToast(buildDatabaseSaveErrorMessage(error), 'error');
-    }
+    });
 }
 
 /**
@@ -3064,6 +3155,133 @@ function exportToEditor() {
     setTimeout(() => {
         window.location.href = '../index.html?import=true';
     }, 500);
+}
+
+// ============================================
+// PHASE A — DATA SAFETY HELPERS
+// ============================================
+
+/**
+ * Mark the schedule as having unsaved changes. Updates the attribution label
+ * copy so the user can always see "Unsaved changes" in the action bar.
+ */
+function markDirty() {
+    if (isDirty) return;
+    isDirty = true;
+    refreshSaveAttributionForCurrentYear();
+}
+
+/**
+ * Clear the dirty flag after a successful save (cloud or local draft) or after
+ * loading a draft (loaded state matches the saved snapshot).
+ */
+function clearDirty() {
+    if (!isDirty) return;
+    isDirty = false;
+    refreshSaveAttributionForCurrentYear();
+}
+
+function refreshSaveAttributionForCurrentYear() {
+    const year = document.getElementById('academicYear')?.value;
+    if (year) {
+        refreshSaveAttributionLabelForYear(year);
+    } else {
+        setSaveAttributionLabel(null, null);
+    }
+}
+
+/**
+ * Show a persistent error banner above the action bar. Survives until the user
+ * dismisses it (or until clearErrorBanner is called). Used for recoverable but
+ * important failures that would otherwise be swallowed by a 3-second toast
+ * (e.g., corrupt draft on load, save errors).
+ */
+function showErrorBanner(message, { actions = [] } = {}) {
+    let banner = document.getElementById('builderRecoverableErrorBanner');
+    if (!banner) {
+        banner = document.createElement('div');
+        banner.id = 'builderRecoverableErrorBanner';
+        banner.className = 'builder-recoverable-error';
+        banner.setAttribute('role', 'alert');
+        banner.setAttribute('aria-live', 'assertive');
+        document.body.appendChild(banner);
+    }
+
+    // Clear and rebuild
+    while (banner.firstChild) banner.removeChild(banner.firstChild);
+
+    const text = document.createElement('div');
+    text.className = 'builder-recoverable-error__message';
+    text.textContent = message;
+    banner.appendChild(text);
+
+    const actionRow = document.createElement('div');
+    actionRow.className = 'builder-recoverable-error__actions';
+    actions.forEach(({ label, onClick }) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'builder-recoverable-error__btn';
+        btn.textContent = label;
+        btn.addEventListener('click', () => {
+            try { onClick && onClick(); } finally { /* keep banner unless cleared */ }
+        });
+        actionRow.appendChild(btn);
+    });
+    const dismiss = document.createElement('button');
+    dismiss.type = 'button';
+    dismiss.className = 'builder-recoverable-error__btn builder-recoverable-error__btn--dismiss';
+    dismiss.textContent = 'Dismiss';
+    dismiss.setAttribute('aria-label', 'Dismiss error');
+    dismiss.addEventListener('click', clearErrorBanner);
+    actionRow.appendChild(dismiss);
+    banner.appendChild(actionRow);
+
+    banner.classList.add('visible');
+}
+
+function clearErrorBanner() {
+    const banner = document.getElementById('builderRecoverableErrorBanner');
+    if (banner) banner.classList.remove('visible');
+}
+
+/**
+ * Wrap an async save action with button busy state: disables the trigger,
+ * swaps the label to a "saving" form, sets aria-busy, restores on resolve/reject.
+ * The caller still owns success/error toasts and clearDirty.
+ */
+async function withSaveButtonBusy(buttonId, busyLabel, action) {
+    const button = document.getElementById(buttonId);
+    if (!button) return action();
+
+    const originalLabel = button.innerHTML;
+    const wasDisabled = button.disabled;
+    button.disabled = true;
+    button.setAttribute('aria-busy', 'true');
+    button.innerHTML = busyLabel;
+
+    try {
+        return await action();
+    } finally {
+        button.disabled = wasDisabled;
+        button.removeAttribute('aria-busy');
+        button.innerHTML = originalLabel;
+    }
+}
+
+/**
+ * beforeunload guard — warn only when there are unsaved changes. The browser
+ * shows its generic confirm dialog; we just have to call preventDefault and
+ * set returnValue.
+ */
+function attachBeforeUnloadGuard() {
+    if (dirtyTrackingReady) return;
+    dirtyTrackingReady = true;
+    window.addEventListener('beforeunload', (event) => {
+        if (!isDirty) return;
+        event.preventDefault();
+        event.returnValue = '';
+        return '';
+    });
 }
 
 /**
@@ -3345,6 +3563,7 @@ function handleAddCourse(e) {
     // Add to assigned courses
     if (!assignedCourses[key]) assignedCourses[key] = [];
     assignedCourses[key].push(newCourse);
+    markDirty();
 
     // Close modal and refresh grid
     closeAddCourseModal();

--- a/pages/schedule-builder.js
+++ b/pages/schedule-builder.js
@@ -75,6 +75,13 @@ const SAVE_ATTRIBUTION_STORAGE_KEY = 'schedule_builder_last_save_attribution_v1'
 let isDirty = false;
 let dirtyTrackingReady = false;
 
+// Phase E — keyboard drag-and-drop state.
+// When a course is "picked up" via Enter/Space, this holds enough info to
+// commit a move on the next Enter/Space against a schedule cell, identical
+// to what HTML5 drag/drop puts in dataTransfer.
+let keyboardPickedCourse = null;
+// { courseCode, section, fromDay, fromTime, fromRoom, sourceElementId }
+
 const DEFAULT_FACULTY_BUILD_SCENARIO = {
     faculty: [
         { name: 'Travis Masingale', included: true, annualCredits: 31, inloadCredits: 5, desn499PerQuarter: 2 },
@@ -699,6 +706,9 @@ document.addEventListener('DOMContentLoaded', async function() {
         // Phase A — warn before unload if the user has unsaved edits.
         // Safe to attach unconditionally; the listener early-returns when not dirty.
         attachBeforeUnloadGuard();
+
+        // Phase E — global Escape cancels any keyboard pickup in progress.
+        attachKeyboardPickupCancelListener();
 
         const activeYear = document.getElementById('academicYear')?.value || '2026-27';
         refreshSaveAttributionLabelForYear(activeYear);
@@ -2184,6 +2194,16 @@ function createGridCell(day, timeKey, room, timeDisplay) {
         handleDrop(e, day, timeKey, room);
     });
 
+    // Phase E — keyboard drop. Cells only get tabindex when a course is picked
+    // (managed by setSchedulCellsTabbable). When focused with a pickup
+    // active, Enter/Space commits the drop here.
+    cell.addEventListener('keydown', (event) => {
+        if (!keyboardPickedCourse) return;
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        commitKeyboardDropToCell(day, timeKey, room);
+    });
+
     courses.forEach(course => {
         const block = createCourseBlock(course);
         cell.appendChild(block);
@@ -2228,6 +2248,13 @@ function createCourseBlock(course) {
     const block = document.createElement('div');
     block.className = `course-block priority-${course.priority}`;
     block.draggable = true;
+    block.tabIndex = 0;
+    block.setAttribute('role', 'button');
+    block.setAttribute(
+        'aria-label',
+        `${course.courseCode} section ${course.section}, ${course.courseTitle || 'untitled'}, taught by ${course.facultyName || 'TBD'}. ` +
+        `Press Enter or Space to pick up and move; press the delete button to remove.`
+    );
     block.dataset.courseCode = course.courseCode;
     block.dataset.section = course.section;
 
@@ -2242,9 +2269,11 @@ function createCourseBlock(course) {
 
     // Add delete button
     const deleteBtn = document.createElement('button');
+    deleteBtn.type = 'button';
     deleteBtn.className = 'course-delete-btn';
     deleteBtn.innerHTML = '×';
     deleteBtn.title = 'Remove course from schedule';
+    deleteBtn.setAttribute('aria-label', `Remove ${course.courseCode}-${course.section} from schedule`);
     deleteBtn.onclick = (e) => {
         e.stopPropagation();
         deleteCourse(course.courseCode, course.section, course.day, course.time, course.room);
@@ -2275,6 +2304,25 @@ function createCourseBlock(course) {
     // Click to show details
     block.onclick = () => showCourseDetails(course);
 
+    // Phase E — keyboard pickup. Enter/Space picks up (or drops if a target
+    // cell is focused). Esc handled by the global cancel listener.
+    block.addEventListener('keydown', (event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        // If the focus target is the delete button inside the card, let that
+        // button's own click semantics handle it — keydown on a <button>
+        // already fires click for Enter and Space.
+        if (event.target && event.target.classList.contains('course-delete-btn')) return;
+        event.preventDefault();
+        if (keyboardPickedCourse && keyboardPickedCourse.courseCode === course.courseCode && keyboardPickedCourse.section === course.section) {
+            cancelKeyboardPickup();
+            block.focus();
+        } else {
+            pickUpCourseForKeyboard(course, block);
+        }
+    });
+
+    // Make the delete button keyboard-discoverable (it's a real <button>, so
+    // it's already focusable — just give it an aria-label).
     return block;
 }
 
@@ -2404,8 +2452,11 @@ function renderUnassignedList() {
 
     let html = '';
     unassigned.forEach(course => {
+        const aria = `${course.courseCode} section ${course.section}, ${course.courseTitle || 'untitled'}. ` +
+                     `Currently unassigned. Press Enter or Space to pick up.`;
         html += `
             <div class="unassigned-item" draggable="true"
+                 role="button" tabindex="0" aria-label="${aria.replace(/"/g, '&quot;')}"
                  ondragstart="handleUnassignedDrag(event, '${course.courseCode}', '${course.section}')"
                  data-course="${course.courseCode}" data-section="${course.section}">
                 <div class="course-code">
@@ -2421,6 +2472,25 @@ function renderUnassignedList() {
     });
 
     container.innerHTML = html;
+
+    // Phase E — keyboard pickup on each unassigned item. innerHTML wipes out
+    // listeners, so we wire them after the render.
+    container.querySelectorAll('.unassigned-item').forEach((item) => {
+        const code = item.dataset.course;
+        const section = item.dataset.section;
+        const course = unassigned.find((c) => c.courseCode === code && c.section === section);
+        if (!course) return;
+        item.addEventListener('keydown', (event) => {
+            if (event.key !== 'Enter' && event.key !== ' ') return;
+            event.preventDefault();
+            if (keyboardPickedCourse && keyboardPickedCourse.courseCode === code && keyboardPickedCourse.section === section) {
+                cancelKeyboardPickup();
+                item.focus();
+            } else {
+                pickUpCourseForKeyboard(course, item);
+            }
+        });
+    });
 }
 
 /**
@@ -3300,6 +3370,181 @@ function attachBeforeUnloadGuard() {
         event.preventDefault();
         event.returnValue = '';
         return '';
+    });
+}
+
+// ============================================
+// PHASE E — KEYBOARD DRAG-AND-DROP
+// Lets keyboard / SR users complete the Edit Schedule Grid step without
+// mouse drag. Pattern: Enter/Space on a course "picks it up"; Tab cycles
+// through schedule cells; Enter/Space on a cell commits the move via the
+// same code path as handleDrop. Escape cancels.
+// ============================================
+
+function announceKbdMove(message) {
+    const node = document.getElementById('kbdPickupAnnouncer');
+    if (node) node.textContent = message;
+}
+
+function describeCellForAnnouncement(day, timeKey, room) {
+    const dayLabel = (day === 'MW') ? 'Monday/Wednesday' : (day === 'TR') ? 'Tuesday/Thursday' : day;
+    return `${dayLabel} ${timeKey} room ${room}`;
+}
+
+function setSchedulCellsTabbable(enabled) {
+    document.body.classList.toggle('kbd-pickup-active', enabled);
+    const cells = document.querySelectorAll('.schedule-cell');
+    cells.forEach((cell) => {
+        if (enabled) {
+            cell.setAttribute('tabindex', '0');
+            cell.setAttribute('role', 'button');
+            const day = cell.dataset.day;
+            const room = cell.dataset.room;
+            const time = cell.dataset.time;
+            cell.setAttribute('aria-label', `Drop here: ${describeCellForAnnouncement(day, time, room)}`);
+        } else {
+            cell.removeAttribute('tabindex');
+            cell.removeAttribute('role');
+            cell.removeAttribute('aria-label');
+        }
+    });
+}
+
+function pickUpCourseForKeyboard(course, sourceElement) {
+    // If something else is already picked, cancel it first.
+    if (keyboardPickedCourse) cancelKeyboardPickup({ silent: true });
+
+    keyboardPickedCourse = {
+        courseCode: course.courseCode,
+        section: course.section,
+        fromDay: course.day || null,
+        fromTime: course.time || null,
+        fromRoom: course.room || null,
+        sourceLabel: `${course.courseCode}-${course.section}`
+    };
+
+    if (sourceElement) sourceElement.classList.add('kbd-picked');
+    setSchedulCellsTabbable(true);
+
+    const fromText = course.day
+        ? `from ${describeCellForAnnouncement(course.day, course.time, course.room)}`
+        : 'from the unassigned list';
+    announceKbdMove(
+        `Picked up ${keyboardPickedCourse.sourceLabel} ${fromText}. ` +
+        `Tab to choose a destination cell, then press Enter or Space to drop. ` +
+        `Press Escape to cancel.`
+    );
+}
+
+function cancelKeyboardPickup({ silent = false } = {}) {
+    if (!keyboardPickedCourse) return;
+    const label = keyboardPickedCourse.sourceLabel;
+    keyboardPickedCourse = null;
+    setSchedulCellsTabbable(false);
+    document.querySelectorAll('.kbd-picked').forEach((el) => el.classList.remove('kbd-picked'));
+    if (!silent) announceKbdMove(`Cancelled. ${label} was not moved.`);
+}
+
+function commitKeyboardDropToCell(toDay, toTime, toRoom) {
+    if (!keyboardPickedCourse) return;
+    const picked = keyboardPickedCourse;
+    const fromKey = picked.fromDay
+        ? `${picked.fromDay}-${picked.fromTime}-${picked.fromRoom}`
+        : 'unassigned';
+    const toKey = `${toDay}-${toTime}-${toRoom}`;
+    if (fromKey === toKey) {
+        announceKbdMove('Same cell — no change.');
+        cancelKeyboardPickup({ silent: true });
+        return;
+    }
+
+    // Mirror the handleDrop move/swap logic so behavior matches mouse drag.
+    let movedCourse = null;
+    if (assignedCourses[fromKey]) {
+        const idx = assignedCourses[fromKey].findIndex(
+            (c) => c.courseCode === picked.courseCode && c.section === picked.section
+        );
+        if (idx > -1) movedCourse = assignedCourses[fromKey].splice(idx, 1)[0];
+    }
+    if (!movedCourse) {
+        announceKbdMove('Could not find the picked course — please try again.');
+        cancelKeyboardPickup({ silent: true });
+        return;
+    }
+
+    if (
+        movedCourse.facultyName &&
+        movedCourse.facultyName !== 'TBD' &&
+        hasFacultyTimeConflict(movedCourse.facultyName, toDay, toTime)
+    ) {
+        if (!assignedCourses[fromKey]) assignedCourses[fromKey] = [];
+        assignedCourses[fromKey].push(movedCourse);
+        showToast(`Cannot move: ${movedCourse.facultyName} is already teaching at that time`, 'warning');
+        announceKbdMove(`Move blocked: ${movedCourse.facultyName} has a conflict at ${describeCellForAnnouncement(toDay, toTime, toRoom)}.`);
+        cancelKeyboardPickup({ silent: true });
+        return;
+    }
+
+    let swappedCourse = null;
+    if (assignedCourses[toKey] && assignedCourses[toKey].length > 0) {
+        const targetIdx = assignedCourses[toKey].findIndex((c) => c.room === toRoom);
+        if (targetIdx > -1) {
+            swappedCourse = assignedCourses[toKey].splice(targetIdx, 1)[0];
+            if (fromKey !== 'unassigned' && picked.fromDay) {
+                swappedCourse.day = picked.fromDay;
+                swappedCourse.time = picked.fromTime;
+                swappedCourse.room = picked.fromRoom;
+                if (!assignedCourses[fromKey]) assignedCourses[fromKey] = [];
+                assignedCourses[fromKey].push(swappedCourse);
+            } else {
+                if (!assignedCourses['unassigned']) assignedCourses['unassigned'] = [];
+                swappedCourse.day = null;
+                swappedCourse.time = null;
+                swappedCourse.room = null;
+                assignedCourses['unassigned'].push(swappedCourse);
+            }
+        }
+    }
+
+    movedCourse.day = toDay;
+    movedCourse.time = toTime;
+    movedCourse.room = toRoom;
+    if (!assignedCourses[toKey]) assignedCourses[toKey] = [];
+    assignedCourses[toKey].push(movedCourse);
+
+    markDirty();
+
+    // Tear down pickup state BEFORE re-render so the new DOM is clean.
+    const sourceLabel = picked.sourceLabel;
+    keyboardPickedCourse = null;
+    setSchedulCellsTabbable(false);
+    document.querySelectorAll('.kbd-picked').forEach((el) => el.classList.remove('kbd-picked'));
+
+    renderScheduleGrid();
+    renderUnassignedList();
+    renderFacultySummary();
+
+    if (swappedCourse) {
+        const swappedLabel = `${swappedCourse.courseCode}-${swappedCourse.section}`;
+        showToast(`Swapped ${picked.courseCode} with ${swappedCourse.courseCode}`);
+        announceKbdMove(`${sourceLabel} dropped at ${describeCellForAnnouncement(toDay, toTime, toRoom)}, swapped with ${swappedLabel}.`);
+    } else {
+        showToast(`Moved ${picked.courseCode}-${picked.section} to ${toDay} ${toTime}`);
+        announceKbdMove(`${sourceLabel} dropped at ${describeCellForAnnouncement(toDay, toTime, toRoom)}.`);
+    }
+}
+
+/**
+ * Global Esc handler for cancelling a pickup. Installed once at DOMContentLoaded.
+ */
+function attachKeyboardPickupCancelListener() {
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && keyboardPickedCourse) {
+            // Don't fight modal Esc handlers — bail if a modal is open.
+            if (__modalControllers && __modalControllers.size > 0) return;
+            event.preventDefault();
+            cancelKeyboardPickup();
+        }
     });
 }
 

--- a/pages/schedule-builder.js
+++ b/pages/schedule-builder.js
@@ -3284,6 +3284,104 @@ function attachBeforeUnloadGuard() {
     });
 }
 
+// ============================================
+// PHASE B — MODAL CONTROLLER (focus trap, Esc, backdrop, focus return)
+// ============================================
+
+// Map of modalId -> { previousFocus, onKeydown, onOverlayClick } so we can
+// install per-modal listeners on mount and tear them down on unmount.
+const __modalControllers = new Map();
+
+function __getFocusableInside(modalEl) {
+    if (!modalEl) return [];
+    const selector = [
+        'a[href]', 'area[href]', 'button:not([disabled])',
+        'input:not([disabled]):not([type="hidden"])',
+        'select:not([disabled])', 'textarea:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])', '[contenteditable="true"]'
+    ].join(',');
+    return Array.from(modalEl.querySelectorAll(selector)).filter((el) => {
+        // Skip elements that aren't actually visible
+        return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+    });
+}
+
+function mountModal(modalId, closeFn) {
+    const overlay = document.getElementById(modalId);
+    if (!overlay) return;
+    const dialog = overlay.querySelector('.modal');
+    if (!dialog) return;
+
+    const previousFocus = document.activeElement;
+    overlay.classList.add('active');
+
+    // Move focus into the dialog — first focusable, else the dialog itself.
+    const focusables = __getFocusableInside(dialog);
+    const firstFocus = focusables[0] || dialog;
+    if (!firstFocus.hasAttribute('tabindex') && firstFocus === dialog) {
+        dialog.setAttribute('tabindex', '-1');
+    }
+    requestAnimationFrame(() => {
+        try { firstFocus.focus(); } catch (_) { /* noop */ }
+    });
+
+    const onKeydown = (event) => {
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            closeFn();
+            return;
+        }
+        if (event.key !== 'Tab') return;
+        const inDialog = __getFocusableInside(dialog);
+        if (inDialog.length === 0) {
+            event.preventDefault();
+            return;
+        }
+        const first = inDialog[0];
+        const last = inDialog[inDialog.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    };
+
+    const onOverlayClick = (event) => {
+        // Click on the dim backdrop (the overlay itself) closes — clicks on
+        // the dialog or its children don't bubble here when stopped, but
+        // explicitly check target.
+        if (event.target === overlay) {
+            closeFn();
+        }
+    };
+
+    document.addEventListener('keydown', onKeydown, true);
+    overlay.addEventListener('mousedown', onOverlayClick);
+
+    __modalControllers.set(modalId, { previousFocus, onKeydown, onOverlayClick });
+}
+
+function unmountModal(modalId) {
+    const overlay = document.getElementById(modalId);
+    if (overlay) overlay.classList.remove('active');
+
+    const controller = __modalControllers.get(modalId);
+    if (!controller) return;
+
+    document.removeEventListener('keydown', controller.onKeydown, true);
+    if (overlay) overlay.removeEventListener('mousedown', controller.onOverlayClick);
+
+    __modalControllers.delete(modalId);
+
+    // Restore focus to whatever the user was on before opening
+    const target = controller.previousFocus;
+    if (target && typeof target.focus === 'function') {
+        try { target.focus(); } catch (_) { /* noop */ }
+    }
+}
+
 /**
  * Show toast notification
  */
@@ -3308,15 +3406,15 @@ function showToast(message, type = 'success') {
 function openAddCourseModal() {
     populateCourseDropdown();
     populateFacultyDropdown();
-    document.getElementById('addCourseModal').classList.add('active');
     document.getElementById('addCourseSection').value = '001';
+    mountModal('addCourseModal', closeAddCourseModal);
 }
 
 /**
  * Close Add Course modal
  */
 function closeAddCourseModal() {
-    document.getElementById('addCourseModal').classList.remove('active');
+    unmountModal('addCourseModal');
     document.getElementById('addCourseForm').reset();
 }
 
@@ -3624,14 +3722,14 @@ async function openFacultyPreferencesModal() {
     document.getElementById('facultyPreferencesForm').reset();
     currentFacultyId = null;
 
-    modal.classList.add('active');
+    mountModal('facultyPreferencesModal', closeFacultyPreferencesModal);
 }
 
 /**
  * Close the Faculty Preferences modal
  */
 function closeFacultyPreferencesModal() {
-    document.getElementById('facultyPreferencesModal').classList.remove('active');
+    unmountModal('facultyPreferencesModal');
     currentFacultyId = null;
 }
 
@@ -3820,7 +3918,6 @@ function tryHydrateApiKeyFromInput() {
  * Open API Settings Modal
  */
 function openApiSettingsModal() {
-    const modal = document.getElementById('apiSettingsModal');
     const input = document.getElementById('apiKeyInput');
     const status = document.getElementById('apiKeyStatus');
     const typedKey = input?.value?.trim();
@@ -3839,14 +3936,14 @@ function openApiSettingsModal() {
         status.innerHTML = '<span class="status-disconnected">No API key configured</span>';
     }
 
-    modal.classList.add('active');
+    mountModal('apiSettingsModal', closeApiSettingsModal);
 }
 
 /**
  * Close API Settings Modal
  */
 function closeApiSettingsModal() {
-    document.getElementById('apiSettingsModal').classList.remove('active');
+    unmountModal('apiSettingsModal');
 }
 
 /**


### PR DESCRIPTION
Resolves 6 of 6 P0s + 13 of 20 P1s + 1 of 2 P2s from the 2026-05-26 UI/UX audit of the schedule builder. 5 commits, each phase reviewable separately.

## Stack

| # | Commit | Phase | Findings |
|---|---|---|---|
| 1 | `363cac8` | A — Data safety | P0 #2 dirty/beforeunload · #5 save-in-flight UI · #6 silent draft load fail |
| 2 | `c38f4cc` | B — Accessibility floor | P0 #3 modals not dialogs · #4 no live regions · P1 target sizes, focus mgmt, aria |
| 3 | `9238801` | C — Copy + reveal sequence | P1 stale "Generate Schedule" / "ChatGPT" / "Make Workloads" / "-- at --" copy; pre-data panels hidden until Load & Analyze |
| 4 | `fc22667` | D — Visual brand quick wins | P0 #13 wrong red (#b7142e → EWU #a10022) · #14 teal-on-red shadow · P1 focus rings, btn-small dedupe |
| 5 | `f06f3d5` | E — Drag-drop keyboard alternative | P0 #1 WCAG 2.1.1 + 2.5.7 — pickup/Tab/drop pattern with SR announcements |

## Verification

38 tracked Jest suites, 153 tests — all passing at every commit boundary.

Audit report and run artifact saved at `.context/compound-engineering/ce-review/schedule-builder-uiux-2026-05-26/findings.md` (untracked, in working tree).

## Manual verification (auth required, local-only since prod has no test data)

After login, `pages/schedule-builder.html` →

- Attribution label reads "Not yet saved to cloud…" (no more `-- at --`)
- Drag a course → amber "Unsaved changes" pill + tab-close prompt
- Publish to Cloud → button disables + "☁️ Saving…" + aria-busy
- Esc closes any modal; focus returns to the trigger; Tab traps inside
- Tab onto a course block → Enter picks up → Tab to a cell → Enter drops; Esc cancels
- Brand red focus rings everywhere (not amber/teal); EWU red on hover halos

## Out of scope (separate ticket)

The remaining 7 P1s and 1 P2 from the audit are all design-system token consolidation (cards, typography, spacing scale, full color-token system) — separate effort, not "audit fixes."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
