### PR TITLE
[WIP / do-not-merge] Park unfinished Codex production-readiness work

### DIFF
--- a/docs/plans/2026-05-12-001-refactor-public-schedule-hardening-plan.md
+++ b/docs/plans/2026-05-12-001-refactor-public-schedule-hardening-plan.md
@@ -1,0 +1,450 @@
+---
+title: "refactor: harden public schedule view and centralize canonical data sources"
+type: refactor
+status: active
+date: 2026-05-12
+origin: ce-review of branch codex/internal-schedule-match-public-view (2026-05-12)
+---
+
+# Harden Public Schedule View and Centralize Canonical Data Sources
+
+## Overview
+
+This plan resolves the P0–P2 findings from the 2026-05-12 ce-review of `codex/internal-schedule-match-public-view`. It addresses the user's three stated goals: (1) close the security gap introduced by the new Supabase env-switching layer, (2) make production and dev look/feel hold up over time by extracting shared Foundry tokens, and (3) replace hard-coded constants in `pages/public-schedule.js` with reads from the existing canonical data sources (`data/course-catalog.json`, `scripts/faculty-mapping.json`, `data/room-constraints.json`).
+
+The review proved drift is already happening — `DESN 215` is `'Indesign'` in the JS overrides and `'InDesign'` in the SQL sync. This plan removes the drift surface.
+
+## Problem Frame
+
+- The PR introduces a public read-only schedule page and routes its data to Supabase production, but does so by duplicating canonical data into a 800-line IIFE module (`pages/public-schedule.js`). Course titles, faculty roster + colors, room metadata, and the list of public academic years all live as frozen constants in that file.
+- The same PR widens the Supabase config layer to support env switching, but the new query-param and localStorage overrides apply on production hosts with no domain allowlist — enabling a client-redirect attack via a phishing URL.
+- The faculty canonical-name resolver uses bidirectional substring matching that misroutes any instructor whose name contains an alias key as a substring (`Millstone` → S.Mills).
+- The editor schedule was reskinned to match the public view by inlining ~148 lines of `.foundry-production` CSS into `index.html`; the public view ships the same tokens via `css/public-schedule.css`. Two copies will drift.
+
+The user asked the review to focus on "look and feel of production synced" and "real data, not hard-coded value." Both are surface symptoms of the same root cause: shared concerns implemented twice rather than once.
+
+## Requirements Trace
+
+- **R1.** Eliminate the open-redirect / client-hijack vector in `js/supabase-config.js` so URL query params and localStorage cannot retarget a deployed page's Supabase client. *(ce-review P0 #1)*
+- **R2.** Make `public-schedule.html` deterministically use the production Supabase project regardless of prior localStorage state. *(P1 #4)*
+- **R3.** Align Supabase row-level access with `docs/auth-contract.md` so the public-schedule RPC is the *only* anon read path — anon SELECT on `scheduled_courses` and `faculty` must not return more than the RPC contract intends. *(P1 #2)*
+- **R4.** Replace bidirectional substring faculty matching with deterministic exact/word-boundary matching grounded in `scripts/faculty-mapping.json`. *(P1 #3)*
+- **R5.** Read course titles, faculty roster/colors, room list, and the public-years list from the existing canonical files (or a single derived module), not from frozen constants in `pages/public-schedule.js`. Fix the existing `DESN 215` drift as part of the migration. *(P1 #5, #6, #7)*
+- **R6.** Ensure the public-schedule page can never call into a null Supabase client due to DOMContentLoaded handler ordering. *(P1 #8)*
+- **R7.** Extract Foundry design tokens to a single shared CSS file consumed by both `index.html` and `public-schedule.html`. *(P2 #9)*
+- **R8.** Add timeouts and a real failure-vs-empty distinction to the public schedule's data path so a slow Supabase no longer hangs the page indefinitely. *(P2 #10, #16)*
+- **R9.** Add validation tests that catch the failure modes the current suite misses: drift between the JS catalog and the SQL canonical, the faculty substring false-match, the empty-quarter render path, and the `?supabaseUrl=` override on production hosts. *(testing gaps consolidated across reviewers)*
+
+## Scope Boundaries
+
+**In scope**
+- Files touched on `codex/internal-schedule-match-public-view` and the canonical data sources they should consume
+- Supabase env-switching surface in `js/supabase-config.js`
+- RLS policy review for `scheduled_courses` and `faculty` (read-only audit + tightening migration)
+- Shared CSS extraction limited to the Foundry tokens already inlined in this branch
+
+**Out of scope**
+- Broader cleanup of the 35+ stale `codex/*` branches in the GitHub remote (user mentioned this; tracked separately — see Documentation/Operational Notes)
+- Schedule-grid renderer extraction into a shared module (review P2 #15). This is the right long-term move but is bigger than this plan; deferred to a follow-up.
+- Rotating the production anon key. The review flagged it (P2 #17); a rotation procedure is documented separately, not enacted here.
+- Untracked test files in the worktree — `tests/audit-runtime-dependencies.test.js` and the other un-staged files listed in `git status` — are separate audit/exploratory work and not gated by this plan. They may be committed independently or cleaned up per the branch-hygiene task in Operational Notes.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `pages/public-schedule.js:17-140` — frozen-constant blocks (`DEFAULTS`, `PUBLIC_YEARS`, `ROOM_ORDER`, `ROOM_LABELS`, `COURSE_TITLE_OVERRIDES`, `FACULTY_COLORS`, `FALLBACK_FACULTY_COLORS`, `FACULTY_ALIASES`). These are the targets to remove.
+- `pages/public-schedule.js:678-702` (`loadCourseCatalog`) — already loads `data/course-catalog.json`; the override map shadows it. Pattern to keep, scope to expand.
+- `js/supabase-config.js:38-208` — env-resolution helpers. `isPublicSchedulePage()` and `isLocalSupabaseHost()` already exist (lines 159, 161); they're just consulted in the wrong order. Pattern to keep, ordering to fix.
+- `js/faculty-manager.js:19` — existing `FACULTY_COLORS` IIFE constant. The editor's source of truth today. Candidate for promotion to a shared module that both the editor and the public view consume.
+- `scripts/faculty-mapping.json` — canonical `nameNormalization` map. Does not currently include colors; will need a small additive change or a sibling file.
+- `data/room-constraints.json` — canonical room list with `excludeFromGrid: true` already flagging room 207. This is the right room source.
+- `scripts/supabase-public-schedule-read.sql:34` — `v_allowed_years` array, duplicating `PUBLIC_YEARS`. Either derive years from the database or accept SQL as the single source and have JS read them.
+- `index.html` — ~148 lines of `.foundry-production` CSS added in this PR, duplicating tokens in `css/public-schedule.css`. Extract target.
+- IIFE pattern (CLAUDE.md): all `js/` shared modules use IIFE singletons; any new shared module created by this plan must follow that pattern.
+
+### Institutional Learnings
+
+- `docs/plans/2026-04-30-001-feat-public-schedule-view-plan.md` — the originating plan stated the public schedule must read via the `get_public_schedule` RPC and must not grant anonymous table reads. The current implementation honors the page's call shape but the underlying `Public read` RLS policies on `scheduled_courses` and `faculty` undermine the contract.
+- `docs/auth-contract.md` — "Public access is limited to the read-only `public.get_public_schedule` RPC and must not grant anonymous table reads." R3 enforces this.
+- `docs/public-schedule-release-checklist.md` — already lists "Confirm RPC exists" and validation queries; this plan should add an RLS verification step there.
+
+### External References
+
+- None warranted. The codebase has established patterns for all the work in this plan (IIFE modules, JSON-loaded canonical data, Jest tests against the data files). External research would add no value.
+
+## Key Technical Decisions
+
+- **Decision: Gate Supabase env/URL/anonKey overrides to local hosts only.** The current implementation honors `?supabaseUrl=`, `?supabaseAnonKey=`, `?supabaseEnv=`, and matching localStorage keys on any host. We will gate all three override sources (query param, localStorage, `window.PROGRAM_COMMAND_SUPABASE_CONFIG`) behind `isLocalSupabaseHost(hostname)`. *Rationale:* The override mechanism exists for local development; honoring it on production hosts is what creates the client-hijack vector. A deploy-time override, if ever needed in the future, can be injected server-side rather than via URL params.
+- **Decision: `isPublicSchedulePage()` wins over storage/query overrides.** Even with overrides gated to local hosts, a developer can run `public-schedule.html` on `localhost` and we still want it to use production. `resolveSupabaseEnvironmentConfig()` will short-circuit to `production` when `isPublicSchedulePage()` is true, before reading any override source. *Rationale:* The public schedule is a read-only production view by definition; "I want to test the public view against dev data" is a corner case that warrants an explicit query param (e.g., `?supabaseEnv=develop`) rather than a silent localStorage carryover.
+- **Decision: Promote `FACULTY_COLORS` to a shared IIFE module `js/faculty-display.js`.** Both `js/faculty-manager.js` and `pages/public-schedule.js` will consume it. Faculty *display* colors stay in JS (the canonical mapping doesn't currently carry color, and adding a `colors` block to `scripts/faculty-mapping.json` mixes a data file with a presentation concern). The *name normalization* logic moves to consume `scripts/faculty-mapping.json` directly. *Rationale:* Keeps the IIFE-singleton convention from CLAUDE.md, gives both pages a single source for color, and lets the JSON file stay focused on identity/normalization.
+- **Decision: Exact + word-boundary matching for faculty names; no substring fallback.** `getCanonicalFacultyName()` will: (1) try exact match against the canonical mapping; (2) try word-boundary match (e.g., `/\bMills\b/i`); (3) return the original name with `faculty-unknown` styling. No bidirectional `includes()`. *Rationale:* Eliminates the entire class of false matches the review identified. The fallback color path already exists for unknowns and is the correct landing zone.
+- **Decision: Course titles read from `data/course-catalog.json`; `COURSE_TITLE_OVERRIDES` removed entirely.** The catalog is already loaded; the override map only existed to paper over historical drift. Any genuinely-different public-display title can be added to the catalog itself or expressed as a field on the catalog row (e.g., `publicTitle`). *Rationale:* One source of truth. The `DESN 215 'Indesign' vs 'InDesign'` drift this PR shipped is exactly what removing the override prevents.
+- **Decision: `PUBLIC_YEARS` derived at runtime from `get_public_schedule` distinct years, with a fallback constant only for offline/degraded operation.** The RPC will be extended (or a new lightweight RPC added) to return the distinct academic years the public schedule covers. The `v_allowed_years` allowlist stays in SQL as the authority; JS reflects, not duplicates. *Rationale:* Removes the two-place hardcode and makes the year list self-updating as new years are added to the SQL allowlist.
+- **Decision: `ROOM_ORDER` / `ROOM_LABELS` read from `data/room-constraints.json`, filtering by `excludeFromGrid !== true`.** The catalog already has the canonical list, capacity, type, and exclusion flag. *Rationale:* Removes the silent-drop bug where a course scheduled in an unknown room disappears from the public view.
+- **Decision: Foundry tokens extracted to `css/foundry-theme.css`, loaded by both pages.** No JS-level theme machinery — just CSS custom properties under a single selector. *Rationale:* The user's "look/feel synced" ask is structural, not visual. The current parity holds only until someone edits one copy.
+- **Decision: Tighten RLS as a separate migration, not by editing the existing schema file.** Add `scripts/supabase-restrict-public-table-reads.sql` that revokes `anon` SELECT on the relevant tables and re-grants only what the RPC needs via `SECURITY DEFINER`. Keep the migration idempotent. *Rationale:* Production already runs the broad policy; a forward migration is auditable, reviewable, and rollback-able. Editing schema.sql in place loses the change history.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should faculty colors live in the JSON mapping or a JS module?** Resolved: shared JS module (`js/faculty-display.js`). Keeps the mapping file focused on identity normalization and follows the IIFE convention.
+- **Should we keep the `?supabaseEnv=develop` override on `public-schedule.html`?** Resolved: yes for local hosts only. Useful for local QA of the public view against dev data; not honored on production hosts.
+- **Should `PUBLIC_YEARS` be derived from data or kept as a small JSON file?** Resolved: derived from a Supabase RPC at load time, with a hardcoded fallback only if the RPC fails. Source of truth stays in SQL (`v_allowed_years`).
+
+### Deferred to Implementation
+
+- **Exact RPC name for distinct public years.** Will be either an extension of `get_public_schedule` or a new `get_public_schedule_years` function. Implementer picks based on whether the existing RPC can cheaply return a distinct-year metadata column.
+- **Whether `js/faculty-display.js` exposes a class or pure functions.** Both fit the IIFE pattern; pick at write time based on whether internal mutable state is needed (likely not).
+- **Whether room labels need a `publicLabel` field on `data/room-constraints.json` rows.** The current overrides relabel `206`→`UX Lab`, `CEB 102`→`Design Studio`, etc. The `name` field already carries `"206 UX Lab"` — implementer decides whether to parse or to add a sibling field.
+- **Whether `js/supabase-config.js` is rewritten or trimmed in place.** Review found 274 lines for a 2-environment switcher (P2 #14). The simplification is genuinely useful but is decoupled from R1–R2; defer the file-shape decision to implementation, after R1 and R2 are in.
+
+## Implementation Units
+
+- [ ] **Unit 1: Gate Supabase override sources to local hosts and make public-schedule force production**
+
+**Goal:** Close the open-redirect vector (R1) and guarantee `public-schedule.html` always uses production (R2).
+
+**Requirements:** R1, R2
+
+**Dependencies:** None — this is the highest-priority unit and lands first.
+
+**Files:**
+- Modify: `js/supabase-config.js` (rework `resolveSupabaseEnvironmentConfig`, `readSupabaseOverride`, `getRequestedSupabaseEnvironmentName`)
+- Modify: `tests/supabase-config.environments.test.js`
+
+**Approach:**
+- In `resolveSupabaseEnvironmentConfig()`, short-circuit to the `production` config when `isPublicSchedulePage()` returns true, before any override lookups.
+- Wrap `readSupabaseSearchParam`, `readSupabaseStorageValue`, and `readWindowSupabaseOverride` (only when consulted for environment/url/anonKey overrides) behind `isLocalSupabaseHost(hostname)`. Do not gate storage reads that are unrelated to env switching.
+- Preserve the existing `prod`/`dev`/`development` shortcuts only if they survive Unit 6; otherwise remove with Unit 6.
+
+**Patterns to follow:**
+- `isPublicSchedulePage()` and `isLocalSupabaseHost()` already exist in the same file — extend their use rather than re-implementing.
+- Keep the file's IIFE-friendly module shape (no ES `import`/`export` for runtime code).
+
+**Test scenarios:**
+- *Happy path:* On `localhost` editor, `?supabaseEnv=develop` is honored.
+- *Happy path:* On any `*.local` editor host, localStorage `programCommand.supabase.environment=develop` is honored.
+- *Edge case:* On `localhost` with `public-schedule.html` in the path, the resolver returns `production` even when localStorage says `develop` and the URL has `?supabaseEnv=develop`.
+- *Error path:* On a deployed (non-local) host, `?supabaseUrl=https://attacker.supabase.co&supabaseAnonKey=...` is ignored and the production URL/key are used. Assert the configured client URL is the production project ref.
+- *Error path:* On a deployed host, localStorage `programCommand.supabase.develop.anonKey` is ignored.
+- *Integration:* `public-schedule.html` served from `127.0.0.1:8080` with localStorage env=`develop` still issues its RPC against the production project ref.
+- *Error path:* On a deployed (non-local) host, `window.PROGRAM_COMMAND_SUPABASE_CONFIG.production.url` set to `https://attacker.supabase.co` is ignored and the production project ref is used. Same for `.develop.anonKey`.
+
+**Verification:**
+- All new and existing assertions in `tests/supabase-config.environments.test.js` pass.
+- Manual: open `https://<prod-host>/public-schedule.html?supabaseEnv=develop&supabaseUrl=https://attacker.supabase.co` and confirm via DevTools that `window.SUPABASE_CONFIG.projectRef === 'ohnrhjxcjkrdtudpzjgn'`.
+
+---
+
+- [ ] **Unit 2: Restrict anon table reads to align with the auth contract**
+
+**Goal:** Make the public-schedule RPC the only anon read path so `docs/auth-contract.md` holds (R3).
+
+**Requirements:** R3
+
+**Dependencies:** None — independent of Unit 1; can land in parallel.
+
+**Files:**
+- Create: `scripts/supabase-restrict-public-table-reads.sql`
+- Create: `scripts/supabase-restrict-public-table-reads-rollback.sql`
+- Modify: `docs/public-schedule-release-checklist.md` (add verification step)
+- Test: `tests/supabase-restrict-public-table-reads.test.js`
+
+**Approach:**
+- The new migration drops or replaces the existing `"Public read"` policy on `scheduled_courses` and `faculty` (and any other table the audit surfaces) with policies that deny anon SELECT (`FOR SELECT TO anon USING (false)`) or revoke the privilege entirely.
+- Verify `EXECUTE` on `public.get_public_schedule` to `anon` remains intact; it's `SECURITY DEFINER` and runs with the owner's privileges, so the function still works.
+- Companion rollback script restores the prior `"Public read"` policy verbatim so an emergency revert is one command.
+- Migration is wrapped in `BEGIN; ... COMMIT;` with `DROP POLICY IF EXISTS` for idempotency.
+- Update the release checklist with a SQL verification query that confirms an anon JWT cannot SELECT from `scheduled_courses` directly.
+
+**Patterns to follow:**
+- `scripts/supabase-public-schedule-read.sql` (style, `BEGIN`/`COMMIT`, header comments).
+- Existing RLS policies in `scripts/supabase-schema.sql`.
+
+**Test scenarios:**
+- *Happy path:* The migration file contains `DROP POLICY IF EXISTS "Public read"` for each affected table, and re-creates a restrictive policy or revokes `SELECT FROM anon`.
+- *Happy path:* The migration grants nothing additional to `anon` beyond `EXECUTE` on `public.get_public_schedule`.
+- *Edge case:* Rollback script restores the same policy names so re-applying the forward migration is a no-op idempotency check.
+- *Integration:* Manual verification step in `docs/public-schedule-release-checklist.md` runs `SELECT count(*) FROM scheduled_courses` under an anon JWT and expects either an error or zero rows.
+
+**Verification:**
+- Static SQL contract test passes.
+- Manual: against a staging Supabase, an anon client errors on direct `from('scheduled_courses').select('*')` while `rpc('get_public_schedule', ...)` continues to return rows.
+
+---
+
+- [ ] **Unit 3: Replace bidirectional substring matching with deterministic faculty name resolution**
+
+**Goal:** Eliminate the `Millstone → S.Mills` class of false matches (R4).
+
+**Requirements:** R4
+
+**Dependencies:** Unit 4. Unit 3 consumes `FacultyDisplay.getCanonicalFacultyName()` from Unit 4's shared module. Order: Unit 4 → Unit 3.
+
+**Files:**
+- Modify: `pages/public-schedule.js` (replace `getCanonicalFacultyName`, drop `FACULTY_ALIASES`, drop `normalizeFacultyKey` if unused after the change)
+- Modify: `tests/public-schedule.test.js`
+
+**Approach:**
+- `getCanonicalFacultyName(raw)` becomes: (1) trim/normalize whitespace; (2) exact match against the canonical mapping loaded from `scripts/faculty-mapping.json` via Unit 4's shared module; (3) word-boundary match against canonical last names; (4) return the trimmed original with the unknown styling.
+- Remove `FACULTY_ALIASES` entirely.
+- Keep `getFallbackFacultyColor` for the unknown case.
+
+**Patterns to follow:**
+- The existing `getFacultyInfo()` shape (returns `{className, color, name}`) is the consumer contract; preserve it.
+
+**Test scenarios:**
+- *Happy path:* `"T. Masingale"` and `"Travis Masingale"` both resolve to `T.Masingale` with the canonical color.
+- *Edge case:* `"Dr. K. Millstone"` resolves to itself (unknown faculty) with the `faculty-unknown` styling and a fallback color — *not* S.Mills.
+- *Edge case:* `"Smith Mills"` resolves to itself (or to S.Mills only via word-boundary on the second token — explicit assertion either way so the chosen rule is clear).
+- *Edge case:* `"lybbertson"` resolves to unknown, not M.Lybbert.
+- *Edge case:* Empty string and `null` resolve to `TBD` (existing behavior preserved).
+- *Integration:* Rendering a schedule containing `"Dr. Millstone"` in the RPC payload paints a faculty-unknown block in the grid; the faculty legend does not list S.Mills.
+
+**Verification:**
+- All new and existing `tests/public-schedule.test.js` assertions pass.
+- Manual: load `public-schedule.html` against a fixture with an unknown instructor; the legend shows them under the generated/unknown bucket.
+
+---
+
+- [ ] **Unit 4: Extract shared faculty display module and load name normalization from JSON**
+
+**Goal:** Single source of faculty colors + canonical names across editor and public view (part of R5, and the canonical-mapping-load portion of R4).
+
+**Requirements:** R5, R4 (canonical mapping load — Unit 3 implements the matching logic that consumes this mapping)
+
+**Dependencies:** Should land before Unit 3; Unit 3 consumes it.
+
+**Files:**
+- Create: `js/faculty-display.js` (IIFE singleton exposing `getFacultyInfo`, `getCanonicalFacultyName`, `getKnownFaculty`)
+- Modify: `js/faculty-manager.js` (delegate to `FacultyDisplay` instead of holding its own `FACULTY_COLORS`)
+- Modify: `pages/public-schedule.js` (drop `FACULTY_COLORS`/`FALLBACK_FACULTY_COLORS`/`FACULTY_ALIASES`; consume `FacultyDisplay`)
+- Modify: `index.html` and `public-schedule.html` (load `js/faculty-display.js` before `js/faculty-manager.js` and before `pages/public-schedule.js`)
+- Test: `tests/faculty-display.test.js`
+
+**Approach:**
+- New IIFE module owns the color map for known faculty and the fallback palette.
+- The module fetches `scripts/faculty-mapping.json` on first call and caches the result (mirror the `loadCourseCatalog` memoization pattern in `pages/public-schedule.js:678-702`). The cache is module-singleton, session-wide: both `index.html` and `public-schedule.html` load the same `js/faculty-display.js`, so the JSON is fetched once per page load and re-used across both pages within a session.
+- `js/faculty-manager.js`'s `FACULTY_COLORS` constant is removed; its `getColorForFaculty()` (or equivalent) delegates to `FacultyDisplay.getFacultyInfo()`.
+- The shared module exposes a synchronous color lookup (using the in-memory cache) and an async `ready()` for callers that need to await initial JSON load.
+
+**Patterns to follow:**
+- `loadCourseCatalog` memoization in `pages/public-schedule.js`.
+- IIFE singleton shape from any module in `js/` (e.g., `js/schedule-manager.js`).
+
+**Test scenarios:**
+- *Happy path:* `FacultyDisplay.getFacultyInfo('T.Masingale')` returns the canonical color and class.
+- *Happy path:* `FacultyDisplay.getFacultyInfo('Travis Masingale')` (the form in `scripts/faculty-mapping.json`) resolves to the same canonical entry as `'T.Masingale'`.
+- *Edge case:* An instructor name not in the mapping returns `faculty-unknown` styling and a deterministic fallback color (same input → same color across calls).
+- *Edge case:* Calling before `ready()` resolves returns the unknown styling but does not throw.
+- *Integration:* `js/faculty-manager.js`'s consumer methods produce the same display output before and after the refactor for every faculty member in `scripts/faculty-mapping.json`.
+
+**Verification:**
+- `tests/faculty-display.test.js` passes.
+- Editor schedule (`index.html`) renders identical faculty colors to a pre-refactor screenshot for every known instructor.
+
+---
+
+- [ ] **Unit 5: Read course titles from the canonical catalog and fix DESN 215 casing**
+
+**Goal:** Remove `COURSE_TITLE_OVERRIDES`; load all course titles from `data/course-catalog.json`; correct the existing drift (part of R5).
+
+**Requirements:** R5
+
+**Dependencies:** Independent of Units 1–4; can land in parallel after Unit 4 to keep PRs reviewable.
+
+**Files:**
+- Modify: `pages/public-schedule.js` (drop `COURSE_TITLE_OVERRIDES`; have `getCanonicalCourseTitleByCode` consult only the loaded catalog)
+- Modify: `data/course-catalog.json` (verify `DESN 215` title is `"InDesign"`; correct if not)
+- Modify: `scripts/supabase-sync-course-catalog.sql` (verify `DESN 215` row; correct if needed so SQL and JSON agree)
+- Test: `tests/public-schedule.test.js` (drop assertions that depend on `COURSE_TITLE_OVERRIDES`; add catalog-driven assertions)
+- Test: `tests/supabase-course-catalog-sync.test.js` (loosen brittle exact-text assertions per review P3 #21; assert structural correctness instead)
+
+**Approach:**
+- `getCanonicalCourseTitleByCode(code, fallback, catalogByCode)` becomes a two-step lookup: `catalogByCode[code]?.title || fallback`. Remove the override block entirely. *Scope note:* RPC-row shape validation and unicode-dash normalization are Unit 9's responsibility; Unit 5 handles only the title-resolution path.
+- Spot-check every course currently in `COURSE_TITLE_OVERRIDES` against `data/course-catalog.json`; for any title that differs, the catalog wins and the migration corrects the catalog (with a brief note in PR description) only after confirming the catalog form is the desired public-display form. If a public-display variant is genuinely needed for a specific code, add a `publicTitle` field to the catalog row and prefer it when present.
+- The SQL sync file's INSERT/UPDATE statements must match the JSON for every DESN code; rerun the sync against staging as part of release validation.
+
+**Patterns to follow:**
+- Existing `loadCourseCatalog` / `createCourseCatalogByCode` in `pages/public-schedule.js`.
+
+**Test scenarios:**
+- *Happy path:* `getCanonicalCourseTitleByCode('DESN 215', '', catalogByCode)` returns `'InDesign'` (after correction).
+- *Happy path:* Every code in the schedule fixture renders with the title from `data/course-catalog.json`.
+- *Edge case:* A course code not in the catalog falls back to the RPC-supplied `course_title`.
+- *Edge case:* A course with whitespace variants (`"DESN  215"`, lowercase) normalizes to the canonical lookup.
+- *Integration:* The pre-existing brittle assertions in `tests/supabase-course-catalog-sync.test.js` are replaced with: "every DESN code in the JSON catalog appears in the SQL INSERT block with the same title", asserting parity rather than literal text matches.
+
+**Verification:**
+- All public-schedule tests pass.
+- A new drift-detection test compares `data/course-catalog.json` titles to the INSERT tuples in `scripts/supabase-sync-course-catalog.sql` and fails if any DESN code differs.
+- Manual: load the rendered public schedule and confirm DESN 215 displays as `InDesign`.
+
+---
+
+- [ ] **Unit 6: Read room list and public-years list from canonical sources**
+
+**Goal:** Remove the remaining hard-coded `ROOM_ORDER`, `ROOM_LABELS`, `PUBLIC_YEARS`, `DEFAULTS.year` blocks (part of R5).
+
+**Requirements:** R5
+
+**Dependencies:** Can land in parallel with Unit 5. Order: Units 4–5 land first (smaller, lower-risk), then Unit 6.
+
+**Files:**
+- Modify: `pages/public-schedule.js` (drop `ROOM_ORDER`, `ROOM_LABELS`, `PUBLIC_ROOM_SET`, `PUBLIC_YEARS`, `DEFAULTS.year`)
+- Modify: `scripts/supabase-public-schedule-read.sql` (consider exposing distinct allowed years through a new RPC or column; the SQL allowlist stays the authority)
+- Test: `tests/public-schedule.test.js`
+- Test: `tests/supabase-public-schedule-read.test.js`
+
+**Approach:**
+- At init, the page fetches `data/room-constraints.json` and derives the room order/labels from rooms where `excludeFromGrid !== true`. Filter rule: a room is included in the grid if `excludeFromGrid` is absent, `false`, `null`, or `0`, and excluded only if it is the JavaScript boolean `true`. The fetch is memoized like the course catalog.
+- For public years: the page fetches the available years from Supabase. If the existing RPC can cheaply return them, add a `WITH years AS (...)` block; otherwise add a small `get_public_schedule_years()` SQL function. The JS keeps a *fallback* constant (single year, current) only for the offline-render path.
+- `DEFAULTS.year` becomes `(years[0] ?? '<single fallback>')` — the most recent year returned by the RPC.
+
+**Patterns to follow:**
+- Memoization pattern in `loadCourseCatalog`.
+- SQL function shape in `scripts/supabase-public-schedule-read.sql`.
+
+**Test scenarios:**
+- *Happy path:* When the rooms RPC/file returns the canonical list, the grid renders columns in the same order as `data/room-constraints.json` (excluding `excludeFromGrid`).
+- *Happy path:* When the years RPC returns `['2026-27', '2025-26']`, the year selector shows both and defaults to `2026-27`.
+- *Edge case:* A course scheduled in room `'207'` (marked `excludeFromGrid: true`) is filtered out exactly as today; assert via a fixture row.
+- *Edge case:* A course scheduled in a *new* room (e.g., `'CEB 105'`) added to `data/room-constraints.json` appears in the grid without code changes. This is the regression-prevention test for the silent-drop bug.
+- *Error path:* If the years RPC fails, the page falls back to the single hardcoded current year and renders a degraded-source banner. Empty schedule renders, no crash.
+- *Integration:* The SQL test asserts the years function or the RPC return shape includes the `v_allowed_years` set.
+
+**Verification:**
+- All tests pass.
+- Manual: temporarily add a fake room to `data/room-constraints.json`, reload `public-schedule.html`, and confirm the new column appears with no JS change.
+
+---
+
+- [ ] **Unit 7: Extract Foundry tokens to a shared CSS file**
+
+**Goal:** Single source of Foundry tokens so editor and public-schedule cannot drift visually (R7).
+
+**Requirements:** R7
+
+**Dependencies:** Independent; can land any time after Unit 1 lands.
+
+**Files:**
+- Create: `css/foundry-theme.css` (extract the `.foundry-production` CSS variable + rule block currently inlined in `index.html`)
+- Modify: `index.html` (remove the inline `.foundry-production` block; add `<link rel="stylesheet" href="css/foundry-theme.css">`)
+- Modify: `public-schedule.html` (add `<link>` to `css/foundry-theme.css` before `css/public-schedule.css`)
+- Modify: `css/public-schedule.css` (remove any Foundry-token definitions that now live in `foundry-theme.css`; keep public-schedule-only layout rules)
+
+**Approach:**
+- Identify the exact CSS variable block (`--foundry-*` custom properties) and `.foundry-production` selectors added to `index.html` on this branch.
+- Move them verbatim into `css/foundry-theme.css` under a single `:root` block (for variables) and the original selectors (for rule blocks).
+- Confirm no other CSS rules in `index.html` or `css/public-schedule.css` redefine the same variables; if they do, decide whether they're page-specific overrides (keep) or duplicates (remove).
+
+**Test scenarios:**
+
+Test expectation: none — pure CSS extraction with no behavioral change. Verification is visual.
+
+**Verification:**
+- Diff `index.html` against pre-extraction state: only the `<link>` tag and the deleted CSS block change.
+- Visual: side-by-side screenshots of `index.html` and `public-schedule.html` before/after show no rendering differences. Use the existing `public-schedule-*.png` screenshots in the worktree as baselines.
+
+---
+
+- [ ] **Unit 8: Resolve DOMContentLoaded race and harden RPC load path**
+
+**Goal:** No null-client failures; bounded loading; real failure-vs-empty distinction (R6, R8).
+
+**Requirements:** R6, R8
+
+**Dependencies:** Can land any time; small, contained.
+
+**Files:**
+- Modify: `pages/public-schedule.js` (ordering guard + timeout + tighter error check)
+- Modify: `js/supabase-config.js` (expose an explicit `whenSupabaseReady()` promise that resolves after `initSupabase()` completes)
+- Test: `tests/public-schedule.test.js`
+
+**Approach:**
+- `js/supabase-config.js` exposes `window.whenSupabaseReady` — a promise that resolves with the configured client (or rejects on configuration error). The existing DOMContentLoaded handler resolves it after `initSupabase()` finishes.
+- `pages/public-schedule.js`'s init `await`s `whenSupabaseReady` before calling `getClient()`. Removes the ordering footgun.
+- `load(year)` wraps the RPC call in `Promise.race` with a 10-second timeout that rejects with a typed error; catalog fetch gets a 5-second `AbortController` timeout.
+- After the RPC resolves, validate `Array.isArray(data)`; throw a clear error if not. This is the "silent success on `{data: null, error: null}`" fix.
+- The error-state renderer (`renderErrorState`) gets a null guard on `getElementById` per review P3 #18.
+
+**Test scenarios:**
+- *Happy path:* `whenSupabaseReady` resolves; `load()` runs against a mocked client and renders the grid.
+- *Edge case:* `whenSupabaseReady` is awaited even if the public-schedule init handler fires first; assert via a test where the two DOMContentLoaded listeners are registered in reverse order.
+- *Error path:* RPC takes >10s; `load()` rejects with the timeout error and the page shows the error state, not a stuck "Loading…" status.
+- *Error path:* RPC returns `{data: null, error: null}`; `load()` throws "invalid response" and the page shows the error state.
+- *Error path:* `data/course-catalog.json` returns a 404; catalog fetch aborts after 5s; rendering falls back to RPC-supplied titles (or canonical mapping if Unit 5 has landed) without hanging.
+- *Edge case:* `getElementById('publicScheduleGrid')` returns null (HTML structure error); `renderErrorState` returns silently rather than throwing.
+- *Empty state:* RPC returns an empty array; `renderEmptyState` runs and the "No public schedule rows are available" message appears. This is the previously-untested branch from review testing gap #2.
+
+**Verification:**
+- All scenarios pass in `tests/public-schedule.test.js`.
+- Manual: throttle Supabase to "Slow 3G" in DevTools; confirm the page shows an error after 10s, not a perpetual loading spinner.
+
+---
+
+- [ ] **Unit 9: Unicode-dash time-slot parsing + RPC column validation + drift-detection test**
+
+**Goal:** Defensive parsing of time slots and RPC payload validation; automated drift detection that would have caught the DESN 215 issue (R9).
+
+**Requirements:** R9
+
+**Dependencies:** Lands after Units 1–6 so the new sources of truth are in place.
+
+**Files:**
+- Modify: `pages/public-schedule.js` (`formatTimeSlot`, `getTimeSlotParts`, `normalizePublicScheduleRows`)
+- Create: `tests/canonical-data-drift.test.js`
+- Modify: `tests/public-schedule.test.js`
+
+**Approach:**
+- Update the time-slot parsers to split on `/[‐-―−-]/` (hyphen-minus + en-dash + em-dash + minus sign).
+- In `normalizePublicScheduleRows`, validate each row has the expected fields (`day_pattern`, `time_slot`, `course_code`, `instructor_name`, `room_code`). Throw a clear typed error naming the missing column if any required field is undefined on a non-empty payload. This surfaces RPC contract drift the moment it occurs. *Scope note:* this unit introduces defensive RPC-shape validation that Units 1–8 did not. Unit 5 (title resolution) and Unit 6 (canonical year/room loading) assume the rows are already well-formed; Unit 9 is what enforces that assumption.
+- New drift test compares `data/course-catalog.json` against `scripts/supabase-sync-course-catalog.sql` (titles, credits, level) and against `js/faculty-display.js` (faculty names match `scripts/faculty-mapping.json`).
+
+**Test scenarios:**
+- *Happy path:* `formatTimeSlot('10:00-12:20')` returns `'10:00 AM - 12:20 PM'` (existing behavior).
+- *Edge case:* `formatTimeSlot('10:00–12:20')` (en-dash) returns the same formatted string.
+- *Edge case:* `formatTimeSlot('10:00—12:20')` (em-dash) and `'10:00−12:20'` (minus) likewise.
+- *Error path:* `normalizePublicScheduleRows([{...missing day_pattern}])` throws an `Error` whose message names `day_pattern` as the missing field.
+- *Happy path:* For each DESN code in `data/course-catalog.json`, the `scripts/supabase-sync-course-catalog.sql` INSERT has the same title; the drift test fails loudly if not.
+- *Happy path:* For each canonical name in `scripts/faculty-mapping.json`, `js/faculty-display.js` resolves to a known entry; the drift test fails if a mapping key has no display entry.
+
+**Verification:**
+- `tests/canonical-data-drift.test.js` passes against the post-Unit-5 state of the repo.
+- Intentional drift (manually change `'InDesign'` to `'Indesign'` in either file) fails the test with a clear diff.
+
+## System-Wide Impact
+
+- **Interaction graph:** Units 1, 2, and 8 touch the auth/data path that runs before every public-schedule render. A regression here is a page-down event for the public view. Validate Unit 1 against the editor (which still uses overrides on localhost) and Unit 8 against the empty-quarter path.
+- **Error propagation:** Unit 8 changes the "stuck on Loading" outcome into a deterministic error state. Confirm the error state in `css/public-schedule.css` is styled and visible — there's a `public-schedule-error-state.png` screenshot in the worktree suggesting this was visualized before; reconcile against it.
+- **State lifecycle risks:** Unit 4 introduces a memoized JSON fetch shared across pages. If `js/faculty-display.js` is loaded by the editor and then the public view in the same browser session, the cache must serve both correctly (deterministic on the same JSON file).
+- **API surface parity:** Unit 2 is the only externally-observable contract change. Anything that today silently calls `supabase.from('scheduled_courses').select(...)` from an anon context will break. Search the codebase for direct table calls before merging Unit 2; the RPC has been the contract per `auth-contract.md` but enforcement was loose.
+- **Integration coverage:** Unit 5's drift-detection test and Unit 8's whenReady promise both cover behaviors that unit-level mocks would miss. Keep them as integration-style tests against real JSON files and a fake-but-shaped Supabase client.
+- **Unchanged invariants:** The `get_public_schedule` RPC's return shape stays the same throughout this plan. Editor read paths via authenticated sessions are not affected by Unit 2 (auth'd users still SELECT directly). The IIFE module pattern from CLAUDE.md is preserved by every new JS module.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Unit 2 (RLS tightening) breaks an authenticated read path that today relies on the loose `"Public read"` policy. | Audit the codebase for direct `from('scheduled_courses').select(...)` and `from('faculty').select(...)` calls before merging Unit 2. Run in staging first; the rollback script restores the old policy in one command. |
+| Unit 5 corrects DESN 215 in `data/course-catalog.json` but a user expects the JS-override form. | Confirm with the user (or via the existing release checklist) that "InDesign" is the desired public-display form before flipping; the SQL canonical already uses it. Add a `publicTitle` field on the catalog row if a different display form is genuinely needed. |
+| Unit 6's "fetch years from Supabase" path adds a second network call on first paint, slowing the public view. | Memoize the call; ship the most recent year as the hardcoded fallback so the initial render doesn't block on the years RPC. Years can be revealed in the tab strip once the call resolves. |
+| Unit 8's 10-second timeout is too aggressive on slow networks and surfaces an error state to legitimate slow loads. | Make the timeout configurable via `window.PROGRAM_COMMAND_SUPABASE_CONFIG.publicScheduleTimeoutMs`; default 10s. Re-tune after observing real-world load times. |
+| Unit 4 introduces a third place that consumes `scripts/faculty-mapping.json`, increasing the surface area for a breaking change to that file. | The drift test in Unit 9 covers this: any change to the mapping that leaves a display entry orphaned (or vice versa) fails the suite. |
+| Branch-level cleanup ("clean everything up in dev") is broader than this plan covers. | Listed as scope-out and tracked in Operational Notes below; user will decide which `codex/*` branches to delete separately. |
+
+## Documentation / Operational Notes
+
+- **Release checklist update (Unit 2):** Add an anon-SELECT verification step to `docs/public-schedule-release-checklist.md`. Add a paragraph documenting that the `?supabaseEnv=` / `?supabaseUrl=` / `?supabaseAnonKey=` overrides are intentionally local-only after Unit 1 lands.
+- **Auth contract reaffirmation:** After Unit 2 ships, `docs/auth-contract.md` should call out that the public-table RLS policies are now restrictive — a one-line factual update, not a contract change.
+- **Branch hygiene (deferred):** `git branch -r --merged origin/main` will list `codex/*` branches that can be safely deleted; `git for-each-ref --format='%(refname:short) %(committerdate:short)' refs/remotes/origin/codex/` will identify stale unmerged branches. Pair this with the user; do not delete remote branches autonomously. This is not gated by this plan and can proceed in parallel.
+
+## Sources & References
+
+- **Origin:** ce-review of `codex/internal-schedule-match-public-view` (2026-05-12), 10-reviewer parallel synthesis. P0 #1, P1 #2–#8, P2 #9–#16, P3 #18–#21.
+- Existing plan: `docs/plans/2026-04-30-001-feat-public-schedule-view-plan.md` (defined the original public-schedule contract).
+- `docs/auth-contract.md` — the contract Unit 2 enforces.
+- `docs/public-schedule-release-checklist.md` — checklist Unit 2 updates.
+- `CLAUDE.md` — IIFE pattern, canonical data file locations, course/year format conventions.

--- a/docs/progress-handoff-2026-05-27.md
+++ b/docs/progress-handoff-2026-05-27.md
@@ -1,0 +1,180 @@
+---
+date: 2026-05-27
+session: 2026-05-26 → 2026-05-27 (one continuous session, dates rolled mid-context)
+status: ✅ shipped to prod; ⏳ one Supabase migration still pending
+---
+
+# Progress handoff — 2026-05-27
+
+Single-day session that ran from triage of the live public schedule
+through a multi-phase UI/UX audit and remediation of `schedule-builder`,
+plus a quick layout reorder of `program-command`. Two PRs merged, both
+live in prod. One Supabase migration is still pending. Eight follow-up
+slices identified.
+
+## Quick orientation for the next session
+
+- Production URL: <https://sicxz.github.io/program-command/>
+- Main HEAD: `c8751c4` (PR #260 merge)
+- Local server: `python3 -m http.server 8080` (background task
+  `bastnsxud` may still be running; restart if not)
+- Last audit report: [`.context/compound-engineering/ce-review/schedule-builder-uiux-2026-05-26/findings.md`](/Users/tmasingale/Documents/GitHub/scheduler-v2-codex/.context/compound-engineering/ce-review/schedule-builder-uiux-2026-05-26/findings.md)
+- Memory updated: [`phase1-and-public-landing-shipped.md`](/Users/tmasingale/.claude/projects/-Users-tmasingale-Documents-GitHub-scheduler-v2-codex/memory/phase1-and-public-landing-shipped.md)
+  reflects the dropdown deploy + RPC migration applied state.
+
+## What shipped today
+
+### 1. PR #258 — Year dropdown (already in flight at session start)
+- Tested locally, admin-merged (`gh pr merge 258 --merge --admin`),
+  dispatched `ci.yml` on main, then `deploy-pages.yml`.
+- Live at <https://sicxz.github.io/program-command/public-schedule.html>.
+- Year list is now `['2026-27', '2025-26']` rendered as a `<select>` —
+  no more 4-tab row with empty 2024-25 / 2023-24.
+
+### 2. RPC migration applied to prod Supabase
+- File: [`scripts/supabase-public-schedule-read.sql`](/Users/tmasingale/Documents/GitHub/scheduler-v2-codex/scripts/supabase-public-schedule-read.sql)
+- Applied via Supabase SQL editor (project `ohnrhjxcjkrdtudpzjgn`) after
+  diagnosing that the deployed RPC was the older commit `63fce2a`
+  whose allowlist hard-coded `'2026-27'` and silently returned 0 rows
+  for any other year.
+- Post-migration RPC results: 2026-27 → 56 rows, **2025-26 → 57 rows**
+  across Fall / Winter / Spring. Earlier years (2024-25, 2023-24) are
+  legitimately empty in the DB.
+
+### 3. PR #260 — Schedule builder UI/UX audit Phases A–E
+Branch `feat/schedule-builder-data-safety` → merged 2026-05-26.
+Five reviewable commits, one phase each:
+
+| Commit | Phase | Resolves |
+|---|---|---|
+| `363cac8` | **A** — Data safety | P0 #2 dirty/beforeunload · #5 save-in-flight UI · #6 silent draft load fail |
+| `c38f4cc` | **B** — Accessibility floor | P0 #3 modals → real dialogs · #4 live regions · P1 target sizes, focus mgmt, aria |
+| `9238801` | **C** — Copy + reveal sequence | P1 stale copy ("Generate Schedule", "ChatGPT", "Make Workloads", "-- at --"); pre-data panels hidden until Load & Analyze |
+| `fc22667` | **D** — Visual brand quick wins | P0 #13 wrong red (#b7142e → EWU #a10022) · #14 teal-on-red shadow · P1 focus rings, btn-small dedupe |
+| `f06f3d5` | **E** — Drag-drop keyboard alternative | P0 #1 WCAG 2.1.1 + 2.5.7 pickup/Tab/drop with SR announcements |
+
+### 4. PR #259 — Program command schedule-first layout
+Branch `feat/program-command-layout` → merged 2026-05-26.
+
+Pure CSS reorder via flex `order` on `.container`. DOM order
+unchanged (preserves the 17k-line file's many `querySelector` /
+`getElementById` calls). Visual order is now:
+
+1. `app-header`
+2. `quarter-nav` (welded to the grid below)
+3. `.content` (the schedule view panel)
+4. `.stats-bar`
+5. `lens-filters`
+6. `.dashboard-nav`
+
+Both PRs admin-merged (1-approver ruleset on `main`; the user is the
+sole repo owner). Standard deploy flow: dispatch `ci.yml` on main → wait
+green → dispatch `deploy-pages.yml` → wait → verify. See [`deploy-after-merge-procedure.md`](/Users/tmasingale/.claude/projects/-Users-tmasingale-Documents-GitHub-scheduler-v2-codex/memory/deploy-after-merge-procedure.md).
+
+## Still pending
+
+### Supabase migration not yet applied
+- File: [`scripts/supabase-current-term-setting.sql`](/Users/tmasingale/Documents/GitHub/scheduler-v2-codex/scripts/supabase-current-term-setting.sql)
+- Effect: creates `public.public_schedule_settings` table +
+  `get_public_current_term` (anon-readable) + `set_public_current_term`
+  (authenticated). Lets the admin set which AY + quarter the public
+  page defaults to.
+- Until applied, the anon RPC returns `PGRST202: function not found`
+  and the public page silently falls back to **Fall 2026-27** via the
+  resilient code path in `pages/public-schedule.js`.
+- To apply: open <https://supabase.com/dashboard/project/ohnrhjxcjkrdtudpzjgn/sql/new>,
+  paste the file contents, run. Single idempotent block. Confirmed
+  safe in the test suite (`tests/supabase-current-term-setting.test.js`).
+
+### Branches not deleted on merge
+Following the prior convention from PRs #256/#257, both new merged
+branches still exist on origin:
+- `feat/schedule-builder-data-safety`
+- `feat/program-command-layout`
+
+Plus the older `feat/public-year-dropdown` from earlier in the day.
+Run `git push origin :<branch>` (or the existing
+[`compound-engineering:git-clean-gone-branches`](https://github.com/sicxz/program-command/) skill)
+when you want them gone.
+
+## Audit findings still open
+
+Of the 28 deduped findings in the audit report, **20 were resolved**
+across Phases A–E. The remaining 8 are all design-system token
+consolidation work, deliberately deferred as out-of-scope for "audit
+fixes":
+
+- **P1 #25** — Cards / buttons / typography / spacing / status colors
+  all improvised per component. Needs a real token system in
+  `css/design-system.css` that `schedule-builder.css` and friends
+  consume.
+- **P1 #22** — Color-only priority signals (`.course-block.priority-*`
+  and `.faculty-load.overload`). Needs a text/icon companion for
+  color-vision-deficient users.
+- **P1 #28** — Two stylesheets fight for `.builder-header`
+  (`schedule-builder.css` vs `program-command-dashboard-theme.css`
+  with `!important`). Phase D defused the teal-vs-red conflict but
+  the duelling-stylesheet situation remains.
+- **P2 #27** — No motion system, no spacing scale, 15 inline `style=""`
+  attributes still in `pages/schedule-builder.html`.
+- Plus four lower-severity P1/P2 polish items.
+
+These belong in a "design system consolidation" ticket, not a fix pass.
+
+## Loose UI/UX threads from the live session
+
+User flagged, not yet addressed:
+
+- **`app-header` is still ~200px tall** on `program-command.html`.
+  Could compact to one line; settings gear could move into the header
+  strip instead of floating as a card.
+- **Stats bar shows `0 / 0 / 19 / 83%` before data exists** — same
+  trick we used in Phase C (hide until populated) should apply here too.
+- The schedule-first layout reorder is **CSS-only via flex `order`**.
+  At some point this should be refactored to actual DOM order for
+  maintainability, but doing so requires touching the 17k-line file
+  more invasively — defer until other work touches that area.
+
+## Key file pointers for the next session
+
+| File | What it is |
+|---|---|
+| `pages/schedule-builder.html` | The big chair editor — heavily touched in Phases B/C/E |
+| `pages/schedule-builder.js` (~4,200 lines now) | Page controller. New helpers grouped under PHASE A/B/E comment banners near the top of the helper section (around line 3290 onward). |
+| `css/schedule-builder.css` (~2,700 lines now) | Page styles. New blocks under PHASE A/B/C/E comment banners near the bottom. |
+| `js/auth-guard.js` | Owns multi-editor conflict + view-only mode. Phase B added `role="alert"` / `role="status"` and bumped `.edit-lock-btn` to 28×28. |
+| `program-command.html` | The 17k-line app shell. Only change today: `.container--schedule-first` flex-order block at ~line 4423. |
+| `scripts/supabase-public-schedule-read.sql` | Applied to prod today. |
+| `scripts/supabase-current-term-setting.sql` | **Still pending — apply when convenient.** |
+| `.context/compound-engineering/ce-review/schedule-builder-uiux-2026-05-26/findings.md` | Full audit report (28 findings, P0–P2 grouped). |
+| `docs/progress-handoff-2026-05-27.md` | This file. |
+
+## Local environment state at end of session
+
+- Working tree on `feat/program-command-layout` (already merged; safe to
+  switch off).
+- `M CLAUDE.md` and a large list of untracked files (`.codex/`,
+  `.cursor/`, `.playwright-mcp/`, `TRAVIS.md`, several `docs/plans/*`
+  files, and ~15 untracked aspirational test files in `tests/`) — all
+  pre-existing the session. Not touched.
+- Background bash task `bastnsxud` was running `python3 -m http.server
+  8080` for local verification. May have exited if the session has
+  been idle; restart with `python3 -m http.server 8080` from the repo
+  root if needed.
+
+## Suggested next slice
+
+Decreasing order of leverage:
+
+1. **Apply `supabase-current-term-setting.sql`** to prod Supabase so
+   the admin's default-term picker actually takes effect. ~5 minutes,
+   already tested.
+2. **Compact the `<app-header>` on `program-command.html`** and tuck
+   the Settings card into the header strip. Visible win at every page
+   load.
+3. **Hide the stats bar until data exists** (`Critical / Conflicts /
+   Courses / Utilization`). Same pattern as Phase C panel-reveal.
+4. **Design system token consolidation** (the big P1 backlog above) —
+   needs a separate planning pass; budget for half a day minimum.
+
+Pick one, start it, ship it.

--- a/docs/progress-handoff-2026-05-29.md
+++ b/docs/progress-handoff-2026-05-29.md
@@ -1,0 +1,93 @@
+# Progress Handoff — 2026-05-29
+
+## What this branch is
+
+`wip/codex-readiness-tests` is a **parking branch**, not a feature branch. On
+2026-05-29 the working tree had accumulated three unrelated bodies of change
+mixed together on `feat/header-stats-polish` (which has an open, focused UI PR,
+#261). This branch quarantines the **unfinished Codex production-readiness
+work** so it is saved in version control without polluting PR #261 or breaking
+CI.
+
+> **Do NOT merge this branch as-is.** 17 of its test suites are red (see below).
+> Merging would block the deploy gate — `deploy-pages.yml` refuses to publish
+> unless the `test` check is green.
+
+## How the untangle was done
+
+| Bucket | Where it went | Status |
+|---|---|---|
+| `.gitignore` for agent tooling + `CLAUDE.md` two-model-stack doc | branch `chore/tooling-gitignore-two-model-doc` → **PR #262** to `main` | Clean, mergeable |
+| Agent tooling / local scratch (`.codex/`, `.context/`, `.cursor/`, `.playwright-mcp/`, `header-check.png`, `TRAVIS.md`) | now gitignored (see PR #262) | Not committed, by design |
+| Unfinished Codex readiness work (this branch) | `wip/codex-readiness-tests` → draft PR | **17 suites red** — parked |
+| Header/stats UI polish | `feat/header-stats-polish` → PR #261 | Untouched, left clean at `93d1563` |
+
+## What's parked on this branch
+
+- `js/program-shell.js` — new program-shell module. **Not yet wired into any
+  HTML** (no `<script src>` references it). Its test is green (see below).
+- `docs/plans/2026-05-12-001-refactor-public-schedule-hardening-plan.md`
+- `docs/progress-handoff-2026-05-27.md`
+- 19 `tests/*.test.js` files.
+
+### Test status of the parked tests
+
+**Already green (2)** — could be promoted to `main` quickly on their own:
+
+- `tests/program-shell.test.js` (covers `js/program-shell.js`)
+- `tests/schedule-modules.direct-data.test.js`
+
+**Red (17)** — all fail for the same reason: they assert against audit docs and
+a runtime-dependency script that were **never created**. The tests are the only
+half of the work that landed.
+
+Missing files the red tests expect:
+
+```
+scripts/audit-runtime-dependencies.js
+docs/audits/README.md
+docs/audits/dashboard-shell-baseline.md
+docs/audits/data-truth-audit.md
+docs/audits/multi-department-blockers.md
+docs/audits/multi-department-release-gate.md
+docs/audits/operational-confidence-audit.md
+docs/audits/platformization-audit.md
+docs/audits/product-consistency-audit.md
+docs/audits/production-readiness-program.md
+docs/audits/production-source-of-truth-policy.md
+```
+
+Red suites:
+`audit-runtime-dependencies`, `constraints-dashboard.canonical-data`,
+`constraints-engine.runtime-rules`, `course-management.intent`,
+`data-truth-audit-doc`, `db-service.academic-year-read`,
+`db-service.department-scoping`, `db-service.source-status`,
+`multi-department-release-gate-doc`, `platformization-audit-doc`,
+`product-consistency-audit-doc`, `production-readiness-program-doc`,
+`release-time-manager.profile-scope`, `schedule-builder.database-baseline`,
+`schedule-builder.runtime-rules`, `schedule-builder.runtime-source-banner`,
+`validators.generic-course-code`.
+
+## Next steps
+
+1. **Land the easy wins first.** Cherry-pick `tests/program-shell.test.js`,
+   `js/program-shell.js`, and `tests/schedule-modules.direct-data.test.js` onto
+   a small branch → PR to `main`. They are green today. (If you want
+   `program-shell.js` actually used, also wire it into the relevant page's
+   `<script>` tags — currently it's dead code.)
+2. **Decide the fate of the red 17.** Either:
+   - **Finish the work:** locate the original Codex source for
+     `scripts/audit-runtime-dependencies.js` and the `docs/audits/*` set (check
+     branch `codex/production-readiness-audit` — `TRAVIS.md`, now gitignored,
+     pointed there), bring it onto a feature branch alongside these tests, and
+     get the suite green before any PR to `main`; **or**
+   - **Drop the tests:** if the readiness-audit direction is abandoned, delete
+     these 17 test files rather than carrying red tests indefinitely.
+3. **Merge PR #262** (chore) whenever convenient — it's independent and safe.
+4. **Keep PR #261 moving** — it's a clean UI change and unaffected by any of the above.
+
+## Verification at handoff time
+
+- `feat/header-stats-polish` HEAD: `93d1563` (unchanged; PR #261 untouched).
+- Full suite on `main` + parked files: 40 passed suites, 17 failed (the parked
+  red set), `203` tests / `40` failing.

--- a/js/program-shell.js
+++ b/js/program-shell.js
@@ -1,0 +1,1136 @@
+(function programShellModule(global) {
+    'use strict';
+
+    const SHELL_SELECTION_STORAGE_KEY = 'programCommandShellSelectionV1';
+    const ONBOARDING_CONTEXT_STORAGE_KEY = 'programCommandOnboardingContextV1';
+
+    const DEFAULT_PROGRAM_GROUPS = Object.freeze([
+        {
+            id: 'departments-programs',
+            title: 'Departments & Programs',
+            entries: [
+                {
+                    type: 'program',
+                    id: 'biology',
+                    label: 'Biology',
+                    suggestedCode: 'BIOL',
+                    baseProfileId: 'design-v1'
+                },
+                {
+                    type: 'program',
+                    id: 'chemistry-biochemistry',
+                    label: 'Chemistry & Biochemistry',
+                    suggestedCode: 'CHEM',
+                    baseProfileId: 'design-v1'
+                },
+                {
+                    type: 'department',
+                    title: 'Computer Science, Cybersecurity & Electrical Engineering',
+                    items: [
+                        {
+                            id: 'csee-department',
+                            label: 'Department view',
+                            identityName: 'Computer Science, Cybersecurity & Electrical Engineering',
+                            identityShortName: 'CSEE Department',
+                            suggestedCode: 'CSEE',
+                            departmentId: 'csee',
+                            departmentLabel: 'Computer Science, Cybersecurity & Electrical Engineering',
+                            workspaceKind: 'department',
+                            workspaceSummary: 'Master department view',
+                            baseProfileId: 'design-v1'
+                        },
+                        {
+                            id: 'computer-science-cybersecurity',
+                            label: 'Computer Science + Cybersecurity',
+                            identityName: 'Computer Science + Cybersecurity',
+                            identityShortName: 'CS + Cyber',
+                            suggestedCode: 'CSCY',
+                            departmentId: 'csee',
+                            departmentLabel: 'Computer Science, Cybersecurity & Electrical Engineering',
+                            workspaceKind: 'combined-programs',
+                            workspaceSummary: 'Shared multi-program workspace',
+                            memberProgramIds: ['computer-science', 'cybersecurity'],
+                            baseProfileId: 'design-v1'
+                        },
+                        {
+                            id: 'computer-science',
+                            label: 'Computer Science',
+                            suggestedCode: 'CSCD',
+                            departmentId: 'csee',
+                            departmentLabel: 'Computer Science, Cybersecurity & Electrical Engineering',
+                            workspaceKind: 'program',
+                            workspaceSummary: 'Program workspace',
+                            baseProfileId: 'design-v1'
+                        },
+                        {
+                            id: 'cybersecurity',
+                            label: 'Cybersecurity',
+                            suggestedCode: 'CYBR',
+                            departmentId: 'csee',
+                            departmentLabel: 'Computer Science, Cybersecurity & Electrical Engineering',
+                            workspaceKind: 'program',
+                            workspaceSummary: 'Program workspace',
+                            baseProfileId: 'design-v1'
+                        },
+                        {
+                            id: 'electrical-engineering',
+                            label: 'Electrical Engineering',
+                            suggestedCode: 'EE',
+                            departmentId: 'csee',
+                            departmentLabel: 'Computer Science, Cybersecurity & Electrical Engineering',
+                            workspaceKind: 'program',
+                            workspaceSummary: 'Program workspace',
+                            baseProfileId: 'design-v1'
+                        }
+                    ]
+                },
+                {
+                    type: 'program',
+                    id: 'design',
+                    label: 'Design',
+                    suggestedCode: 'DESN',
+                    baseProfileId: 'design-v1',
+                    profileId: 'design-v1',
+                    seededDefault: true
+                },
+                {
+                    type: 'section',
+                    title: 'Education',
+                    items: [
+                        {
+                            id: 'science-education',
+                            label: 'Science Education',
+                            suggestedCode: 'SCED',
+                            parentLabel: 'Education',
+                            baseProfileId: 'design-v1'
+                        },
+                        {
+                            id: 'mathematics-education',
+                            label: 'Mathematics Education',
+                            suggestedCode: 'MAED',
+                            parentLabel: 'Education',
+                            baseProfileId: 'design-v1'
+                        }
+                    ]
+                },
+                {
+                    type: 'program',
+                    id: 'environmental-science',
+                    label: 'Environmental Science',
+                    suggestedCode: 'ENVS',
+                    baseProfileId: 'design-v1'
+                },
+                {
+                    type: 'program',
+                    id: 'geosciences',
+                    label: 'Geosciences',
+                    suggestedCode: 'GEOS',
+                    baseProfileId: 'design-v1'
+                },
+                {
+                    type: 'program',
+                    id: 'mathematics',
+                    label: 'Mathematics',
+                    suggestedCode: 'MATH',
+                    baseProfileId: 'design-v1'
+                },
+                {
+                    type: 'program',
+                    id: 'mechanical-engineering-technology',
+                    label: 'Mechanical Engineering & Technology',
+                    suggestedCode: 'MET',
+                    baseProfileId: 'design-v1'
+                },
+                {
+                    type: 'program',
+                    id: 'physics',
+                    label: 'Physics',
+                    suggestedCode: 'PHYS',
+                    baseProfileId: 'design-v1'
+                }
+            ]
+        }
+    ]);
+
+    function safeLocalStorage() {
+        try {
+            return global.localStorage || null;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function readJsonStorage(key) {
+        const storage = safeLocalStorage();
+        if (!storage) return null;
+        try {
+            const raw = storage.getItem(key);
+            return raw ? JSON.parse(raw) : null;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    function writeJsonStorage(key, value) {
+        const storage = safeLocalStorage();
+        if (!storage) return;
+        try {
+            storage.setItem(key, JSON.stringify(value));
+        } catch (error) {
+            // Ignore storage failures in the shell; the runtime can still proceed.
+        }
+    }
+
+    function clearStorageKey(key) {
+        const storage = safeLocalStorage();
+        if (!storage) return;
+        try {
+            storage.removeItem(key);
+        } catch (error) {
+            // Ignore storage failures.
+        }
+    }
+
+    function flattenPrograms(groups = DEFAULT_PROGRAM_GROUPS) {
+        return (Array.isArray(groups) ? groups : []).flatMap((group) => {
+            const entries = Array.isArray(group?.entries) ? group.entries : [];
+            return entries.flatMap((entry) => {
+                if (!entry || typeof entry !== 'object') return [];
+                if (entry.type === 'section') {
+                    return (Array.isArray(entry.items) ? entry.items : []).map((item) => ({
+                        ...item,
+                        parentLabel: String(item?.parentLabel || entry.title || '').trim() || null
+                    }));
+                }
+                if (entry.type === 'department') {
+                    return (Array.isArray(entry.items) ? entry.items : []).map((item) => ({
+                        ...item,
+                        parentLabel: String(item?.parentLabel || entry.title || '').trim() || null,
+                        departmentId: String(item?.departmentId || sanitizeDepartmentId(entry.title || entry.id || '')).trim() || null,
+                        departmentLabel: String(item?.departmentLabel || entry.title || '').trim() || null
+                    }));
+                }
+                return [entry];
+            });
+        });
+    }
+
+    function findProgramById(programId, groups = DEFAULT_PROGRAM_GROUPS) {
+        const normalizedId = String(programId || '').trim();
+        if (!normalizedId) return null;
+        return flattenPrograms(groups).find((program) => String(program.id) === normalizedId) || null;
+    }
+
+    function buildSuggestedIdentity(program) {
+        const label = String(program?.identityName || program?.label || '').trim();
+        const suggestedCode = String(program?.suggestedCode || '').trim().toUpperCase();
+        return {
+            name: label,
+            code: suggestedCode,
+            displayName: String(program?.identityDisplayName || (label ? `EWU ${label}` : '')).trim(),
+            shortName: String(program?.identityShortName || program?.label || label).trim()
+        };
+    }
+
+    function sanitizeDepartmentId(value) {
+        return String(value || '')
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+/, '')
+            .replace(/-+$/, '');
+    }
+
+    function createProgramSelection(program) {
+        if (!program || typeof program !== 'object') return null;
+        return {
+            id: String(program.id || '').trim(),
+            label: String(program.label || '').trim(),
+            parentLabel: String(program.parentLabel || '').trim() || null,
+            departmentId: String(program.departmentId || '').trim() || null,
+            departmentLabel: String(program.departmentLabel || '').trim() || null,
+            profileId: String(program.profileId || '').trim() || null,
+            baseProfileId: String(program.baseProfileId || program.profileId || 'design-v1').trim() || 'design-v1',
+            suggestedCode: String(program.suggestedCode || '').trim() || null,
+            workspaceKind: String(program.workspaceKind || 'program').trim() || 'program',
+            workspaceSummary: String(program.workspaceSummary || '').trim() || null,
+            memberProgramIds: Array.isArray(program.memberProgramIds)
+                ? program.memberProgramIds.map((id) => String(id || '').trim()).filter(Boolean)
+                : [],
+            identityName: String(program.identityName || '').trim() || null,
+            identityShortName: String(program.identityShortName || '').trim() || null,
+            identityDisplayName: String(program.identityDisplayName || '').trim() || null,
+            seededDefault: Boolean(program.seededDefault),
+            selectedAt: new Date().toISOString()
+        };
+    }
+
+    const TERM_LABELS = Object.freeze({
+        fall: 'Fall',
+        winter: 'Winter',
+        spring: 'Spring',
+        summer: 'Summer'
+    });
+
+    const TERM_SORT_ORDER = Object.freeze({
+        fall: 0,
+        winter: 1,
+        spring: 2,
+        summer: 3,
+        unassigned: 99
+    });
+
+    function createArtifactMetadata(artifact) {
+        if (!artifact || typeof artifact !== 'object') return null;
+        return {
+            name: String(artifact.name || '').trim() || null,
+            size: Number(artifact.size) || 0,
+            type: String(artifact.type || '').trim() || null,
+            capturedAt: artifact.capturedAt || new Date().toISOString()
+        };
+    }
+
+    function isScreenshotFile(file) {
+        if (!file || typeof file !== 'object') return false;
+        const name = String(file.name || '').trim().toLowerCase();
+        const type = String(file.type || '').trim().toLowerCase();
+        if (type.startsWith('image/')) return true;
+        return /\.(png|jpe?g|webp|gif|bmp)$/i.test(name);
+    }
+
+    function inferScreenshotTermYear(value) {
+        const normalized = String(value || '').trim();
+        if (!normalized) return { term: null, year: null };
+
+        const byTermFirst = normalized.match(/\b(fall|winter|spring|summer)\b[^0-9]{0,12}(20\d{2})\b/i);
+        if (byTermFirst) {
+            return {
+                term: String(byTermFirst[1] || '').trim().toLowerCase() || null,
+                year: Number(byTermFirst[2]) || null
+            };
+        }
+
+        const byYearFirst = normalized.match(/\b(20\d{2})\b[^a-z0-9]{0,12}(fall|winter|spring|summer)\b/i);
+        if (byYearFirst) {
+            return {
+                term: String(byYearFirst[2] || '').trim().toLowerCase() || null,
+                year: Number(byYearFirst[1]) || null
+            };
+        }
+
+        return { term: null, year: null };
+    }
+
+    function formatScreenshotGroupLabel(term, year) {
+        if (!term || !year) return 'Unassigned';
+        return `${TERM_LABELS[term] || term} ${year}`;
+    }
+
+    function buildScreenshotArtifactBatch(files, options = {}) {
+        const normalizedFiles = Array.from(files || [])
+            .filter((file) => file && typeof file === 'object' && isScreenshotFile(file))
+            .map((file, index) => {
+                const artifact = createArtifactMetadata(file) || {};
+                const relativePath = String(file.webkitRelativePath || file.relativePath || '').trim() || null;
+                const sourcePath = relativePath || artifact.name || `screenshot-${index + 1}`;
+                const inference = inferScreenshotTermYear(sourcePath);
+                const groupKey = inference.term && inference.year
+                    ? `${inference.term}-${inference.year}`
+                    : 'unassigned';
+
+                return {
+                    name: artifact.name || `screenshot-${index + 1}`,
+                    size: artifact.size || 0,
+                    type: artifact.type || null,
+                    relativePath,
+                    sourcePath,
+                    term: inference.term,
+                    year: inference.year,
+                    groupKey
+                };
+            });
+
+        const groupsMap = new Map();
+        normalizedFiles.forEach((file) => {
+            if (!groupsMap.has(file.groupKey)) {
+                groupsMap.set(file.groupKey, {
+                    key: file.groupKey,
+                    term: file.term,
+                    year: file.year,
+                    label: formatScreenshotGroupLabel(file.term, file.year),
+                    fileCount: 0,
+                    sampleNames: []
+                });
+            }
+
+            const group = groupsMap.get(file.groupKey);
+            group.fileCount += 1;
+            if (group.sampleNames.length < 4) {
+                group.sampleNames.push(file.relativePath || file.name);
+            }
+        });
+
+        const rootFolderName = String(options.rootFolderName || '').trim() || (() => {
+            const firstRelativePath = normalizedFiles.find((file) => file.relativePath)?.relativePath || '';
+            return firstRelativePath ? firstRelativePath.split('/')[0] : null;
+        })();
+
+        const groups = Array.from(groupsMap.values()).sort((left, right) => {
+            const leftYear = Number(left.year) || Number.MAX_SAFE_INTEGER;
+            const rightYear = Number(right.year) || Number.MAX_SAFE_INTEGER;
+            if (leftYear !== rightYear) return leftYear - rightYear;
+
+            const leftOrder = TERM_SORT_ORDER[left.term || 'unassigned'] ?? TERM_SORT_ORDER.unassigned;
+            const rightOrder = TERM_SORT_ORDER[right.term || 'unassigned'] ?? TERM_SORT_ORDER.unassigned;
+            if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+
+            return String(left.label || '').localeCompare(String(right.label || ''));
+        });
+
+        return {
+            mode: String(options.mode || 'files').trim() || 'files',
+            rootFolderName: rootFolderName || null,
+            count: normalizedFiles.length,
+            totalSize: normalizedFiles.reduce((sum, file) => sum + (Number(file.size) || 0), 0),
+            groups,
+            files: normalizedFiles,
+            capturedAt: options.capturedAt || new Date().toISOString()
+        };
+    }
+
+    function resolveStoredSelection(groups = DEFAULT_PROGRAM_GROUPS) {
+        const storedSelection = readSelection();
+        const resolvedProgram = findProgramById(storedSelection?.id, groups);
+        if (!resolvedProgram) return null;
+
+        return {
+            ...resolvedProgram,
+            profileId: String(storedSelection?.profileId || resolvedProgram.profileId || '').trim() || null,
+            baseProfileId: String(storedSelection?.baseProfileId || resolvedProgram.baseProfileId || resolvedProgram.profileId || 'design-v1').trim() || 'design-v1',
+            seededDefault: storedSelection?.seededDefault == null
+                ? Boolean(resolvedProgram.seededDefault)
+                : Boolean(storedSelection.seededDefault)
+        };
+    }
+
+    function readSelection() {
+        return readJsonStorage(SHELL_SELECTION_STORAGE_KEY);
+    }
+
+    function persistSelection(selection) {
+        writeJsonStorage(SHELL_SELECTION_STORAGE_KEY, selection);
+    }
+
+    function createOnboardingContext(program, options = {}) {
+        const selection = createProgramSelection(program);
+        const artifact = createArtifactMetadata(options.artifact);
+        const artifactBatch = options.artifactBatch && typeof options.artifactBatch === 'object'
+            ? buildScreenshotArtifactBatch(options.artifactBatch.files || [], options.artifactBatch)
+            : null;
+
+        return {
+            ...(selection || {}),
+            source: String(options.source || 'manual').trim() || 'manual',
+            suggestedIdentity: buildSuggestedIdentity(program),
+            artifact,
+            artifactBatch,
+            createdAt: new Date().toISOString()
+        };
+    }
+
+    function persistOnboardingContext(context) {
+        writeJsonStorage(ONBOARDING_CONTEXT_STORAGE_KEY, context);
+    }
+
+    function readOnboardingContext() {
+        return readJsonStorage(ONBOARDING_CONTEXT_STORAGE_KEY);
+    }
+
+    function clearOnboardingContext() {
+        clearStorageKey(ONBOARDING_CONTEXT_STORAGE_KEY);
+    }
+
+    function isLocalPreviewHost() {
+        const hostname = String(global.location?.hostname || '').trim().toLowerCase();
+        return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+    }
+
+    function formatProgramLabel(program) {
+        if (!program) return 'No program selected';
+        const label = String(program.label || '').trim();
+        const parentLabel = String(program.parentLabel || '').trim();
+        return parentLabel ? `${parentLabel} / ${label}` : label;
+    }
+
+    function normalizeProgramMatchValue(value) {
+        return String(value || '')
+            .trim()
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '');
+    }
+
+    async function findExistingProgramProfile(program, options = {}) {
+        const manager = options.profileManager || global.DepartmentProfileManager || null;
+        if (!program || !manager || typeof manager.listProfiles !== 'function' || typeof manager.loadProfile !== 'function') {
+            return null;
+        }
+
+        try {
+            const targetProgramId = normalizeProgramMatchValue(program.id);
+            const targetCode = normalizeProgramMatchValue(program.suggestedCode);
+            const targetLabel = normalizeProgramMatchValue(program.label);
+            const storedActiveProfileId = typeof manager.getStoredProfileId === 'function'
+                ? String(manager.getStoredProfileId() || '').trim()
+                : '';
+
+            async function loadCandidate(profileId, source) {
+                if (!profileId) return null;
+                const loaded = await manager.loadProfile(profileId);
+                const profile = loaded?.profile;
+                if (!profile || typeof profile !== 'object') return null;
+
+                const onboardingMeta = profile.onboardingMeta && typeof profile.onboardingMeta === 'object'
+                    ? profile.onboardingMeta
+                    : {};
+                const identity = profile.identity && typeof profile.identity === 'object'
+                    ? profile.identity
+                    : {};
+
+                const catalogProgramId = normalizeProgramMatchValue(onboardingMeta.catalogProgramId);
+                if (catalogProgramId && catalogProgramId === targetProgramId) {
+                    return {
+                        profileId,
+                        profile,
+                        source
+                    };
+                }
+
+                const identityCode = normalizeProgramMatchValue(identity.code);
+                const identityName = normalizeProgramMatchValue(identity.name);
+                const identityShortName = normalizeProgramMatchValue(identity.shortName);
+                const catalogProgramLabel = normalizeProgramMatchValue(onboardingMeta.catalogProgramLabel);
+
+                if (
+                    (targetCode && identityCode === targetCode) ||
+                    (targetLabel && (
+                        catalogProgramLabel === targetLabel ||
+                        identityName === targetLabel ||
+                        identityShortName === targetLabel
+                    ))
+                ) {
+                    return {
+                        profileId,
+                        profile,
+                        source: `${source}-fallback`
+                    };
+                }
+
+                return null;
+            }
+
+            if (storedActiveProfileId) {
+                const activeMatch = await loadCandidate(storedActiveProfileId, 'active-profile');
+                if (activeMatch) return activeMatch;
+            }
+
+            const listing = await manager.listProfiles();
+            const profiles = Array.isArray(listing?.profiles) ? listing.profiles : [];
+            const candidates = profiles
+                .filter((entry) => entry && entry.id && entry.source === 'custom-local')
+                .sort((left, right) => String(right?.savedAt || '').localeCompare(String(left?.savedAt || '')));
+
+            let fallbackMatch = null;
+            for (const entry of candidates) {
+                const candidateMatch = await loadCandidate(entry.id, 'custom-profile');
+                if (!candidateMatch) continue;
+                if (candidateMatch.source === 'custom-profile') {
+                    return candidateMatch;
+                }
+                if (!fallbackMatch) {
+                    fallbackMatch = candidateMatch;
+                }
+            }
+
+            return fallbackMatch;
+        } catch (error) {
+            return null;
+        }
+    }
+
+    async function detectProgramData(program, options = {}) {
+        if (!program || typeof program !== 'object') {
+            return { hasData: false, source: 'none' };
+        }
+
+        if (program.seededDefault) {
+            return { hasData: true, source: 'embedded-runtime' };
+        }
+
+        const manager = options.profileManager || global.DepartmentProfileManager || null;
+        const getClient = options.getSupabaseClient || global.getSupabaseClient || null;
+        const isConfigured = options.isSupabaseConfigured || global.isSupabaseConfigured || null;
+
+        const existingProfileMatch = await findExistingProgramProfile(program, { profileManager: manager });
+        if (existingProfileMatch?.profileId) {
+            return {
+                hasData: true,
+                source: existingProfileMatch.source || 'custom-profile',
+                profileId: existingProfileMatch.profileId
+            };
+        }
+
+        if (program.profileId && manager && typeof manager.loadProfile === 'function') {
+            try {
+                const loaded = await manager.loadProfile(program.profileId);
+                const prefix = String(loaded?.profile?.scheduler?.storageKeyPrefix || '').trim();
+                if (prefix) {
+                    const storage = safeLocalStorage();
+                    const hasLocalData = storage
+                        ? Object.keys(storage).some((key) => key.startsWith(prefix))
+                        : false;
+                    if (hasLocalData) {
+                        return { hasData: true, source: 'local-storage', profileId: program.profileId };
+                    }
+                }
+            } catch (error) {
+                // Keep probing with other sources.
+            }
+        }
+
+        if (typeof isConfigured === 'function' && isConfigured() && typeof getClient === 'function') {
+            try {
+                const client = getClient();
+                if (client && typeof client.from === 'function' && program.suggestedCode) {
+                    const { data: department } = await client
+                        .from('departments')
+                        .select('id')
+                        .eq('code', String(program.suggestedCode).trim().toUpperCase())
+                        .maybeSingle();
+
+                    if (department?.id) {
+                        const [scheduledCoursesResult, courseResult, facultyResult] = await Promise.all([
+                            client.from('scheduled_courses').select('id', { count: 'exact', head: true }).eq('department_id', department.id),
+                            client.from('courses').select('id', { count: 'exact', head: true }).eq('department_id', department.id),
+                            client.from('faculty').select('id', { count: 'exact', head: true }).eq('department_id', department.id)
+                        ]);
+
+                        const counts = [
+                            Number(scheduledCoursesResult?.count) || 0,
+                            Number(courseResult?.count) || 0,
+                            Number(facultyResult?.count) || 0
+                        ];
+
+                        if (counts.some((count) => count > 0)) {
+                            return { hasData: true, source: 'supabase', profileId: program.profileId || null };
+                        }
+                    }
+                }
+            } catch (error) {
+                // Ignore Supabase probe failures and fall back to the configured defaults.
+            }
+        }
+
+        return { hasData: false, source: 'none' };
+    }
+
+    function bootstrap(options = {}) {
+        if (!global.document) {
+            return Promise.resolve(false);
+        }
+
+        const launchRuntime = typeof options.launchRuntime === 'function' ? options.launchRuntime : null;
+        if (!launchRuntime) {
+            throw new Error('Program shell bootstrap requires a launchRuntime function.');
+        }
+
+        const overlay = global.document.getElementById('programShellOverlay');
+        if (!overlay) {
+            return launchRuntime();
+        }
+
+        const authService = options.authService || global.AuthService || null;
+        const manager = options.profileManager || global.DepartmentProfileManager || null;
+        const onboardingUrl = String(options.onboardingUrl || 'pages/department-onboarding.html').trim() || 'pages/department-onboarding.html';
+        const groups = Array.isArray(options.programGroups) ? options.programGroups : DEFAULT_PROGRAM_GROUPS;
+
+        const elements = {
+            overlay,
+            programList: global.document.getElementById('programShellProgramList'),
+            summary: global.document.getElementById('programShellSummary'),
+            authForm: global.document.getElementById('programShellAuthForm'),
+            email: global.document.getElementById('programShellEmail'),
+            password: global.document.getElementById('programShellPassword'),
+            sessionPanel: global.document.getElementById('programShellSessionPanel'),
+            sessionText: global.document.getElementById('programShellSessionText'),
+            previewButton: global.document.getElementById('programShellPreviewButton'),
+            switchAccountButton: global.document.getElementById('programShellSwitchAccountButton'),
+            continueButton: global.document.getElementById('programShellContinueButton'),
+            backButton: global.document.getElementById('programShellBackButton'),
+            chooser: global.document.getElementById('programShellChooser'),
+            manualButton: global.document.getElementById('programShellManualButton'),
+            spreadsheetButton: global.document.getElementById('programShellSpreadsheetButton'),
+            screenshotDirectoryButton: global.document.getElementById('programShellScreenshotDirectoryButton'),
+            screenshotButton: global.document.getElementById('programShellScreenshotButton'),
+            spreadsheetInput: global.document.getElementById('programShellSpreadsheetInput'),
+            screenshotDirectoryInput: global.document.getElementById('programShellScreenshotDirectoryInput'),
+            screenshotInput: global.document.getElementById('programShellScreenshotInput'),
+            screenshotSupportText: global.document.getElementById('programShellScreenshotSupportText'),
+            chooserMeta: global.document.getElementById('programShellChooserMeta'),
+            status: global.document.getElementById('programShellStatus')
+        };
+
+        const state = {
+            selectedProgram: resolveStoredSelection(groups),
+            session: null,
+            previewMode: false,
+            chooserVisible: false,
+            runtimeLaunched: false,
+            directoryUploadSupported: Boolean(elements.screenshotDirectoryInput && ('webkitdirectory' in elements.screenshotDirectoryInput))
+        };
+
+        function authSatisfied() {
+            return Boolean(state.session || state.previewMode);
+        }
+
+        function setStatus(kind, message) {
+            if (!elements.status) return;
+            elements.status.className = `program-shell-status ${kind}`;
+            elements.status.textContent = message;
+        }
+
+        function persistSelectedProgram(program, overrides = {}) {
+            if (!program || typeof program !== 'object') return;
+            state.selectedProgram = {
+                ...program,
+                ...overrides
+            };
+            persistSelection(createProgramSelection(state.selectedProgram));
+        }
+
+        function resetChooserDetails() {
+            state.chooserVisible = false;
+            if (elements.chooserMeta) {
+                elements.chooserMeta.textContent = '';
+            }
+        }
+
+        function renderProgramList() {
+            if (!elements.programList) return;
+            elements.programList.innerHTML = '';
+
+            groups.forEach((group) => {
+                const card = global.document.createElement('section');
+                card.className = 'program-shell-catalog';
+
+                const heading = global.document.createElement('div');
+                heading.className = 'program-shell-catalog-heading';
+                heading.textContent = String(group?.title || '').trim() || 'Programs';
+                card.appendChild(heading);
+
+                const entryWrap = global.document.createElement('div');
+                entryWrap.className = 'program-shell-catalog-list';
+
+                const entries = Array.isArray(group?.entries) ? group.entries : [];
+                entries.forEach((entry) => {
+                    if (!entry || typeof entry !== 'object') return;
+                    if (entry.type === 'section') {
+                        const section = global.document.createElement('div');
+                        section.className = 'program-shell-subsection';
+
+                        const sectionTitle = global.document.createElement('div');
+                        sectionTitle.className = 'program-shell-subsection-title';
+                        sectionTitle.textContent = String(entry.title || '').trim() || 'Programs';
+                        section.appendChild(sectionTitle);
+
+                        const sectionList = global.document.createElement('div');
+                        sectionList.className = 'program-shell-subsection-list';
+
+                        (Array.isArray(entry.items) ? entry.items : []).forEach((item) => {
+                            const itemButton = buildProgramButton({
+                                ...item,
+                                parentLabel: String(item?.parentLabel || entry.title || '').trim() || null
+                            });
+                            sectionList.appendChild(itemButton);
+                        });
+
+                        section.appendChild(sectionList);
+                        entryWrap.appendChild(section);
+                        return;
+                    }
+                    if (entry.type === 'department') {
+                        const section = global.document.createElement('div');
+                        section.className = 'program-shell-subsection';
+
+                        const sectionTitle = global.document.createElement('div');
+                        sectionTitle.className = 'program-shell-subsection-title';
+                        sectionTitle.textContent = String(entry.title || '').trim() || 'Department';
+                        section.appendChild(sectionTitle);
+
+                        const sectionList = global.document.createElement('div');
+                        sectionList.className = 'program-shell-subsection-list';
+
+                        (Array.isArray(entry.items) ? entry.items : []).forEach((item) => {
+                            const itemButton = buildProgramButton({
+                                ...item,
+                                parentLabel: String(item?.parentLabel || entry.title || '').trim() || null,
+                                departmentId: String(item?.departmentId || sanitizeDepartmentId(entry.title || entry.id || '')).trim() || null,
+                                departmentLabel: String(item?.departmentLabel || entry.title || '').trim() || null
+                            });
+                            sectionList.appendChild(itemButton);
+                        });
+
+                        section.appendChild(sectionList);
+                        entryWrap.appendChild(section);
+                        return;
+                    }
+
+                    entryWrap.appendChild(buildProgramButton(entry));
+                });
+
+                card.appendChild(entryWrap);
+                elements.programList.appendChild(card);
+            });
+        }
+
+        function buildProgramButton(program) {
+            const button = global.document.createElement('button');
+            button.type = 'button';
+            button.className = 'program-shell-program-button';
+            button.dataset.programId = String(program.id || '');
+            button.setAttribute('aria-pressed', state.selectedProgram?.id === program.id ? 'true' : 'false');
+
+            if (state.selectedProgram?.id === program.id) {
+                button.classList.add('selected');
+            }
+
+            const label = global.document.createElement('span');
+            label.className = 'program-shell-program-label';
+            label.textContent = String(program.label || '').trim();
+            button.appendChild(label);
+
+            const meta = global.document.createElement('span');
+            meta.className = 'program-shell-program-meta';
+            meta.textContent = program.seededDefault
+                ? 'Seeded workspace available'
+                : String(program.workspaceSummary || '').trim() || 'Start with onboarding';
+            button.appendChild(meta);
+
+            button.addEventListener('click', () => {
+                persistSelectedProgram(program, { profileId: String(program.profileId || '').trim() || null });
+                state.previewMode = false;
+                resetChooserDetails();
+                setStatus('info', `${formatProgramLabel(program)} selected. Authenticate to continue.`);
+                updateUi();
+                if (elements.email) {
+                    elements.email.focus();
+                }
+            });
+
+            return button;
+        }
+
+        function updateUi() {
+            renderProgramList();
+
+            if (elements.summary) {
+                elements.summary.textContent = state.selectedProgram
+                    ? `${formatProgramLabel(state.selectedProgram)} selected.`
+                    : 'Choose a program to unlock the correct entry path.';
+            }
+
+            const showSessionPanel = authSatisfied();
+            if (elements.authForm) {
+                elements.authForm.hidden = showSessionPanel;
+            }
+            if (elements.sessionPanel) {
+                elements.sessionPanel.hidden = !showSessionPanel;
+            }
+            if (elements.sessionText) {
+                if (state.previewMode) {
+                    elements.sessionText.textContent = 'Local preview session active.';
+                } else if (state.session?.user?.email) {
+                    elements.sessionText.textContent = `Signed in as ${state.session.user.email}.`;
+                } else {
+                    elements.sessionText.textContent = 'Authentication complete.';
+                }
+            }
+
+            if (elements.previewButton) {
+                elements.previewButton.hidden = !isLocalPreviewHost() || authSatisfied();
+            }
+
+            if (elements.continueButton) {
+                elements.continueButton.disabled = !state.selectedProgram || !authSatisfied();
+            }
+
+            if (elements.screenshotDirectoryButton) {
+                elements.screenshotDirectoryButton.hidden = !state.directoryUploadSupported;
+            }
+            if (elements.screenshotSupportText) {
+                elements.screenshotSupportText.textContent = state.directoryUploadSupported
+                    ? 'Folder upload keeps nested quarter folders when the browser supports directory selection.'
+                    : 'This browser does not expose directory selection here, so use multiple screenshot files instead.';
+            }
+            if (elements.screenshotButton) {
+                elements.screenshotButton.textContent = state.directoryUploadSupported
+                    ? 'Choose screenshot files'
+                    : 'Choose screenshots';
+            }
+
+            if (elements.chooser) {
+                elements.chooser.hidden = !state.chooserVisible || !authSatisfied();
+            }
+            if (elements.backButton) {
+                elements.backButton.hidden = !state.chooserVisible || !authSatisfied();
+            }
+        }
+
+        async function refreshSessionFromAuth() {
+            if (!authService || typeof authService.getSession !== 'function') {
+                state.session = null;
+                updateUi();
+                return;
+            }
+            try {
+                state.session = await authService.getSession();
+            } catch (error) {
+                state.session = null;
+            }
+            updateUi();
+        }
+
+        async function handleCredentialSubmit(mode) {
+            if (!authService) {
+                setStatus('error', 'Authentication service is unavailable.');
+                return;
+            }
+
+            const email = String(elements.email?.value || '').trim();
+            const password = String(elements.password?.value || '');
+            if (!email || !password) {
+                setStatus('error', 'Enter an email and password to continue.');
+                return;
+            }
+
+            try {
+                if (mode === 'create') {
+                    const result = await authService.signUp(email, password, 'chair');
+                    if (!result?.session) {
+                        setStatus('warn', 'Account created. Check your email confirmation, then sign in to continue.');
+                        updateUi();
+                        return;
+                    }
+                } else {
+                    await authService.signIn(email, password);
+                }
+
+                state.previewMode = false;
+                await refreshSessionFromAuth();
+                setStatus('ok', 'Authentication complete. Continue into Program Command.');
+            } catch (error) {
+                const message = error?.message || 'Authentication failed.';
+                setStatus('error', message);
+            }
+        }
+
+        function activatePreviewMode() {
+            state.previewMode = true;
+            state.session = null;
+            setStatus('warn', 'Local preview session enabled on localhost. Production still requires a real account.');
+            updateUi();
+        }
+
+        async function handleContinue() {
+            if (!state.selectedProgram) {
+                setStatus('error', 'Choose a program before continuing.');
+                return;
+            }
+            if (!authSatisfied()) {
+                setStatus('error', 'Authenticate before entering a program workspace.');
+                return;
+            }
+
+            setStatus('info', `Checking ${formatProgramLabel(state.selectedProgram)} for existing program data...`);
+            const dataState = await detectProgramData(state.selectedProgram, {
+                profileManager: manager
+            });
+
+            if (dataState.hasData) {
+                const nextProfileId = String(dataState.profileId || state.selectedProgram.profileId || '').trim();
+                if (nextProfileId) {
+                    persistSelectedProgram(state.selectedProgram, { profileId: nextProfileId });
+                }
+                if (manager && typeof manager.setActiveProfile === 'function' && nextProfileId) {
+                    try {
+                        await manager.setActiveProfile(nextProfileId);
+                    } catch (error) {
+                        setStatus('error', error?.message || 'Could not activate the selected profile.');
+                        return;
+                    }
+                }
+
+                clearOnboardingContext();
+                state.chooserVisible = false;
+                updateUi();
+                setStatus('ok', `Opening ${formatProgramLabel(state.selectedProgram)} in Program Command...`);
+
+                if (!state.runtimeLaunched) {
+                    state.runtimeLaunched = true;
+                    overlay.hidden = true;
+                    await launchRuntime();
+                }
+                return;
+            }
+
+            state.chooserVisible = true;
+            if (elements.chooserMeta) {
+                elements.chooserMeta.textContent = `${formatProgramLabel(state.selectedProgram)} does not have seeded data yet. Start with manual setup or capture the import artifacts for the follow-on import slice.`;
+            }
+            setStatus('info', `${formatProgramLabel(state.selectedProgram)} is empty. Choose how you want to start onboarding.`);
+            updateUi();
+        }
+
+        function navigateToOnboarding(source, intake = {}) {
+            if (!state.selectedProgram) {
+                setStatus('error', 'Choose a program before starting onboarding.');
+                return;
+            }
+            if (!authSatisfied()) {
+                setStatus('error', 'Authenticate before entering onboarding.');
+                return;
+            }
+            if (!state.chooserVisible) {
+                setStatus('error', 'Continue into the selected program before choosing an onboarding path.');
+                return;
+            }
+
+            const context = createOnboardingContext(state.selectedProgram, {
+                source,
+                artifact: intake.artifact || null,
+                artifactBatch: intake.artifactBatch || null
+            });
+            persistOnboardingContext(context);
+            global.location.href = `${onboardingUrl}?source=${encodeURIComponent(source)}&program=${encodeURIComponent(context.id || '')}`;
+        }
+
+        function handleScreenshotSelection(files, mode) {
+            const artifactBatch = buildScreenshotArtifactBatch(files, {
+                mode
+            });
+
+            if (!artifactBatch.count) {
+                setStatus('error', 'Choose one or more screenshot files to continue.');
+                return;
+            }
+
+            navigateToOnboarding('screenshot', { artifactBatch });
+        }
+
+        renderProgramList();
+
+        elements.authForm?.addEventListener('submit', (event) => {
+            event.preventDefault();
+            handleCredentialSubmit('signin');
+        });
+
+        global.document.getElementById('programShellCreateAccountButton')?.addEventListener('click', () => {
+            handleCredentialSubmit('create');
+        });
+
+        elements.previewButton?.addEventListener('click', activatePreviewMode);
+        elements.switchAccountButton?.addEventListener('click', async () => {
+            state.previewMode = false;
+            try {
+                await authService?.signOut?.();
+            } catch (error) {
+                // Ignore sign-out failures during shell switching.
+            }
+            state.session = null;
+            elements.password.value = '';
+            setStatus('info', 'Signed out. Choose another account to continue.');
+            updateUi();
+        });
+        elements.continueButton?.addEventListener('click', handleContinue);
+        elements.backButton?.addEventListener('click', () => {
+            resetChooserDetails();
+            setStatus('info', 'Choose a different program or continue into onboarding when ready.');
+            updateUi();
+        });
+        elements.manualButton?.addEventListener('click', () => {
+            navigateToOnboarding('manual', null);
+        });
+        elements.spreadsheetButton?.addEventListener('click', () => {
+            elements.spreadsheetInput?.click();
+        });
+        elements.screenshotDirectoryButton?.addEventListener('click', () => {
+            elements.screenshotDirectoryInput?.click();
+        });
+        elements.screenshotButton?.addEventListener('click', () => {
+            elements.screenshotInput?.click();
+        });
+        elements.spreadsheetInput?.addEventListener('change', (event) => {
+            const file = event.target?.files?.[0];
+            if (!file) return;
+            navigateToOnboarding('spreadsheet', {
+                artifact: {
+                    name: file.name,
+                    size: file.size,
+                    type: file.type,
+                    capturedAt: new Date().toISOString()
+                }
+            });
+        });
+        elements.screenshotDirectoryInput?.addEventListener('change', (event) => {
+            const files = Array.from(event.target?.files || []);
+            if (!files.length) return;
+            handleScreenshotSelection(files, 'directory');
+        });
+        elements.screenshotInput?.addEventListener('change', (event) => {
+            const files = Array.from(event.target?.files || []);
+            if (!files.length) return;
+            handleScreenshotSelection(files, 'files');
+        });
+
+        if (authService && typeof authService.onAuthStateChange === 'function') {
+            try {
+                authService.onAuthStateChange(() => {
+                    refreshSessionFromAuth().catch(() => {});
+                });
+            } catch (error) {
+                // Ignore auth state subscription failures.
+            }
+        }
+
+        overlay.hidden = false;
+        setStatus('info', state.selectedProgram
+            ? `${formatProgramLabel(state.selectedProgram)} selected. Authenticate to continue.`
+            : 'Welcome to Program Command. Choose a program to begin.');
+
+        return refreshSessionFromAuth();
+    }
+
+    const api = {
+        SHELL_SELECTION_STORAGE_KEY,
+        ONBOARDING_CONTEXT_STORAGE_KEY,
+        DEFAULT_PROGRAM_GROUPS,
+        flattenPrograms,
+        findProgramById,
+        buildSuggestedIdentity,
+        createProgramSelection,
+        buildScreenshotArtifactBatch,
+        createOnboardingContext,
+        detectProgramData,
+        readSelection,
+        persistSelection,
+        readOnboardingContext,
+        persistOnboardingContext,
+        clearOnboardingContext,
+        bootstrap
+    };
+
+    global.ProgramCommandShell = api;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/audit-runtime-dependencies.test.js
+++ b/tests/audit-runtime-dependencies.test.js
@@ -1,0 +1,113 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const scriptPath = path.join(repoRoot, 'scripts', 'audit-runtime-dependencies.js');
+const inventoryDocPath = path.join(repoRoot, 'docs', 'audits', 'production-surface-inventory.md');
+const readmePath = path.join(repoRoot, 'docs', 'audits', 'README.md');
+const evidenceModelPath = path.join(repoRoot, 'docs', 'audits', 'audit-evidence-model.md');
+
+function runScan(targets = []) {
+    const args = [scriptPath, ...targets];
+    const output = execFileSync('node', args, {
+        cwd: repoRoot,
+        encoding: 'utf8'
+    });
+
+    return JSON.parse(output);
+}
+
+describe('audit runtime dependency scanner', () => {
+    let tempDir;
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-runtime-deps-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('reports local static data fetches, localStorage usage, fallback markers, and design defaults', () => {
+        const flaggedFile = path.join(tempDir, 'flagged.js');
+        fs.writeFileSync(flaggedFile, [
+            "const CURRENT_DEPARTMENT_CODE = 'DESN';",
+            "const defaultProfile = 'design-v1';",
+            "const raw = localStorage.getItem('draft');",
+            "const response = await fetch('../data/course-catalog.json');",
+            "console.warn('Using embedded fallback profile because no profile file could be loaded.');"
+        ].join('\n'));
+
+        const report = runScan([flaggedFile]);
+        const fileResult = report.files[0];
+
+        expect(report.summary.filesScanned).toBe(1);
+        expect(report.summary.counts.localJsonFetches).toBe(1);
+        expect(report.summary.counts.localStorageUsages).toBe(1);
+        expect(report.summary.counts.fallbackMarkers).toBeGreaterThanOrEqual(1);
+        expect(report.summary.counts.designDefaults).toBeGreaterThanOrEqual(2);
+        expect(fileResult.path).toBe(flaggedFile);
+        expect(fileResult.matches.localJsonFetches[0]).toMatchObject({
+            line: 4,
+            detail: '../data/course-catalog.json'
+        });
+        expect(fileResult.matches.localStorageUsages[0]).toMatchObject({ line: 3 });
+    });
+
+    test('returns empty match sets for files without flagged patterns', () => {
+        const cleanFile = path.join(tempDir, 'clean.js');
+        fs.writeFileSync(cleanFile, [
+            'function add(a, b) {',
+            '  return a + b;',
+            '}'
+        ].join('\n'));
+
+        const report = runScan([cleanFile]);
+        const fileResult = report.files[0];
+
+        expect(report.summary.filesScanned).toBe(1);
+        expect(report.summary.filesWithMatches).toBe(0);
+        expect(fileResult.matches).toEqual({
+            localJsonFetches: [],
+            localStorageUsages: [],
+            fallbackMarkers: [],
+            designDefaults: []
+        });
+    });
+
+    test('reports missing targets as explicit failures', () => {
+        const missingFile = path.join(tempDir, 'missing.js');
+        const report = runScan([missingFile]);
+
+        expect(report.files).toHaveLength(0);
+        expect(report.failures).toHaveLength(1);
+        expect(report.failures[0]).toMatchObject({
+            path: missingFile,
+            code: 'ENOENT'
+        });
+    });
+});
+
+describe('audit docs alignment', () => {
+    test('inventory doc lists every default scan target', () => {
+        const report = runScan();
+        const inventoryDoc = fs.readFileSync(inventoryDocPath, 'utf8');
+
+        expect(report.targetsUsed.length).toBeGreaterThan(0);
+        report.targetsUsed.forEach((target) => {
+            expect(inventoryDoc).toContain(`- \`${target}\``);
+        });
+    });
+
+    test('audit docs establish the readiness-audit workspace and evidence model', () => {
+        const readme = fs.readFileSync(readmePath, 'utf8');
+        const evidenceModel = fs.readFileSync(evidenceModelPath, 'utf8');
+
+        expect(readme).toContain('The audit is organized around four readiness pillars');
+        expect(readme).toContain('production-surface-inventory.md');
+        expect(evidenceModel).toContain('## Finding Record');
+        expect(evidenceModel).toContain('Unknowns are allowed in pillar audits. They are not allowed in a passed release gate.');
+    });
+});

--- a/tests/constraints-dashboard.canonical-data.test.js
+++ b/tests/constraints-dashboard.canonical-data.test.js
@@ -1,0 +1,193 @@
+describe('constraints dashboard canonical data adapters', () => {
+    let dashboard;
+    let originalAddEventListener;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        document.body.innerHTML = '<div id="runtimeDataSourceBanner" hidden></div>';
+        originalAddEventListener = document.addEventListener;
+        document.addEventListener = jest.fn((eventName, handler, options) => {
+            if (eventName === 'DOMContentLoaded') {
+                return;
+            }
+            return originalAddEventListener.call(document, eventName, handler, options);
+        });
+
+        dashboard = require('../pages/constraints-dashboard.js');
+    });
+
+    afterEach(() => {
+        document.addEventListener = originalAddEventListener;
+    });
+
+    test('builds canonical dashboard rules from database-backed records', () => {
+        const rules = dashboard.buildDashboardRulesFromCanonicalData({
+            courses: [
+                {
+                    id: 'course-1',
+                    code: 'DESN 301',
+                    title: 'Visual Storytelling',
+                    allowed_rooms: ['212'],
+                    preferred_times: ['afternoon'],
+                    preferred_days: ['TR'],
+                    room_constraint_hard: true,
+                    time_constraint_hard: false,
+                    is_case_by_case: true
+                },
+                {
+                    id: 'course-2',
+                    code: 'DESN 200',
+                    title: 'Visual Thinking',
+                    allowed_rooms: null,
+                    preferred_times: ['morning', 'afternoon', 'evening'],
+                    preferred_days: ['MW', 'TR'],
+                    room_constraint_hard: false,
+                    time_constraint_hard: false,
+                    is_case_by_case: false
+                }
+            ],
+            faculty: [
+                { id: 'faculty-1', name: 'M. Lybbert' }
+            ],
+            rooms: [
+                {
+                    id: 'room-1',
+                    room_code: '207',
+                    name: '207 Media Lab',
+                    exclude_from_grid: true
+                }
+            ],
+            constraints: [
+                {
+                    id: 'constraint-campus',
+                    constraint_type: 'campus_transition',
+                    enabled: true,
+                    description: 'Travel between campuses',
+                    rule_details: {
+                        min_gap_hours: 0.5
+                    }
+                },
+                {
+                    id: 'constraint-evening',
+                    constraint_type: 'evening_safety',
+                    enabled: true,
+                    description: 'Evening staffing',
+                    rule_details: {
+                        min_instructors: 2,
+                        time_after: '16:00'
+                    }
+                },
+                {
+                    id: 'constraint-room',
+                    constraint_type: 'room_restriction',
+                    enabled: true,
+                    description: 'Room 212 restriction',
+                    rule_details: {
+                        room: '212',
+                        allowed_courses: ['DESN 301']
+                    }
+                }
+            ],
+            facultyPreferences: [
+                {
+                    id: 'pref-1',
+                    faculty_id: 'faculty-1',
+                    time_preferred: ['morning'],
+                    time_blocked: ['evening'],
+                    day_preferred: ['MW'],
+                    day_blocked: ['TR'],
+                    campus_assignment: 'cheney',
+                    qualified_courses: ['DESN 301'],
+                    notes: 'Prefers early studio blocks'
+                }
+            ]
+        });
+
+        expect(rules.courseConstraints).toEqual([
+            expect.objectContaining({
+                courseId: 'course-1',
+                code: 'DESN 301',
+                allowedRooms: ['212'],
+                preferredTimes: ['afternoon'],
+                preferredDays: ['TR'],
+                roomConstraintHard: true
+            })
+        ]);
+
+        expect(rules.facultyConstraints).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 'constraint-campus',
+                    rule: 'no-back-to-back-different-campus',
+                    bufferMinutes: 30
+                }),
+                expect.objectContaining({
+                    id: 'constraint-evening',
+                    rule: 'minimum-instructors-evening',
+                    minimumCount: 2
+                })
+            ])
+        );
+
+        expect(rules.roomConstraints).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 'room-room-1',
+                    type: 'exclude-from-grid',
+                    room: '207'
+                }),
+                expect.objectContaining({
+                    id: 'constraint-room',
+                    type: 'room-assignment',
+                    room: '212',
+                    allowedCourses: ['DESN 301']
+                })
+            ])
+        );
+
+        expect(rules.facultyPreferences).toEqual([
+            expect.objectContaining({
+                facultyId: 'faculty-1',
+                faculty: 'M. Lybbert',
+                campusAssignment: 'cheney',
+                qualifiedCourses: ['DESN 301']
+            })
+        ]);
+
+        expect(rules.caseByCase.courses).toEqual(['DESN 301']);
+    });
+
+    test('renders success and warning data-source banners', () => {
+        dashboard.__setRuntimeDataSourcesForTests({
+            constraints: {
+                label: 'Constraints',
+                canonical: false
+            }
+        });
+
+        const banner = document.getElementById('runtimeDataSourceBanner');
+        let summary = dashboard.__getRuntimeDataSourceSummaryForTests();
+
+        expect(summary.hasFallbacks).toBe(true);
+        expect(banner.hidden).toBe(false);
+        expect(banner.className).toContain('runtime-source-banner-warning');
+
+        dashboard.__setRuntimeDataSourcesForTests({
+            courses: {
+                label: 'Courses',
+                canonical: true
+            },
+            rooms: {
+                label: 'Rooms',
+                canonical: true
+            }
+        });
+
+        summary = dashboard.__getRuntimeDataSourceSummaryForTests();
+
+        expect(summary.hasFallbacks).toBe(false);
+        expect(summary.canonicalCount).toBe(2);
+        expect(banner.className).toContain('runtime-source-banner-success');
+    });
+});

--- a/tests/constraints-engine.runtime-rules.test.js
+++ b/tests/constraints-engine.runtime-rules.test.js
@@ -1,0 +1,51 @@
+const ConstraintsEngine = require('../js/constraints-engine.js');
+
+describe('ConstraintsEngine runtime rule input', () => {
+    test('accepts a prebuilt rules object and derives rooms from campus data', async () => {
+        const initialized = await ConstraintsEngine.init({
+            courseConstraints: [],
+            facultyConstraints: [
+                {
+                    id: 'evening-safety',
+                    enabled: true,
+                    rule: 'minimum-instructors-evening',
+                    minimumCount: 2,
+                    afterTime: '16:00'
+                }
+            ],
+            roomConstraints: [
+                {
+                    id: 'exclude-207',
+                    room: '207',
+                    type: 'exclude-from-grid',
+                    enabled: true
+                }
+            ],
+            campuses: {
+                catalyst: {
+                    name: 'Catalyst (Spokane)',
+                    rooms: [
+                        { id: '206' },
+                        { id: '207' },
+                        { id: '209' }
+                    ]
+                },
+                cheney: {
+                    name: 'Cheney (Main Campus)',
+                    rooms: ['CEB 102']
+                }
+            }
+        });
+
+        expect(initialized).toBe(true);
+        expect(ConstraintsEngine.getAvailableRooms()).toEqual(['206', '209', 'CEB 102']);
+        expect(ConstraintsEngine.getCampusForRoom('CEB 102')).toBe('cheney');
+        expect(ConstraintsEngine.getConstraintById('exclude-207')).toEqual(
+            expect.objectContaining({
+                id: 'exclude-207',
+                room: '207',
+                type: 'exclude-from-grid'
+            })
+        );
+    });
+});

--- a/tests/course-management.intent.test.js
+++ b/tests/course-management.intent.test.js
@@ -1,0 +1,34 @@
+describe('course management URL intents', () => {
+    let courseManagement;
+    let originalAddEventListener;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        originalAddEventListener = document.addEventListener;
+        document.addEventListener = jest.fn((eventName, handler, options) => {
+            if (eventName === 'DOMContentLoaded') {
+                return;
+            }
+            return originalAddEventListener.call(document, eventName, handler, options);
+        });
+
+        courseManagement = require('../pages/course-management.js');
+    });
+
+    afterEach(() => {
+        document.addEventListener = originalAddEventListener;
+    });
+
+    test('parses deep-link intents for course editing and add mode', () => {
+        expect(courseManagement.resolveCourseManagementIntent('?courseId=course-123')).toEqual({
+            action: '',
+            courseId: 'course-123'
+        });
+
+        expect(courseManagement.resolveCourseManagementIntent('?action=add')).toEqual({
+            action: 'add',
+            courseId: ''
+        });
+    });
+});

--- a/tests/data-truth-audit-doc.test.js
+++ b/tests/data-truth-audit-doc.test.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readDoc(relativePath) {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('data truth audit docs', () => {
+    test('defines all required source classes and surface decisions', () => {
+        const auditDoc = readDoc('docs/audits/data-truth-audit.md');
+
+        expect(auditDoc).toContain('`canonical-db-backed`');
+        expect(auditDoc).toContain('`acceptable-local-draft-state`');
+        expect(auditDoc).toContain('`legacy-fallback`');
+        expect(auditDoc).toContain('`unknown-or-mixed`');
+        expect(auditDoc).toContain('Main scheduler (`index.html`)');
+        expect(auditDoc).toContain('Schedule builder (`pages/schedule-builder.js`)');
+        expect(auditDoc).toContain('Department onboarding and profile runtime');
+    });
+
+    test('captures data-truth gate implications and proof requirements', () => {
+        const auditDoc = readDoc('docs/audits/data-truth-audit.md');
+
+        expect(auditDoc).toContain('## Gate Implications');
+        expect(auditDoc).toContain('## Proof Required To Pass');
+        expect(auditDoc).toContain('DTR-001');
+        expect(auditDoc).toContain('Blocks multi-department');
+    });
+
+    test('policy distinguishes allowed draft state from disallowed production fallback behavior', () => {
+        const policyDoc = readDoc('docs/audits/production-source-of-truth-policy.md');
+
+        expect(policyDoc).toContain('## Allowed Runtime Patterns');
+        expect(policyDoc).toContain('## Disallowed Runtime Patterns On Release-Gated Surfaces');
+        expect(policyDoc).toContain('## Local Draft State Rule');
+        expect(policyDoc).toContain('Embedded fallback production data in runtime code');
+        expect(policyDoc).toContain('Local draft state for unsaved edits');
+    });
+
+    test('existing verification docs now point back to the source-of-truth audit story', () => {
+        const freshnessDoc = readDoc('docs/dev-data-freshness.md');
+        const saveContractDoc = readDoc('docs/scheduler-save-contract.md');
+
+        expect(freshnessDoc).toContain('docs/audits/data-truth-audit.md');
+        expect(freshnessDoc).toContain('docs/audits/production-source-of-truth-policy.md');
+        expect(saveContractDoc).toContain('Persisted saved schedule state is canonical');
+        expect(saveContractDoc).toContain('Local draft state may exist for in-progress editing');
+    });
+});

--- a/tests/db-service.academic-year-read.test.js
+++ b/tests/db-service.academic-year-read.test.js
@@ -1,0 +1,66 @@
+const dbService = require('../js/db-service.js');
+
+describe('dbService academic year read path', () => {
+    function resetServiceState() {
+        dbService.departmentId = null;
+        dbService.departmentIdentity = null;
+        dbService.departmentIdByCode = {};
+        dbService.initialized = false;
+        dbService.resetRuntimeSourceStatus();
+    }
+
+    beforeEach(() => {
+        resetServiceState();
+        global.isSupabaseConfigured = jest.fn(() => true);
+        global.getActiveDepartmentIdentity = jest.fn(() => ({
+            code: 'DESN',
+            name: 'Design',
+            displayName: 'EWU Design'
+        }));
+    });
+
+    afterEach(() => {
+        resetServiceState();
+        delete global.isSupabaseConfigured;
+        delete global.getActiveDepartmentIdentity;
+        delete global.getSupabaseClient;
+    });
+
+    test('getAcademicYear reads without creating a missing year row', async () => {
+        const insertSpy = jest.fn();
+        const maybeSingle = jest
+            .fn()
+            .mockResolvedValueOnce({ data: { id: 'dept-1' }, error: null })
+            .mockResolvedValueOnce({ data: { id: 'year-1', year: '2025-26' }, error: null });
+
+        global.getSupabaseClient = jest.fn(() => ({
+            from: jest.fn((table) => {
+                if (table === 'departments') {
+                    return {
+                        select: jest.fn(() => ({
+                            eq: jest.fn(() => ({ single: maybeSingle }))
+                        }))
+                    };
+                }
+
+                if (table === 'academic_years') {
+                    return {
+                        select: jest.fn(() => ({
+                            eq: jest.fn(() => ({
+                                eq: jest.fn(() => ({ maybeSingle }))
+                            }))
+                        })),
+                        insert: insertSpy
+                    };
+                }
+
+                throw new Error(`Unexpected table ${table}`);
+            })
+        }));
+
+        const year = await dbService.getAcademicYear('2025-26');
+
+        expect(year).toEqual({ id: 'year-1', year: '2025-26' });
+        expect(insertSpy).not.toHaveBeenCalled();
+    });
+});

--- a/tests/db-service.department-scoping.test.js
+++ b/tests/db-service.department-scoping.test.js
@@ -1,0 +1,121 @@
+const dbService = require('../js/db-service.js');
+
+describe('dbService department scoping', () => {
+    function resetServiceState() {
+        dbService.departmentId = null;
+        dbService.departmentIdentity = null;
+        dbService.departmentIdByCode = {};
+        dbService.initialized = false;
+        dbService.resetRuntimeSourceStatus();
+    }
+
+    function createDepartmentClient({ selectResponses = [], insertResponses = [] } = {}) {
+        const eqCalls = [];
+        const insertCalls = [];
+        const selectSingle = jest.fn(() => Promise.resolve(selectResponses.shift() || { data: null, error: null }));
+        const insertSingle = jest.fn(() => Promise.resolve(insertResponses.shift() || { data: null, error: null }));
+        const client = {
+            from: jest.fn((table) => {
+                if (table !== 'departments') {
+                    throw new Error(`Unexpected table ${table}`);
+                }
+                return {
+                    select: jest.fn(() => ({
+                        eq: jest.fn((field, value) => {
+                            eqCalls.push({ field, value });
+                            return { single: selectSingle };
+                        })
+                    })),
+                    insert: jest.fn((payload) => {
+                        insertCalls.push(payload);
+                        return {
+                            select: jest.fn(() => ({ single: insertSingle }))
+                        };
+                    })
+                };
+            })
+        };
+
+        return { client, eqCalls, insertCalls };
+    }
+
+    beforeEach(() => {
+        resetServiceState();
+        delete global.__PROGRAM_COMMAND_ACTIVE_PROFILE__;
+        global.isSupabaseConfigured = jest.fn(() => true);
+    });
+
+    afterEach(() => {
+        resetServiceState();
+        delete global.isSupabaseConfigured;
+        delete global.getSupabaseClient;
+        delete global.__PROGRAM_COMMAND_ACTIVE_PROFILE__;
+    });
+
+    test('creates missing departments using the active profile identity', async () => {
+        const { client, eqCalls, insertCalls } = createDepartmentClient({
+            selectResponses: [{ data: null, error: { code: 'PGRST116' } }],
+            insertResponses: [{ data: { id: 'dept-itds' }, error: null }]
+        });
+
+        global.getSupabaseClient = jest.fn(() => client);
+        global.getActiveDepartmentIdentity = jest.fn(() => ({
+            code: 'ITDS',
+            name: 'Interactive Technology + Design',
+            displayName: 'EWU ITDS'
+        }));
+
+        const departmentId = await dbService.initialize();
+
+        expect(departmentId).toBe('dept-itds');
+        expect(eqCalls).toEqual([{ field: 'code', value: 'ITDS' }]);
+        expect(insertCalls).toEqual([{ code: 'ITDS', name: 'Interactive Technology + Design' }]);
+        expect(dbService.departmentIdentity).toEqual({
+            code: 'ITDS',
+            name: 'Interactive Technology + Design',
+            displayName: 'EWU ITDS'
+        });
+    });
+
+    test('caches department ids per code and switches when the active profile changes', async () => {
+        const { client, eqCalls } = createDepartmentClient({
+            selectResponses: [
+                { data: { id: 'dept-itds' }, error: null },
+                { data: { id: 'dept-design' }, error: null }
+            ]
+        });
+
+        global.getSupabaseClient = jest.fn(() => client);
+        global.getActiveDepartmentIdentity = jest
+            .fn()
+            .mockReturnValueOnce({
+                code: 'ITDS',
+                name: 'Interactive Technology + Design',
+                displayName: 'EWU ITDS'
+            })
+            .mockReturnValueOnce({
+                code: 'DESN',
+                name: 'Design',
+                displayName: 'EWU Design'
+            })
+            .mockReturnValueOnce({
+                code: 'ITDS',
+                name: 'Interactive Technology + Design',
+                displayName: 'EWU ITDS'
+            });
+
+        const first = await dbService.initialize();
+        dbService.initialized = false;
+        const second = await dbService.initialize();
+        dbService.initialized = false;
+        const third = await dbService.initialize();
+
+        expect(first).toBe('dept-itds');
+        expect(second).toBe('dept-design');
+        expect(third).toBe('dept-itds');
+        expect(eqCalls).toEqual([
+            { field: 'code', value: 'ITDS' },
+            { field: 'code', value: 'DESN' }
+        ]);
+    });
+});

--- a/tests/db-service.source-status.test.js
+++ b/tests/db-service.source-status.test.js
@@ -1,0 +1,151 @@
+const dbService = require('../js/db-service.js');
+
+describe('dbService runtime source status', () => {
+    function resetServiceState() {
+        dbService.departmentId = null;
+        dbService.departmentIdentity = null;
+        dbService.departmentIdByCode = {};
+        dbService.initialized = false;
+        dbService.initializationPromise = null;
+        dbService.resetRuntimeSourceStatus();
+    }
+
+    beforeEach(() => {
+        resetServiceState();
+        delete global.__PROGRAM_COMMAND_ACTIVE_PROFILE__;
+    });
+
+    afterEach(() => {
+        resetServiceState();
+        delete global.fetch;
+        delete global.getSupabaseClient;
+        delete global.getActiveDepartmentIdentity;
+        delete global.isSupabaseConfigured;
+        delete global.__PROGRAM_COMMAND_ACTIVE_PROFILE__;
+    });
+
+    test('records local fallback status when courses come from JSON', async () => {
+        global.isSupabaseConfigured = jest.fn(() => false);
+        global.fetch = jest.fn(async () => ({
+            json: async () => ({
+                courses: [
+                    { code: 'DESN 101', title: 'Intro to Design' },
+                    { code: 'DESN 201', title: 'Typography' }
+                ]
+            })
+        }));
+
+        const courses = await dbService.getCourses();
+        const snapshot = dbService.getRuntimeSourceStatus();
+
+        expect(courses).toHaveLength(2);
+        expect(snapshot.supabaseConfigured).toBe(false);
+        expect(snapshot.entries.courses).toEqual({
+            key: 'courses',
+            label: 'Courses',
+            source: 'local-file',
+            canonical: false,
+            fallback: true,
+            detail: '../data/course-catalog.json',
+            count: 2,
+            message: 'Courses are loading from the local course catalog fallback because Supabase is not configured.'
+        });
+    });
+
+    test('records canonical database status when courses load from Supabase', async () => {
+        global.isSupabaseConfigured = jest.fn(() => true);
+        global.getActiveDepartmentIdentity = jest.fn(() => ({
+            code: 'ITDS',
+            name: 'Interactive Technology + Design',
+            displayName: 'EWU ITDS'
+        }));
+
+        const departmentSingle = jest.fn(async () => ({ data: { id: 'dept-itds' }, error: null }));
+        const courseOrder = jest.fn(async () => ({
+            data: [{ id: 'course-1', code: 'ITDS 101', title: 'Foundations' }],
+            error: null
+        }));
+
+        global.getSupabaseClient = jest.fn(() => ({
+            from: jest.fn((table) => {
+                if (table === 'departments') {
+                    return {
+                        select: jest.fn(() => ({
+                            eq: jest.fn(() => ({ single: departmentSingle }))
+                        }))
+                    };
+                }
+
+                if (table === 'courses') {
+                    return {
+                        select: jest.fn(() => ({
+                            eq: jest.fn(() => ({ order: courseOrder }))
+                        }))
+                    };
+                }
+
+                throw new Error(`Unexpected table ${table}`);
+            })
+        }));
+
+        const courses = await dbService.getCourses();
+        const snapshot = dbService.getRuntimeSourceStatus();
+
+        expect(courses).toHaveLength(1);
+        expect(snapshot.supabaseConfigured).toBe(true);
+        expect(snapshot.department).toEqual({
+            code: 'ITDS',
+            name: 'Interactive Technology + Design',
+            displayName: 'EWU ITDS'
+        });
+        expect(snapshot.entries.courses).toEqual({
+            key: 'courses',
+            label: 'Courses',
+            source: 'database',
+            canonical: true,
+            fallback: false,
+            detail: 'courses',
+            count: 1,
+            message: 'Courses loaded from the canonical Supabase courses table.'
+        });
+    });
+
+    test('deduplicates concurrent initialize calls against the same department lookup', async () => {
+        global.isSupabaseConfigured = jest.fn(() => true);
+        global.getActiveDepartmentIdentity = jest.fn(() => ({
+            code: 'DESN',
+            name: 'Design',
+            displayName: 'EWU Design'
+        }));
+
+        let resolveDepartment;
+        const departmentSingle = jest.fn(() => new Promise((resolve) => {
+            resolveDepartment = () => resolve({ data: { id: 'dept-1' }, error: null });
+        }));
+
+        global.getSupabaseClient = jest.fn(() => ({
+            from: jest.fn((table) => {
+                if (table !== 'departments') {
+                    throw new Error(`Unexpected table ${table}`);
+                }
+
+                return {
+                    select: jest.fn(() => ({
+                        eq: jest.fn(() => ({ single: departmentSingle }))
+                    }))
+                };
+            })
+        }));
+
+        const first = dbService.initialize();
+        const second = dbService.initialize();
+
+        expect(departmentSingle).toHaveBeenCalledTimes(1);
+
+        resolveDepartment();
+        await Promise.all([first, second]);
+
+        expect(dbService.departmentId).toBe('dept-1');
+        expect(dbService.initializationPromise).toBeNull();
+    });
+});

--- a/tests/multi-department-release-gate-doc.test.js
+++ b/tests/multi-department-release-gate-doc.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readDoc(relativePath) {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('multi-department release gate docs', () => {
+    test('operational confidence audit identifies the missing release-decision system', () => {
+        const auditDoc = readDoc('docs/audits/operational-confidence-audit.md');
+
+        expect(auditDoc).toContain('## Current Strengths');
+        expect(auditDoc).toContain('## Current Gaps');
+        expect(auditDoc).toContain('OCA-001');
+        expect(auditDoc).toContain('Operational Confidence Pass Conditions');
+    });
+
+    test('release gate defines four pillars, statuses, and proof requirements', () => {
+        const gateDoc = readDoc('docs/audits/multi-department-release-gate.md');
+
+        expect(gateDoc).toContain('## Decision Rule');
+        expect(gateDoc).toContain('The decision owner is the user as the sole builder');
+        expect(gateDoc).toContain('## Gate Status Model');
+        expect(gateDoc).toContain('| Data truth |');
+        expect(gateDoc).toContain('| Product consistency |');
+        expect(gateDoc).toContain('| Platformization |');
+        expect(gateDoc).toContain('| Operational confidence |');
+        expect(gateDoc).toContain('## Gate Board');
+        expect(gateDoc).toContain('## Override Rule');
+    });
+
+    test('freshness doc now explains its place in the release-gate evidence model', () => {
+        const freshnessDoc = readDoc('docs/dev-data-freshness.md');
+
+        expect(freshnessDoc).toContain('For the multi-department release gate');
+        expect(freshnessDoc).toContain('docs/audits/multi-department-release-gate.md');
+    });
+});

--- a/tests/platformization-audit-doc.test.js
+++ b/tests/platformization-audit-doc.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readDoc(relativePath) {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('platformization audit docs', () => {
+    test('audit describes the hybrid platform state and key blocking areas', () => {
+        const auditDoc = readDoc('docs/audits/platformization-audit.md');
+
+        expect(auditDoc).toContain('## Current Hybrid Platform State');
+        expect(auditDoc).toContain('Design-seeded defaults');
+        expect(auditDoc).toContain('Local profile activation model');
+        expect(auditDoc).toContain('Program-aware runtime path');
+        expect(auditDoc).toContain('PTA-001');
+    });
+
+    test('blocker doc stays short and focused on phase-2 entry blockers', () => {
+        const blockersDoc = readDoc('docs/audits/multi-department-blockers.md');
+
+        expect(blockersDoc).toContain('## Blocking Categories');
+        expect(blockersDoc).toContain('Canonical Runtime Identity');
+        expect(blockersDoc).toContain('Canonical Profile Source');
+        expect(blockersDoc).toContain('Phase 2 cannot begin while any blocker above remains unresolved');
+    });
+
+    test('profile schema and onboarding qa pack now acknowledge the transitional hybrid state', () => {
+        const profileSchemaDoc = readDoc('docs/department-profile-schema-v1.md');
+        const onboardingQaDoc = readDoc('docs/department-onboarding-qa-pack.md');
+
+        expect(profileSchemaDoc).toContain('## Current Runtime Position');
+        expect(profileSchemaDoc).toContain('Release-Gate Implication');
+        expect(onboardingQaDoc).toContain('## Current Status');
+        expect(onboardingQaDoc).toContain('### Preconditions');
+        expect(onboardingQaDoc).toContain('docs/audits/multi-department-release-gate.md');
+    });
+});

--- a/tests/product-consistency-audit-doc.test.js
+++ b/tests/product-consistency-audit-doc.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readDoc(relativePath) {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('product consistency audit docs', () => {
+    test('audit defines a common consistency rubric and representative surfaces', () => {
+        const auditDoc = readDoc('docs/audits/product-consistency-audit.md');
+
+        expect(auditDoc).toContain('## Consistency Rubric');
+        expect(auditDoc).toContain('Shell structure');
+        expect(auditDoc).toContain('Recommendations dashboard (`pages/recommendations-dashboard.html`)');
+        expect(auditDoc).toContain('EagleNet compare (`pages/eaglenet-compare.html`, `pages/eaglenet-compare.js`)');
+        expect(auditDoc).toContain('PCI-001');
+    });
+
+    test('baseline doc defines the shared shell direction and broader refresh trigger', () => {
+        const baselineDoc = readDoc('docs/audits/dashboard-shell-baseline.md');
+
+        expect(baselineDoc).toContain('## Baseline Candidate');
+        expect(baselineDoc).toContain('`app-header`');
+        expect(baselineDoc).toContain('`css/program-command-dashboard-theme.css`');
+        expect(baselineDoc).toContain('## Broader Refresh Trigger');
+    });
+
+    test('ui guidelines now point to the audit baseline and release-gated shell expectations', () => {
+        const uiDoc = readDoc('docs/ui/primer-product-ui-guidelines.md');
+
+        expect(uiDoc).toContain('docs/audits/product-consistency-audit.md');
+        expect(uiDoc).toContain('docs/audits/dashboard-shell-baseline.md');
+        expect(uiDoc).toContain('## Release-Gated Shell Expectations');
+        expect(uiDoc).toContain('Prefer the shared header direction');
+    });
+});

--- a/tests/production-readiness-program-doc.test.js
+++ b/tests/production-readiness-program-doc.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function readDoc(relativePath) {
+    return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+describe('production readiness program docs', () => {
+    test('program doc defines named workstreams and dependency-informed sequencing', () => {
+        const programDoc = readDoc('docs/audits/production-readiness-program.md');
+
+        expect(programDoc).toContain('## Workstreams');
+        expect(programDoc).toContain('W1. Canonical data/runtime convergence');
+        expect(programDoc).toContain('W2. Shared dashboard shell convergence');
+        expect(programDoc).toContain('W3. Canonical multi-department runtime contract');
+        expect(programDoc).toContain('W4. Release evidence and operational discipline');
+        expect(programDoc).toContain('## Recommended Sequence');
+        expect(programDoc).toContain('## Phase-2 Entry Condition');
+    });
+
+    test('program doc ties workstreams back to the audit artifacts', () => {
+        const programDoc = readDoc('docs/audits/production-readiness-program.md');
+
+        expect(programDoc).toContain('docs/audits/data-truth-audit.md');
+        expect(programDoc).toContain('docs/audits/product-consistency-audit.md');
+        expect(programDoc).toContain('docs/audits/platformization-audit.md');
+        expect(programDoc).toContain('docs/audits/multi-department-release-gate.md');
+    });
+
+    test('older audit backlog now points to the new readiness program framing', () => {
+        const backlogDoc = readDoc('docs/AUDIT-ISSUES-2026-02-21.md');
+
+        expect(backlogDoc).toContain('## Current Status In The Readiness Program');
+        expect(backlogDoc).toContain('docs/audits/production-readiness-program.md');
+        expect(backlogDoc).toContain('W1. Canonical data/runtime convergence');
+        expect(backlogDoc).toContain('W4. Release evidence and operational discipline');
+    });
+});

--- a/tests/program-shell.test.js
+++ b/tests/program-shell.test.js
@@ -1,0 +1,252 @@
+describe('ProgramCommandShell', () => {
+    let shell;
+
+    beforeEach(() => {
+        jest.resetModules();
+        localStorage.clear();
+        delete window.ProgramCommandShell;
+        shell = require('../js/program-shell.js');
+    });
+
+    afterEach(() => {
+        localStorage.clear();
+        delete window.ProgramCommandShell;
+    });
+
+    test('flattens the approved onboarding catalog including department workspaces and education sub-programs', () => {
+        const labels = shell.flattenPrograms().map((program) => program.label);
+
+        expect(labels).toHaveLength(15);
+        expect(labels).toEqual(expect.arrayContaining([
+            'Biology',
+            'Chemistry & Biochemistry',
+            'Department view',
+            'Computer Science + Cybersecurity',
+            'Computer Science',
+            'Cybersecurity',
+            'Electrical Engineering',
+            'Design',
+            'Science Education',
+            'Mathematics Education',
+            'Environmental Science',
+            'Geosciences',
+            'Mathematics',
+            'Mechanical Engineering & Technology',
+            'Physics'
+        ]));
+    });
+
+    test('resolves the seeded Design program with its embedded profile id', () => {
+        const design = shell.findProgramById('design');
+
+        expect(design).toBeTruthy();
+        expect(design.label).toBe('Design');
+        expect(design.profileId).toBe('design-v1');
+        expect(design.seededDefault).toBe(true);
+    });
+
+    test('models the CSEE department with department-wide and combined workspace entries', () => {
+        const department = shell.findProgramById('csee-department');
+        const combined = shell.findProgramById('computer-science-cybersecurity');
+
+        expect(department).toEqual(expect.objectContaining({
+            label: 'Department view',
+            departmentId: 'csee',
+            departmentLabel: 'Computer Science, Cybersecurity & Electrical Engineering',
+            workspaceKind: 'department',
+            suggestedCode: 'CSEE'
+        }));
+        expect(combined).toEqual(expect.objectContaining({
+            label: 'Computer Science + Cybersecurity',
+            workspaceKind: 'combined-programs',
+            memberProgramIds: ['computer-science', 'cybersecurity'],
+            suggestedCode: 'CSCY'
+        }));
+    });
+
+    test('creates onboarding handoff context with selection and artifact metadata', () => {
+        const program = shell.findProgramById('biology');
+        const context = shell.createOnboardingContext(program, {
+            source: 'spreadsheet',
+            artifact: {
+                name: 'biology-seed.xlsx',
+                size: 2048,
+                type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                capturedAt: '2026-03-26T16:00:00.000Z'
+            }
+        });
+
+        expect(context).toMatchObject({
+            id: 'biology',
+            label: 'Biology',
+            source: 'spreadsheet',
+            baseProfileId: 'design-v1',
+            suggestedIdentity: {
+                name: 'Biology',
+                code: 'BIOL',
+                displayName: 'EWU Biology',
+                shortName: 'Biology'
+            },
+            artifact: {
+                name: 'biology-seed.xlsx',
+                size: 2048,
+                type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                capturedAt: '2026-03-26T16:00:00.000Z'
+            }
+        });
+    });
+
+    test('creates department-aware onboarding context for combined workspaces', () => {
+        const program = shell.findProgramById('computer-science-cybersecurity');
+        const context = shell.createOnboardingContext(program, {
+            source: 'manual'
+        });
+
+        expect(context).toMatchObject({
+            id: 'computer-science-cybersecurity',
+            label: 'Computer Science + Cybersecurity',
+            departmentId: 'csee',
+            departmentLabel: 'Computer Science, Cybersecurity & Electrical Engineering',
+            workspaceKind: 'combined-programs',
+            memberProgramIds: ['computer-science', 'cybersecurity'],
+            suggestedIdentity: {
+                name: 'Computer Science + Cybersecurity',
+                code: 'CSCY',
+                displayName: 'EWU Computer Science + Cybersecurity',
+                shortName: 'CS + Cyber'
+            }
+        });
+    });
+
+    test('builds a screenshot batch manifest from nested folder metadata', () => {
+        const batch = shell.buildScreenshotArtifactBatch([
+            {
+                name: 'cscd fall 2025 1.png',
+                size: 128,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/cscd fall 2025/cscd fall 2025 1.png'
+            },
+            {
+                name: 'cscd winter 2026 2.png',
+                size: 256,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/cscd winter 2026/cscd winter 2026 2.png'
+            },
+            {
+                name: 'notes.png',
+                size: 64,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/misc/notes.png'
+            },
+            {
+                name: '.DS_Store',
+                size: 32,
+                type: '',
+                webkitRelativePath: 'cscd-cyber AY2025-26/.DS_Store'
+            }
+        ], {
+            mode: 'directory',
+            capturedAt: '2026-03-26T18:30:00.000Z'
+        });
+
+        expect(batch).toMatchObject({
+            mode: 'directory',
+            rootFolderName: 'cscd-cyber AY2025-26',
+            count: 3,
+            totalSize: 448,
+            capturedAt: '2026-03-26T18:30:00.000Z'
+        });
+        expect(batch.groups).toEqual(expect.arrayContaining([
+            expect.objectContaining({ key: 'fall-2025', label: 'Fall 2025', fileCount: 1 }),
+            expect.objectContaining({ key: 'winter-2026', label: 'Winter 2026', fileCount: 1 }),
+            expect.objectContaining({ key: 'unassigned', label: 'Unassigned', fileCount: 1 })
+        ]));
+        expect(batch.files[0]).toEqual(expect.objectContaining({
+            name: 'cscd fall 2025 1.png',
+            relativePath: 'cscd-cyber AY2025-26/cscd fall 2025/cscd fall 2025 1.png',
+            term: 'fall',
+            year: 2025
+        }));
+    });
+
+    test('creates screenshot onboarding context with grouped artifact batch metadata', () => {
+        const program = shell.findProgramById('cybersecurity');
+        const artifactBatch = shell.buildScreenshotArtifactBatch([
+            {
+                name: 'cyber fall 2025 1.png',
+                size: 200,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/cyber fall 2025/cyber fall 2025 1.png'
+            },
+            {
+                name: 'cyber spring 2026 1.png',
+                size: 220,
+                type: 'image/png',
+                webkitRelativePath: 'cscd-cyber AY2025-26/cyber spring 2026/cyber spring 2026 1.png'
+            }
+        ], {
+            mode: 'directory'
+        });
+
+        const context = shell.createOnboardingContext(program, {
+            source: 'screenshot',
+            artifactBatch
+        });
+
+        expect(context).toMatchObject({
+            id: 'cybersecurity',
+            label: 'Cybersecurity',
+            source: 'screenshot',
+            artifactBatch: expect.objectContaining({
+                mode: 'directory',
+                rootFolderName: 'cscd-cyber AY2025-26',
+                count: 2
+            })
+        });
+        expect(context.artifact).toBeNull();
+        expect(context.artifactBatch.groups).toEqual(expect.arrayContaining([
+            expect.objectContaining({ key: 'fall-2025', label: 'Fall 2025', fileCount: 1 }),
+            expect.objectContaining({ key: 'spring-2026', label: 'Spring 2026', fileCount: 1 })
+        ]));
+    });
+
+    test('detects a previously onboarded custom profile for a non-seeded program', async () => {
+        const biology = shell.findProgramById('biology');
+        const manager = {
+            getStoredProfileId: jest.fn().mockReturnValue('biology-v01'),
+            listProfiles: jest.fn().mockResolvedValue({
+                profiles: [
+                    { id: 'biology-v01', source: 'custom-local', savedAt: '2026-03-26T16:05:00.000Z' }
+                ]
+            }),
+            loadProfile: jest.fn().mockResolvedValue({
+                profile: {
+                    id: 'biology-v01',
+                    identity: {
+                        name: 'Biology',
+                        code: 'BIOL',
+                        shortName: 'Biology'
+                    },
+                    scheduler: {
+                        storageKeyPrefix: 'biolSchedulerData_'
+                    },
+                    onboardingMeta: {
+                        catalogProgramId: 'biology',
+                        catalogProgramLabel: 'Biology'
+                    }
+                }
+            })
+        };
+
+        const result = await shell.detectProgramData(biology, {
+            profileManager: manager,
+            isSupabaseConfigured: () => false
+        });
+
+        expect(result).toEqual(expect.objectContaining({
+            hasData: true,
+            profileId: 'biology-v01'
+        }));
+        expect(manager.loadProfile).toHaveBeenCalledWith('biology-v01');
+    });
+});

--- a/tests/release-time-manager.profile-scope.test.js
+++ b/tests/release-time-manager.profile-scope.test.js
@@ -1,0 +1,48 @@
+const ReleaseTimeManager = require('../js/release-time-manager.js');
+
+describe('ReleaseTimeManager profile-aware behavior', () => {
+    beforeEach(() => {
+        localStorage.clear();
+        ReleaseTimeManager.clearAll();
+        delete global.WorkloadIntegration;
+    });
+
+    afterEach(() => {
+        localStorage.clear();
+        ReleaseTimeManager.clearAll();
+        delete global.WorkloadIntegration;
+        delete global.CONSTANTS;
+    });
+
+    test('uses storage namespaces so departments do not share release-time data', () => {
+        ReleaseTimeManager.init({ storageNamespace: 'itdsSchedulerData_' });
+        ReleaseTimeManager.addAllocation('Jordan Perez', '2026-27', {
+            category: 'chair',
+            credits: 5,
+            quarters: ['Fall']
+        });
+
+        ReleaseTimeManager.init({ storageNamespace: 'designSchedulerData_' });
+        expect(ReleaseTimeManager.getAllFacultyWithReleaseTime('2026-27')).toEqual([]);
+
+        ReleaseTimeManager.init({ storageNamespace: 'itdsSchedulerData_' });
+        expect(ReleaseTimeManager.getAllFacultyWithReleaseTime('2026-27')).toHaveLength(1);
+    });
+
+    test('labels applied-learning categories from the active profile course map', () => {
+        global.WorkloadIntegration = {
+            getAppliedLearningCourses: jest.fn(() => ([
+                { code: 'ITDS 495', title: 'Internship', rate: 0.1 },
+                { code: 'ITDS 499', title: 'Independent Study', rate: 0.2 }
+            ]))
+        };
+
+        const labels = ReleaseTimeManager.getCategories().reduce((acc, category) => {
+            acc[category.id] = category.label;
+            return acc;
+        }, {});
+
+        expect(labels.independent_study).toBe('ITDS 499 / Independent Study');
+        expect(labels.applied_learning).toBe('ITDS 495 / Internship');
+    });
+});

--- a/tests/schedule-builder.database-baseline.test.js
+++ b/tests/schedule-builder.database-baseline.test.js
@@ -1,0 +1,87 @@
+describe('schedule-builder database baseline hydration', () => {
+    let builder;
+    let originalAddEventListener;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        document.body.innerHTML = '';
+        originalAddEventListener = document.addEventListener;
+        document.addEventListener = jest.fn((eventName, handler, options) => {
+            if (eventName === 'DOMContentLoaded') {
+                return;
+            }
+            return originalAddEventListener.call(document, eventName, handler, options);
+        });
+
+        builder = require('../pages/schedule-builder.js');
+    });
+
+    afterEach(() => {
+        document.addEventListener = originalAddEventListener;
+    });
+
+    test('builds quarter schedules from saved scheduled_courses rows', () => {
+        const result = builder.buildQuarterSchedulesFromDatabaseRecords([
+            {
+                quarter: 'Fall',
+                day_pattern: 'MW',
+                time_slot: '10:00-12:20',
+                section: '001',
+                projected_enrollment: 18,
+                course: {
+                    code: 'DESN 101',
+                    title: 'Design Lab',
+                    default_credits: 5
+                },
+                faculty: {
+                    name: 'Travis Masingale'
+                },
+                room: {
+                    room_code: '206'
+                }
+            },
+            {
+                quarter: 'Winter',
+                day_pattern: 'TR',
+                time_slot: '13:00-15:20',
+                section: '001',
+                projected_enrollment: 12,
+                course: {
+                    code: 'DESN 201',
+                    title: 'Typography',
+                    default_credits: 5
+                },
+                faculty: {
+                    name: 'Ginelle Hustrulid'
+                },
+                room: {
+                    room_code: '209'
+                }
+            }
+        ], '2026-27');
+
+        expect(result.totalSections).toBe(2);
+        expect(result.quarterSchedules.Fall.assignedCourses['MW-10:00-12:20-206']).toEqual([
+            expect.objectContaining({
+                courseCode: 'DESN 101',
+                facultyName: 'Travis Masingale',
+                predictedDemand: 18
+            })
+        ]);
+        expect(result.quarterSchedules.Winter.assignedCourses['TR-13:00-15:20-209']).toEqual([
+            expect.objectContaining({
+                courseCode: 'DESN 201',
+                facultyName: 'Ginelle Hustrulid',
+                predictedDemand: 12
+            })
+        ]);
+        expect(result.quarterSchedules.Fall.recommendations).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    courseCode: 'DESN 101'
+                })
+            ])
+        );
+    });
+});

--- a/tests/schedule-builder.runtime-rules.test.js
+++ b/tests/schedule-builder.runtime-rules.test.js
@@ -1,0 +1,179 @@
+describe('schedule-builder runtime rule synthesis', () => {
+    let builder;
+    let originalAddEventListener;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        document.body.innerHTML = '';
+        originalAddEventListener = document.addEventListener;
+        document.addEventListener = jest.fn((eventName, handler, options) => {
+            if (eventName === 'DOMContentLoaded') {
+                return;
+            }
+            return originalAddEventListener.call(document, eventName, handler, options);
+        });
+
+        builder = require('../pages/schedule-builder.js');
+    });
+
+    afterEach(() => {
+        document.addEventListener = originalAddEventListener;
+    });
+
+    test('builds room metadata from database inventory with fallback annotations', () => {
+        const metadata = builder.buildRoomMetadataFromInventory(
+            [
+                {
+                    room_code: '206',
+                    name: '206 UX Lab',
+                    campus: 'Catalyst (Spokane)',
+                    capacity: 24,
+                    room_type: 'computer-lab',
+                    exclude_from_grid: false
+                },
+                {
+                    room_code: 'CEB 102',
+                    name: 'CEB 102',
+                    campus: 'Cheney',
+                    capacity: 24,
+                    room_type: 'computer-lab',
+                    exclude_from_grid: false
+                }
+            ],
+            {
+                campuses: {
+                    catalyst: {
+                        name: 'Catalyst (Spokane)',
+                        rooms: [
+                            {
+                                id: '206',
+                                note: 'Preferred UX space'
+                            }
+                        ]
+                    }
+                }
+            }
+        );
+
+        expect(metadata.campuses.catalyst.rooms[0]).toEqual(
+            expect.objectContaining({
+                id: '206',
+                name: '206 UX Lab',
+                note: 'Preferred UX space'
+            })
+        );
+        expect(metadata.campuses.cheney.rooms[0]).toEqual(
+            expect.objectContaining({
+                id: 'CEB 102',
+                name: 'CEB 102'
+            })
+        );
+    });
+
+    test('builds runtime constraints rules from database rooms and constraint rows', () => {
+        const runtimeRules = builder.buildRuntimeConstraintRules({
+            rooms: [
+                {
+                    room_code: '206',
+                    name: '206 UX Lab',
+                    campus: 'Catalyst (Spokane)',
+                    capacity: 24,
+                    room_type: 'computer-lab',
+                    exclude_from_grid: false
+                },
+                {
+                    room_code: '207',
+                    name: '207 Media Lab',
+                    campus: 'Catalyst (Spokane)',
+                    capacity: 24,
+                    room_type: 'flex-space',
+                    exclude_from_grid: true
+                },
+                {
+                    room_code: 'CEB 102',
+                    name: 'CEB 102',
+                    campus: 'Cheney',
+                    capacity: 24,
+                    room_type: 'computer-lab',
+                    exclude_from_grid: false
+                }
+            ],
+            constraints: [
+                {
+                    id: 'constraint-evening',
+                    constraint_type: 'evening_safety',
+                    enabled: true,
+                    rule_details: {
+                        min_instructors: 2,
+                        time_after: '16:00'
+                    }
+                },
+                {
+                    id: 'constraint-room',
+                    constraint_type: 'room_restriction',
+                    enabled: true,
+                    rule_details: {
+                        room: '212',
+                        allowed_courses: ['DESN 301', 'DESN 359']
+                    }
+                }
+            ]
+        });
+
+        expect(runtimeRules.campuses.catalyst.rooms).toEqual(['206', '207']);
+        expect(runtimeRules.campuses.cheney.rooms).toEqual(['CEB 102']);
+        expect(runtimeRules.facultyConstraints).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 'constraint-evening',
+                    rule: 'minimum-instructors-evening'
+                })
+            ])
+        );
+        expect(runtimeRules.roomConstraints).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: 'exclude-207',
+                    room: '207',
+                    type: 'exclude-from-grid'
+                }),
+                expect.objectContaining({
+                    id: 'constraint-room',
+                    room: '212',
+                    type: 'room-assignment',
+                    allowedCourses: ['DESN 301', 'DESN 359']
+                })
+            ])
+        );
+    });
+
+    test('normalizes database courses into builder catalog shape', () => {
+        const catalog = builder.buildCourseCatalogFromDbCourses([
+            {
+                code: 'ITDS 201',
+                title: 'Interaction Design',
+                default_credits: 4,
+                typical_cap: 18,
+                level: '200',
+                quarters_offered: ['Fall', 'Spring']
+            }
+        ]);
+
+        expect(catalog).toEqual({
+            courses: [
+                {
+                    code: 'ITDS 201',
+                    title: 'Interaction Design',
+                    defaultCredits: 4,
+                    typicalEnrollmentCap: 18,
+                    level: '200',
+                    offeredQuarters: ['Fall', 'Spring'],
+                    required: false,
+                    workloadMultiplier: 1,
+                    isVariable: false
+                }
+            ]
+        });
+    });
+});

--- a/tests/schedule-builder.runtime-source-banner.test.js
+++ b/tests/schedule-builder.runtime-source-banner.test.js
@@ -1,0 +1,87 @@
+describe('schedule-builder runtime source banner', () => {
+    let builder;
+    let originalAddEventListener;
+
+    beforeEach(() => {
+        jest.resetModules();
+
+        document.body.innerHTML = `
+            <div id="runtimeDataSourceBanner" hidden></div>
+        `;
+
+        originalAddEventListener = document.addEventListener;
+        document.addEventListener = jest.fn((eventName, handler, options) => {
+            if (eventName === 'DOMContentLoaded') {
+                return;
+            }
+            return originalAddEventListener.call(document, eventName, handler, options);
+        });
+
+        builder = require('../pages/schedule-builder.js');
+    });
+
+    afterEach(() => {
+        document.addEventListener = originalAddEventListener;
+    });
+
+    test('renders a warning banner when tracked inputs still use local files', () => {
+        builder.__setRuntimeDataSourcesForTests({
+            historicalWorkload: {
+                label: 'Historical workload baseline',
+                source: 'local-file',
+                canonical: false,
+                fallback: true,
+                detail: '../workload-data.json',
+                message: 'Historical workload analysis still boots from local workload JSON.'
+            },
+            courses: {
+                label: 'Courses',
+                source: 'database',
+                canonical: true,
+                fallback: false,
+                detail: 'courses',
+                message: 'Courses loaded from the canonical Supabase courses table.'
+            }
+        });
+
+        const banner = document.getElementById('runtimeDataSourceBanner');
+        const summary = builder.__getRuntimeDataSourceSummaryForTests();
+
+        expect(banner.hidden).toBe(false);
+        expect(banner.className).toContain('runtime-source-banner-warning');
+        expect(banner.textContent).toContain('still depends on local data');
+        expect(banner.textContent).toContain('Historical workload baseline');
+        expect(summary.hasFallbacks).toBe(true);
+        expect(summary.fallbackCount).toBe(1);
+    });
+
+    test('renders a success banner when tracked inputs are canonical', () => {
+        builder.__setRuntimeDataSourcesForTests({
+            courses: {
+                label: 'Courses',
+                source: 'database',
+                canonical: true,
+                fallback: false,
+                detail: 'courses',
+                message: 'Courses loaded from the canonical Supabase courses table.'
+            },
+            savedSchedule: {
+                label: 'Saved schedule',
+                source: 'database',
+                canonical: true,
+                fallback: false,
+                detail: 'scheduled_courses',
+                message: '2026-27 schedule changes are now persisted in Supabase scheduled_courses.'
+            }
+        });
+
+        const banner = document.getElementById('runtimeDataSourceBanner');
+        const summary = builder.__getRuntimeDataSourceSummaryForTests();
+
+        expect(banner.hidden).toBe(false);
+        expect(banner.className).toContain('runtime-source-banner-success');
+        expect(banner.textContent).toContain('canonical persisted sources');
+        expect(summary.hasFallbacks).toBe(false);
+        expect(summary.canonicalCount).toBe(2);
+    });
+});

--- a/tests/schedule-modules.direct-data.test.js
+++ b/tests/schedule-modules.direct-data.test.js
@@ -1,0 +1,143 @@
+const ScheduleGenerator = require('../js/schedule-generator.js');
+const DemandPredictor = require('../js/demand-predictor.js');
+
+describe('schedule modules direct data init', () => {
+    afterEach(() => {
+        delete global.fetch;
+        delete global.PrerequisiteGraph;
+    });
+
+    test('ScheduleGenerator can initialize from direct data without fetching the catalog', async () => {
+        global.fetch = jest.fn(async (url) => {
+            if (String(url).includes('workload-data')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        workloadByYear: {
+                            byYear: {}
+                        }
+                    })
+                };
+            }
+
+            if (String(url).includes('enrollment-dashboard-data')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        courseStats: {
+                            'ITDS 201': {
+                                average: 19,
+                                quarterly: {
+                                    'fall-2025': 19
+                                }
+                            }
+                        }
+                    })
+                };
+            }
+
+            throw new Error(`Unexpected fetch: ${url}`);
+        });
+
+        await ScheduleGenerator.init({
+            workloadData: {
+                workloadByYear: {
+                    byYear: {}
+                }
+            },
+            catalogData: {
+                courses: [
+                    {
+                        code: 'ITDS 201',
+                        title: 'Interaction Design',
+                        defaultCredits: 4,
+                        typicalEnrollmentCap: 18,
+                        offeredQuarters: ['Fall']
+                    }
+                ]
+            },
+            enrollmentData: {
+                courseStats: {
+                    'ITDS 201': {
+                        average: 19,
+                        quarterly: {
+                            'fall-2025': 19
+                        }
+                    }
+                }
+            }
+        });
+
+        const result = await ScheduleGenerator.generateSchedule('fall', '2026-27');
+        expect(result.recommendations).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    courseCode: 'ITDS 201',
+                    credits: 4
+                })
+            ])
+        );
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('DemandPredictor can use direct catalog data to label predictions', async () => {
+        global.fetch = jest.fn(async (url) => {
+            if (String(url).includes('enrollment-dashboard-data')) {
+                return {
+                    ok: true,
+                    json: async () => ({
+                        courseStats: {
+                            'ITDS 201': {
+                                average: 20,
+                                sections: 1,
+                                quarterly: {
+                                    'fall-2024': { total: 18 },
+                                    'fall-2025': { total: 22 }
+                                },
+                                trend: 'growing'
+                            }
+                        }
+                    })
+                };
+            }
+
+            throw new Error(`Unexpected fetch: ${url}`);
+        });
+
+        global.PrerequisiteGraph = {
+            init: jest.fn(async () => ({ success: true })),
+            calculatePipeline: jest.fn(() => ({
+                sources: [],
+                bottlenecks: []
+            })),
+            getTracksForCourse: jest.fn(() => [])
+        };
+
+        await DemandPredictor.init({
+            enrollmentData: {
+                courseStats: {
+                    'ITDS 201': {
+                        average: 20,
+                        sections: 1,
+                        quarterly: {
+                            'fall-2024': { total: 18 },
+                            'fall-2025': { total: 22 }
+                        },
+                        trend: 'growing'
+                    }
+                }
+            },
+            catalogData: [
+                {
+                    code: 'ITDS 201',
+                    title: 'Interaction Design',
+                    typicalEnrollmentCap: 18
+                }
+            ]
+        });
+
+        const result = DemandPredictor.predictCourseDemand('ITDS 201', 'Fall', '2026-27');
+        expect(result.courseName).toBe('Interaction Design');
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});

--- a/tests/validators.generic-course-code.test.js
+++ b/tests/validators.generic-course-code.test.js
@@ -1,0 +1,14 @@
+const Validators = require('../js/validators.js');
+
+describe('Validators generic course code support', () => {
+    test('accepts non-DESN department course codes without warnings', () => {
+        const result = Validators.validateCourse({
+            courseCode: 'ITDS 499',
+            credits: 5,
+            quarter: 'Fall'
+        });
+
+        expect(result.valid).toBe(true);
+        expect(result.warnings).toEqual([]);
+    });
+});


### PR DESCRIPTION
> ⚠️ **Draft / do-not-merge.** This is a quarantine branch, not a feature. 17 test suites are red because they assert against `docs/audits/*` and `scripts/audit-runtime-dependencies.js` that were never created. Merging would block the deploy gate.

## Why this exists

The working tree on `feat/header-stats-polish` (open PR #261, a focused UI change) had accumulated unrelated, **unfinished** Codex production-readiness work. This branch saves that work in version control without polluting the UI PR or breaking CI.

See **`docs/progress-handoff-2026-05-29.md`** for the full untangle summary and next steps.

## What's here

- `js/program-shell.js` — new module, not yet wired into any HTML
- 19 `tests/*.test.js`, a hardening plan, and two handoff docs

## Test status

- **Green (2):** `program-shell.test.js`, `schedule-modules.direct-data.test.js` — promotable on their own
- **Red (17):** assert against missing `docs/audits/*` + `scripts/audit-runtime-dependencies.js`

## Next steps

1. Cherry-pick the 2 green files to `main` on a small PR.
2. Either finish the readiness source (see `codex/production-readiness-audit`) so the 17 go green, or drop those tests.

Companion housekeeping PR: #262.

---

[![Compound Engineering v2.60.0](https://img.shields.io/badge/Compound_Engineering-v2.60.0-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with Claude Opus 4.8 (1M context, extended thinking) via [Claude Code](https://claude.com/claude-code)
