### PR TITLE
docs: refresh orientation layer after 2026-06-09 state audit

### DIFF
--- a/docs/ONBOARDING.html
+++ b/docs/ONBOARDING.html
@@ -78,7 +78,9 @@ npm run test:coverage</code></pre>
       <li><strong>Pages</strong> (<code>pages/*.html</code> + <code>pages/*.js</code>) —
           each dashboard pairs an HTML file with a controller JS file.
           <code>public-schedule.html</code> lives at the repo root because
-          it is the public surface.</li>
+          it is the public surface; since PR&nbsp;#256 the site root
+          (<code>index.html</code>) redirects to it, and the editing app
+          lives at <code>program-command.html</code>.</li>
       <li><strong>Shared modules</strong> (<code>js/</code>) — domain
           singletons in the IIFE pattern (<code>ScheduleManager</code>,
           <code>FacultyManager</code>, <code>ReleaseTimeManager</code>,
@@ -229,8 +231,10 @@ you ────┴─▶ short-lived branch ─▶ PR ─▶ [CI: test + onboar
       <li>Never edit any of the forbidden paths below.</li>
     </ul>
 
-    <p>Forbidden paths (Phase 1 Unit 5 will enforce this with a required,
-    non-bypassable CI check; today it is policy-only in <code>AGENTS.md</code>):</p>
+    <p>Forbidden paths (enforced since 2026-05-21 by the required
+    <code>guard-forbidden-paths</code> check —
+    <code>.github/workflows/guard-forbidden-paths.yml</code>, shipped in
+    PR&nbsp;#255 — in addition to the policy in <code>AGENTS.md</code>):</p>
 
     <ul>
       <li><code>.github/workflows/**</code> — modification <em>and</em>
@@ -243,10 +247,10 @@ you ────┴─▶ short-lived branch ─▶ PR ─▶ [CI: test + onboar
 
     <aside class="docs-callout docs-callout--warning">
       <p class="docs-callout-title">Override</p>
-      <p>When Unit 5 lands, the only override will be a human-applied PR
-      label that an agent cannot self-apply. Authorship is checked per
-      commit, not by PR author, so an agent cannot launder edits through a
-      delegated PR.</p>
+      <p>The only override is the human-applied
+      <code>allow-forbidden-paths</code> PR label, which an agent cannot
+      self-apply. Authorship is checked per commit, not by PR author, so an
+      agent cannot launder edits through a delegated PR.</p>
     </aside>
 
     <h2>Repo layout</h2>
@@ -336,7 +340,7 @@ you ────┴─▶ short-lived branch ─▶ PR ─▶ [CI: test + onboar
   </main>
 
   <footer class="docs-footer">
-    <span>Last edited: 2026-05-21</span>
+    <span>Last edited: 2026-06-09</span>
     <span><a href="./ORIENT.html">Back to ORIENT</a></span>
   </footer>
 

--- a/docs/ORIENT.html
+++ b/docs/ORIENT.html
@@ -42,7 +42,7 @@
     -->
     <p class="docs-stamp docs-stamp--stale">
       <strong>Prod state:</strong>
-      <code>prod-state-as-of: never (not yet stamped — first deploy after ORIENT lands will refresh this)</code>
+      <code>prod-state-as-of: unstamped in the repo copy — the deploy stamps only the published artifact; read the live site's ORIENT for the real value</code>
     </p>
 
     <h2>What this project is</h2>
@@ -56,18 +56,28 @@
     <table>
       <tbody>
         <tr>
+          <th scope="row">Surface</th>
+          <td>The site root serves the read-only public schedule
+              (<code>index.html</code> redirects to
+              <code>public-schedule.html</code>); the editing app lives at
+              <code>program-command.html</code>. Shipped in PRs #256–#258.</td>
+        </tr>
+        <tr>
           <th scope="row">Deploy</th>
           <td>GitHub Pages, manual <code>workflow_dispatch</code> only.
               The deploy job refuses to publish unless the deployed commit's
-              <code>test</code> + <code>onboarding</code> checks are both green.</td>
+              <code>test</code> + <code>onboarding</code> checks are both green.
+              CI does not run on push to <code>main</code> — dispatch
+              <code>ci.yml</code> on <code>main</code> first, then
+              <code>deploy-pages.yml</code>.</td>
         </tr>
         <tr>
           <th scope="row">Branch protection</th>
           <td><code>main</code> is governed by the <code>protect-main</code>
               ruleset: required checks <code>test</code> + <code>onboarding</code>
-              (strict), 1 required review, no direct push, no force-push, no
-              deletion. Repo admin is the sole bypass actor. Merged head
-              branches auto-delete.</td>
+              + <code>guard-forbidden-paths</code> (strict), 1 required review,
+              no direct push, no force-push, no deletion. Repo admin is the
+              sole bypass actor. Merged head branches auto-delete.</td>
         </tr>
         <tr>
           <th scope="row">Supabase — prod</th>
@@ -97,46 +107,90 @@
     </table>
 
     <h2>Current focus</h2>
-    <p>Phase 1 of the
+    <p>Phase 2 of the
     <a href="./plans/2026-05-15-001-refactor-forward-operating-model-plan.md">Forward Operating Model plan</a>
-    — operating model + reorientation layer. Phase 0 shipped 2026-05-19
-    (manual deploy + editor allowlist + RLS hardening). Phase 2 (rescue
-    <code>develop</code> + retarget the 8 strategic PRs) is hard-locked
-    behind Phase 1 docs.</p>
+    — rescue <code>develop</code>'s stranded forward work, then retarget or
+    close the remaining strategic PRs. Phase 0 shipped 2026-05-19 (manual
+    deploy + editor allowlist + RLS hardening). Phase 1 shipped 2026-05-21
+    (reorientation docs U6–U9 in PR&nbsp;#254; forbidden-path guard U5 in
+    PR&nbsp;#255), which unlocked Phase 2. A UI/polish wave followed on
+    <code>main</code>: public landing + current-term + year dropdown
+    (PRs&nbsp;#256–#258), schedule-first layout (#259), schedule-builder
+    audit phases A–E (#260), header/stats polish (#261), tooling hygiene
+    (#262).</p>
 
     <table>
       <thead>
         <tr><th>Unit</th><th>What</th><th>Status</th></tr>
       </thead>
       <tbody>
-        <tr><td>U6</td><td>Docs design-system variant (<code>css/docs.css</code> + shell)</td>
-            <td><span class="docs-pill docs-pill--ok">complete</span></td></tr>
-        <tr><td>U7</td><td>ORIENT compass (this file)</td>
-            <td><span class="docs-pill docs-pill--ok">complete</span></td></tr>
-        <tr><td>U8</td><td>Decision log (<code>docs/decision-log.html</code>)</td>
-            <td><span class="docs-pill docs-pill--neutral">next</span></td></tr>
-        <tr><td>U9</td><td>ONBOARDING + cold-start links from README/CLAUDE.md</td>
-            <td><span class="docs-pill docs-pill--neutral">pending</span></td></tr>
-        <tr><td>U4</td><td>Retire Replit refs (needs keep/cut call on <code>api-server.js</code>)</td>
-            <td><span class="docs-pill docs-pill--warn">deferred</span></td></tr>
         <tr><td>U3</td><td>Round out branch protection on <code>main</code></td>
             <td><span class="docs-pill docs-pill--ok">complete</span></td></tr>
-        <tr><td>U5</td><td>Forbidden-path CI guard (depends on U3)</td>
+        <tr><td>U5</td><td>Forbidden-path CI guard (<code>guard-forbidden-paths.yml</code>, PR&nbsp;#255)</td>
+            <td><span class="docs-pill docs-pill--ok">complete</span></td></tr>
+        <tr><td>U6–U9</td><td>Docs design-system variant, ORIENT, decision log, ONBOARDING (PR&nbsp;#254)</td>
+            <td><span class="docs-pill docs-pill--ok">complete</span></td></tr>
+        <tr><td>U4</td><td>Retire Replit refs (keep/cut call on <code>api-server.js</code> resolved 2026-05-21: keep)</td>
+            <td><span class="docs-pill docs-pill--warn">deferred</span></td></tr>
+        <tr><td>U10</td><td>Rescue <code>develop</code>'s forward work (characterization-first; 18 orphaned commits hold the college-command foundations)</td>
             <td><span class="docs-pill docs-pill--neutral">next</span></td></tr>
+        <tr><td>U11</td><td>Delete <code>develop</code> (irreversible; gated on verified U10)</td>
+            <td><span class="docs-pill docs-pill--neutral">pending</span></td></tr>
+        <tr><td>U12</td><td>Retarget or close the strategic PRs with logged reasons (#235 closed superseded 2026-06-09; #203/#204/#216/#219/#225/#227/#229 remain)</td>
+            <td><span class="docs-pill docs-pill--neutral">pending</span></td></tr>
       </tbody>
     </table>
 
     <h2>Next action</h2>
     <aside class="docs-callout docs-callout--note">
       <p class="docs-callout-title">Do this next</p>
-      <p>Unit 5 — the forbidden-path CI guard. Add a required,
-      non-bypassable check that fails when an agent-authored commit adds or
-      modifies <code>.github/workflows/**</code>, <code>ci.yml</code>,
-      <code>js/supabase-config.js</code>, <code>.env*</code>, or Supabase
-      policy SQL, plus the matching <code>AGENTS.md</code> rules. Test-first.
-      Phase 1 docs (U6–U9) + Replit retirement (U4) are in PR&nbsp;#254;
-      branch protection (U3) is live.</p>
+      <p>Apply <code>scripts/supabase-current-term-setting.sql</code> to the
+      prod Supabase project (idempotent; merged in PR&nbsp;#257 but never run
+      — verified missing 2026-06-09, see Pending operations below). Then
+      begin Phase 2 Unit 10: characterization-first rescue of
+      <code>develop</code> per the plan. Do not delete <code>develop</code>
+      or mass-close the strategic PRs before U10 is verified.</p>
     </aside>
+
+    <h2>Pending operations ledger</h2>
+    <table>
+      <thead>
+        <tr><th>Item</th><th>State</th><th>Where tracked</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Current-term Supabase migration
+              (<code>scripts/supabase-current-term-setting.sql</code>)</td>
+          <td><span class="docs-pill docs-pill--warn">not applied to prod</span>
+              — RPC <code>get_public_current_term</code> returned 404 on
+              2026-06-09; public page falls back to hardcoded defaults and the
+              admin term picker is dead until this runs. Verify by probing the
+              RPC for 200 after applying.</td>
+          <td>PR&nbsp;#257 body; this ledger</td>
+        </tr>
+        <tr>
+          <td>Sheets export rehost for static Pages</td>
+          <td><span class="docs-pill docs-pill--neutral">open</span> —
+              export only works in local dev (<code>api-server.js</code>).</td>
+          <td><a href="https://github.com/sicxz/program-command/issues/264">Issue #264</a></td>
+        </tr>
+        <tr>
+          <td>Path A tenant migration (program-scoped RLS)</td>
+          <td><span class="docs-pill docs-pill--warn">deferred</span> —
+              retry needs SQL hardening + end-to-end exercise on the develop
+              project + <code>user_programs</code> seed plan.</td>
+          <td><a href="./decision-log.html">Decision log, 2026-05-19</a></td>
+        </tr>
+        <tr>
+          <td><code>set_public_current_term</code> admin-only tightening</td>
+          <td><span class="docs-pill docs-pill--neutral">open</span> —
+              currently any authenticated user may call it; fold a SQL-side
+              role check in when applying the migration.</td>
+          <td><code>scripts/supabase-current-term-setting.sql</code> comment;
+              issue #185</td>
+        </tr>
+      </tbody>
+    </table>
 
     <h2>Do not touch without confirmation</h2>
     <ul>
@@ -160,14 +214,16 @@
     <h2>How to refresh this page</h2>
     <p>The <code>prod-state-as-of</code> value at the top is rewritten
     mechanically by the deploy workflow (<code>deploy-pages.yml</code>,
-    step "Stamp ORIENT prod-state marker"). The rest of this page is
-    hand-edited at decision time — when the answer to "current focus" or
-    "next action" changes, update it in the same PR that makes the change.</p>
+    step "Stamp ORIENT prod-state marker") — but only in the published
+    artifact, never in the repo copy, which is why the repo copy always
+    reads "unstamped". The rest of this page is hand-edited at decision
+    time — when the answer to "current focus" or "next action" changes,
+    update it in the same PR that makes the change.</p>
 
   </main>
 
   <footer class="docs-footer">
-    <span>Last edited: 2026-05-21</span>
+    <span>Last edited: 2026-06-09</span>
     <span><a href="./decision-log.html">Decision log →</a></span>
   </footer>
 

--- a/docs/decision-log.html
+++ b/docs/decision-log.html
@@ -43,6 +43,43 @@
 
     <article class="docs-decision">
       <header class="docs-decision-head">
+        <span class="docs-decision-date">2026-06-09</span>
+        <span class="docs-decision-title">State audit: Phase 2 declared unlocked; zombie automation killed; hotfix twins reconciled</span>
+      </header>
+      <dl>
+        <dt>Chose</dt>
+        <dd>After a full repo audit: disabled the <code>Codex Issue
+        Writer</code> scheduled workflow (105 runs, 0 successes since
+        April — it passed snake_case inputs to an action expecting
+        kebab-case and never produced one issue); declared Phase 2 of the
+        Forward Operating Model unlocked (Phase 1 finished 2026-05-21);
+        closed issue #231 and PR #235 as already-shipped — both had
+        content twins merged to <code>main</code> on 2026-03-30
+        (PRs&nbsp;#233/#236) during the dual-line hotfix era; closed #240
+        (cleanup verified, 89→36 local branches); merged #261/#262; opened
+        #264 (Sheets export rehost) to honor the 2026-05-21 commitment.</dd>
+        <dt>Why</dt>
+        <dd>The repo's recorded state had drifted from reality in both
+        directions: docs pointed at completed work as "next", while
+        finished fixes sat in open issues. Develop-vs-main comparisons must
+        check for cherry-pick twins by <em>content</em>, not SHA — the
+        hotfix-reconciliation era duplicated fixes across both lines.</dd>
+        <dt>Rejected</dt>
+        <dd>Mass-closing the remaining strategic develop PRs
+        (#203/#216/#219/#225/#227/#229) — plan Units 10–12 govern those;
+        closing before the develop rescue risks losing the college-command
+        foundations. Deleting <code>codex-issue-writer.yml</code> outright —
+        needs a forbidden-path override label; disable achieves the same
+        effect without touching workflows.</dd>
+        <dt>Note</dt>
+        <dd>The current-term migration from PR&nbsp;#257 was confirmed
+        still unapplied to prod (RPC probe 404). Tracked in ORIENT's new
+        pending-operations ledger.</dd>
+      </dl>
+    </article>
+
+    <article class="docs-decision">
+      <header class="docs-decision-head">
         <span class="docs-decision-date">2026-05-21</span>
         <span class="docs-decision-title">Branch protection: 1 required review with repo-admin bypass</span>
       </header>
@@ -292,7 +329,7 @@
   </main>
 
   <footer class="docs-footer">
-    <span>Last edited: 2026-05-21</span>
+    <span>Last edited: 2026-06-09</span>
     <span><a href="./ONBOARDING.html">Onboarding →</a></span>
   </footer>
 


### PR DESCRIPTION
## Why

The reorientation docs had been stale since 2026-05-21 and were actively misleading: ORIENT's "next action" pointed at the U5 guard that shipped the same day the docs landed (PR #255), and ONBOARDING still described the forbidden-path rules as "policy-only".

## What changed

**ORIENT.html**
- Current focus → Phase 2 (develop rescue); unit table marks U5–U9 complete, adds U10–U12 with the do-not-delete-develop-before-U10 guardrail
- Next action → apply the unapplied current-term migration, then begin Unit 10
- New **pending-operations ledger**: current-term SQL (verified missing in prod 2026-06-09 via RPC 404), Sheets rehost (#264), Path A deferral, `set_public_current_term` admin tightening
- Production table: site-root/public-landing surface row; `guard-forbidden-paths` added to required checks; dispatch-ci-first deploy note
- Stamp wording: clarifies the prod-state marker is stamped only in the published artifact, never the repo copy

**ONBOARDING.html**
- Forbidden paths: enforced by the required `guard-forbidden-paths` check since PR #255; `allow-forbidden-paths` label is the live override
- Entry points: index.html → public-schedule.html redirect, app at program-command.html (PR #256)

**decision-log.html**
- 2026-06-09 entry: state audit — Codex Issue Writer disabled (105 runs / 0 successes), Phase 2 declared unlocked, hotfix twins reconciled (#231/#235 closed against PRs #233/#236), #240 closed, #264 opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)