### PR TITLE
feat(program-command): compact app-header + hide stats bar until populated

### DIFF
--- a/js/components/app-header.js
+++ b/js/components/app-header.js
@@ -176,16 +176,26 @@ class AppHeader extends HTMLElement {
                     color: var(--f-ink, #0d1117);
                     border: 1px solid var(--f-hairline, #c9d1d9);
                     border-top: 4px solid var(--f-rule, #111827);
-                    padding: 20px 24px;
+                    padding: 12px 24px;
                 }
 
                 .header-shell {
                     display: flex;
                     justify-content: space-between;
-                    align-items: flex-start;
+                    align-items: center;
                     gap: 24px;
                     max-width: 1440px;
                     margin: 0 auto;
+                }
+
+                /* Eyebrow + title share one baseline row so the header reads
+                   as a single compact strip instead of a stacked block. */
+                .header-titles {
+                    display: flex;
+                    align-items: baseline;
+                    flex-wrap: wrap;
+                    gap: 6px 12px;
+                    min-width: 0;
                 }
 
                 .header-eyebrow {
@@ -199,7 +209,7 @@ class AppHeader extends HTMLElement {
                     font-weight: 850;
                     color: var(--f-soft, #6a737d);
                     text-transform: uppercase;
-                    margin-bottom: 8px;
+                    margin-bottom: 0;
                 }
 
                 .header-eyebrow::before {
@@ -212,19 +222,19 @@ class AppHeader extends HTMLElement {
                 }
 
                 h1 {
-                    font-size: clamp(1.55rem, 2.6vw, 2.1rem);
+                    font-size: clamp(1.25rem, 2vw, 1.6rem);
                     font-weight: 760;
-                    line-height: 1.08;
+                    line-height: 1.1;
                     margin: 0;
                     letter-spacing: 0;
                     color: var(--f-ink, #0d1117);
                 }
 
                 .subtitle {
-                    font-size: 14px;
+                    font-size: 13px;
                     color: var(--f-muted, #3f4652);
                     font-weight: 400;
-                    margin: 6px 0 0 0;
+                    margin: 2px 0 0 0;
                     max-width: 720px;
                 }
 
@@ -337,7 +347,7 @@ class AppHeader extends HTMLElement {
                     .header-shell {
                         flex-direction: column;
                         align-items: stretch;
-                        gap: 12px;
+                        gap: 10px;
                     }
                     .header-actions {
                         align-self: flex-start;
@@ -347,15 +357,17 @@ class AppHeader extends HTMLElement {
                         left: 0;
                         width: min(92vw, 320px);
                     }
-                    h1 { font-size: 1.55rem; }
+                    h1 { font-size: 1.3rem; }
                 }
             </style>
             
             <header>
                 <div class="header-shell">
                     <div class="header-copy">
-                        <div class="header-eyebrow">${eyebrow}</div>
-                        <h1>${titleText}</h1>
+                        <div class="header-titles">
+                            <div class="header-eyebrow">${eyebrow}</div>
+                            <h1>${titleText}</h1>
+                        </div>
                         <p class="subtitle">${subtitleText}</p>
                     </div>
                     <div class="header-actions">

--- a/program-command.html
+++ b/program-command.html
@@ -4539,6 +4539,14 @@
             border: 0;
         }
 
+        /* Keep the stats bar out of layout until it holds real numbers.
+           Scoped under body.foundry-production so it beats the display:grid
+           rule above; .is-pending is removed by updateStats() on first run. */
+        body.foundry-production .stats-bar.is-pending,
+        .stats-bar.is-pending {
+            display: none;
+        }
+
         body.foundry-production .stat-item {
             --stat-signal: var(--f-rule);
             display: grid;
@@ -5400,21 +5408,23 @@
             </div>
         </div>
 
-        <div class="stats-bar">
+        <!-- Hidden until updateStats() runs with real loaded data so we never
+             flash placeholder/stale numbers before the schedule loads. -->
+        <div class="stats-bar is-pending" id="statsBar">
             <div class="stat-item critical">
-                <span class="stat-number" id="criticalConflicts">3</span>
+                <span class="stat-number" id="criticalConflicts">—</span>
                 <span class="stat-label">Critical</span>
             </div>
             <div class="stat-item warning">
-                <span class="stat-number" id="totalConflicts">7</span>
+                <span class="stat-number" id="totalConflicts">—</span>
                 <span class="stat-label">Conflicts</span>
             </div>
             <div class="stat-item info">
-                <span class="stat-number" id="totalCourses">15</span>
+                <span class="stat-number" id="totalCourses">—</span>
                 <span class="stat-label">Courses</span>
             </div>
             <div class="stat-item success">
-                <span class="stat-number" id="utilizationRate">78%</span>
+                <span class="stat-number" id="utilizationRate">—</span>
                 <span class="stat-label">Utilization</span>
             </div>
         </div>
@@ -9157,6 +9167,12 @@
             document.getElementById('totalConflicts').textContent = conflicts.length;
             document.getElementById('totalCourses').textContent = totalCourses;
             document.getElementById('utilizationRate').textContent = utilizationRate + '%';
+
+            // Real numbers are in place — reveal the stats bar (no-op after first run).
+            const statsBar = document.getElementById('statsBar');
+            if (statsBar) {
+                statsBar.classList.remove('is-pending');
+            }
 
             const utilizationEl = document.getElementById('utilizationRate');
             if (utilizationEl) {


### PR DESCRIPTION
Two pre-data UX fixes flagged in the 2026-05-27 session handoff (loose UI/UX threads).

## What changed

**Compact `app-header`** (`js/components/app-header.js`)
- The header was a ~200px stacked block (eyebrow → title → subtitle). It now reads as a compact strip: eyebrow and title share one baseline row, vertical padding drops from 20px → 12px, and the title scales down (`clamp(1.25rem, 2vw, 1.6rem)`).
- Settings already lives in the header strip, so there was no floating Settings card left to relocate.

**Hide stats bar until populated** (`program-command.html`)
- `Critical / Conflicts / Courses / Utilization` shipped with hard-coded placeholder numbers (`3 / 7 / 15 / 78%`) that flashed before the schedule loaded.
- The bar now carries `is-pending` and is `display:none` until `updateStats()` writes real numbers, then reveals itself. Every render path goes through `updateStats()`, so the reveal is reliable. Placeholders replaced with em dashes as a defensive fallback. Same hide-until-populated pattern used in the schedule-builder Phase C work.

**Housekeeping**
- Cleared a stray `skip-worktree` flag on `program-command.html` that was silently dropping edits to the file. Verified there was no local-only content behind the flag (working tree matched HEAD before these edits).

## Verification
- `npm test`: all committed suites pass (1148 tests). The 16 failing suites are all pre-existing **untracked** "aspirational" test files from the working tree, unrelated to this change and not part of the committed suite.
- Page loads (HTTP 200); changes are CSS-only (header) + a class toggle (stats), no `!important` conflicts on `.stats-bar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)