### PR TITLE
chore: ignore agent tooling artifacts + document two-model stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ dist/
 output/
 .playwright-cli/
 error_log.txt
+
+# Agent tooling & local scratch (never commit)
+.codex/
+.context/
+.cursor/
+.playwright-mcp/
+header-check.png
+TRAVIS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Two-Model Stack — Division of Labor
+
+This project uses a two-model coding stack:
+
+- **Claude Code (you)** — architecture, design decisions, codebase reading, API surface design, naming, complex reasoning, visual polish, and anything where judgment > throughput.
+- **Codex / GPT-5.5** — implementation sprints, multi-file refactors, test generation, debugging passes, and long parallel jobs.
+
+**When Claude Code should hand off to Codex:**
+- Writing boilerplate CRUD endpoints
+- Scaffolding test files
+- Mechanical refactors across many files
+- Long running tasks that can run in parallel while Claude designs the next slice
+
+**Token discipline:** Do not re-derive project conventions each session. They are captured here and in the orientation docs. Read once, act.
+
 ## Cold start
 
 Returning cold, or arriving for the first time? Read the reorientation docs in order before touching anything:


### PR DESCRIPTION
## Summary

Two small, unrelated-to-feature housekeeping changes that were sitting in the working tree:

- **`.gitignore`** — stop tracking local agent tooling and scratch files (`.codex/`, `.context/`, `.cursor/`, `.playwright-mcp/`, `header-check.png`, `TRAVIS.md`). These are per-machine artifacts that should never land in the repo.
- **`CLAUDE.md`** — add the "Two-Model Stack — Division of Labor" section documenting the Claude Code / Codex split already in use.

No code or behavior changes; safe to merge independently of any feature branch.

---

[![Compound Engineering v2.60.0](https://img.shields.io/badge/Compound_Engineering-v2.60.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.8 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)