### PR TITLE
feat(unit10-G3): applied learning dashboard profile-aware — port d9d96e0 + auth-block restore

### DIFF
--- a/pages/applied-learning-dashboard.html
+++ b/pages/applied-learning-dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Applied Learning - Design Scheduler</title>
+    <title>Applied Learning - Program Command</title>
 
     <!-- External Stylesheets -->
     <link rel="stylesheet" href="../css/shared.css">
@@ -14,28 +14,24 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 
     <!-- Utility Scripts -->
+    <script src="../js/department-profile.js"></script>
     <script src="../js/data-loader.js"></script>
     <script src="../js/year-filter.js"></script>
     <script src="../js/chart-utils.js"></script>
+    <script src="../js/workload-integration.js"></script>
 </head>
 <body>
     <div class="container">
         <header>
             <a href="../program-command.html" class="back-link">← Back to Schedule</a>
             <h1>📚 Applied Learning Dashboard</h1>
-            <p class="subtitle">DESN 499, 495, 491 - Supervision Tracking & Trends</p>
+            <p class="subtitle" id="dashboardSubtitle">Applied-learning supervision tracking and trends</p>
         </header>
 
         <div class="controls">
             <div class="control-group">
                 <label for="academicYearFilter">Academic Year:</label>
-                <select id="academicYearFilter">
-                    <option value="all">All Years (2022-2026)</option>
-                    <option value="2022-23">2022-23</option>
-                    <option value="2023-24">2023-24</option>
-                    <option value="2024-25" selected>2024-25</option>
-                    <option value="2025-26">2025-26 (Projected)</option>
-                </select>
+                <select id="academicYearFilter"></select>
             </div>
 
             <button onclick="window.location.href='workload-dashboard.html'">👥 Faculty Workload</button>
@@ -56,41 +52,7 @@
                     <span class="badge" id="yearBadge">2024-25</span>
                 </div>
 
-                <div class="stats-bar">
-                    <div class="stat-card">
-                        <div class="stat-label">DESN 499 (Independent Study)</div>
-                        <div class="stat-value" id="desn499Total">0</div>
-                        <div class="stat-subtitle">
-                            <span id="desn499Credits">0 credits</span> •
-                            <span id="desn499Sections">0 sections</span> •
-                            <span id="desn499Workload">0.0 workload</span>
-                        </div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-label">DESN 495 (Internship)</div>
-                        <div class="stat-value" id="desn495Total">0</div>
-                        <div class="stat-subtitle">
-                            <span id="desn495Credits">0 credits</span> •
-                            <span id="desn495Sections">0 sections</span> •
-                            <span id="desn495Workload">0.0 workload</span>
-                        </div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-label">DESN 491 (Senior Project)</div>
-                        <div class="stat-value" id="desn491Total">0</div>
-                        <div class="stat-subtitle">
-                            <span id="desn491Credits">0 credits</span> •
-                            <span id="desn491Sections">0 sections</span>
-                        </div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-label">Total Students Served</div>
-                        <div class="stat-value" id="totalStudents">0</div>
-                        <div class="stat-subtitle">
-                            <span id="totalWorkload">0.0 workload equivalent</span>
-                        </div>
-                    </div>
-                </div>
+                <div class="stats-bar" id="summaryCards"></div>
 
                 <!-- Cumulative Trends Chart -->
                 <div class="section-header">
@@ -102,9 +64,7 @@
                     <div class="chart-wrapper tall">
                         <canvas id="cumulativeTrendChart"></canvas>
                     </div>
-                    <p style="margin-top: 15px; color: #6c757d; font-size: 0.9em;">
-                        <strong>Note:</strong> DESN 499 multiplier = 0.2× | DESN 495 multiplier = 0.1× for workload calculation
-                    </p>
+                    <p id="multiplierNote" style="margin-top: 15px; color: #6c757d; font-size: 0.9em;"></p>
                 </div>
 
                 <!-- Instructor Summary Chart -->
@@ -126,22 +86,7 @@
 
                 <div class="chart-container full-width">
                     <table class="data-table" id="annualBreakdownTable">
-                        <thead>
-                            <tr>
-                                <th rowspan="2">Instructor</th>
-                                <th colspan="3">2022-23</th>
-                                <th colspan="3">2023-24</th>
-                                <th colspan="3">2024-25</th>
-                                <th colspan="3">2025-26</th>
-                                <th rowspan="2">Total</th>
-                            </tr>
-                            <tr>
-                                <th>499</th><th>495</th><th>491</th>
-                                <th>499</th><th>495</th><th>491</th>
-                                <th>499</th><th>495</th><th>491</th>
-                                <th>499</th><th>495</th><th>491</th>
-                            </tr>
-                        </thead>
+                        <thead></thead>
                         <tbody></tbody>
                     </table>
                 </div>
@@ -152,37 +97,7 @@
                     <span class="badge" id="currentYearBadge">2024-25</span>
                 </div>
 
-                <div class="card-grid">
-                    <div class="card" id="desn499Card">
-                        <div class="card-header">
-                            <h3 class="card-title">DESN 499</h3>
-                            <span class="health-score good">Independent Study</span>
-                        </div>
-                        <div class="card-content" id="desn499Details">
-                            Loading...
-                        </div>
-                    </div>
-
-                    <div class="card" id="desn495Card">
-                        <div class="card-header">
-                            <h3 class="card-title">DESN 495</h3>
-                            <span class="health-score good">Internship</span>
-                        </div>
-                        <div class="card-content" id="desn495Details">
-                            Loading...
-                        </div>
-                    </div>
-
-                    <div class="card" id="desn491Card">
-                        <div class="card-header">
-                            <h3 class="card-title">DESN 491</h3>
-                            <span class="health-score good">Senior Project</span>
-                        </div>
-                        <div class="card-content" id="desn491Details">
-                            Loading...
-                        </div>
-                    </div>
-                </div>
+                <div class="card-grid" id="currentYearCards"></div>
             </div>
         </div>
     </div>

--- a/pages/applied-learning-dashboard.js
+++ b/pages/applied-learning-dashboard.js
@@ -1,200 +1,342 @@
 /**
- * EWU Design Applied Learning Dashboard
- * Tracks DESN 499, 495, 491 supervision and trends
+ * Applied Learning Dashboard
+ * Renders profile-aware supervision trends from integrated workload data.
  */
 
-// Global state
 let workloadData = null;
-let currentYear = '2024-25';
+let currentYear = 'all';
+let activeDepartmentProfile = null;
 let charts = {};
 
-/**
- * Initialize dashboard
- */
-async function initDashboard() {
-    console.log('🚀 Initializing Applied Learning Dashboard');
+const APPLIED_LEARNING_CHART_COLORS = [
+    { border: '#667eea', fill: 'rgba(102, 126, 234, 0.14)' },
+    { border: '#51cf66', fill: 'rgba(81, 207, 102, 0.14)' },
+    { border: '#ffa726', fill: 'rgba(255, 167, 38, 0.16)' },
+    { border: '#ef4444', fill: 'rgba(239, 68, 68, 0.14)' },
+    { border: '#14b8a6', fill: 'rgba(20, 184, 166, 0.14)' },
+    { border: '#8b5cf6', fill: 'rgba(139, 92, 246, 0.14)' }
+];
 
-    // Load workload data
-    workloadData = await loadWorkloadData('../');
-
-    if (!workloadData) {
-        showError('Failed to load workload data.');
-        return;
-    }
-
-    // Setup year filter
-    document.getElementById('academicYearFilter').addEventListener('change', onYearChange);
-
-    // Initial load
-    onYearChange({ target: { value: currentYear } });
-
-    hideLoadingShowContent();
-
-    console.log('✅ Dashboard initialized');
+function getDepartmentIdentity() {
+    const identity = activeDepartmentProfile && activeDepartmentProfile.identity
+        ? activeDepartmentProfile.identity
+        : {};
+    return {
+        code: String(identity.code || 'DESN').trim().toUpperCase() || 'DESN',
+        displayName: String(identity.displayName || identity.name || 'EWU Design').trim() || 'EWU Design'
+    };
 }
 
-/**
- * Handle year change
- */
+function getAppliedLearningCourses() {
+    if (typeof WorkloadIntegration === 'undefined' || typeof WorkloadIntegration.getAppliedLearningCourses !== 'function') {
+        return [];
+    }
+
+    return WorkloadIntegration.getAppliedLearningCourses()
+        .map((course) => ({
+            code: String(course?.code || '').trim(),
+            title: String(course?.title || course?.code || '').trim(),
+            rate: Number(course?.rate) || 0
+        }))
+        .filter((course) => course.code)
+        .sort((a, b) => a.code.localeCompare(b.code));
+}
+
+function formatNumber(value, decimals = 1) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return '0';
+    const fixed = Number(numeric.toFixed(decimals));
+    return Number.isInteger(fixed) ? String(fixed) : String(fixed);
+}
+
+function getColor(index) {
+    return APPLIED_LEARNING_CHART_COLORS[index % APPLIED_LEARNING_CHART_COLORS.length];
+}
+
+function getAvailableYears() {
+    if (!workloadData || typeof WorkloadIntegration === 'undefined' || typeof WorkloadIntegration.getAcademicYearOptions !== 'function') {
+        return [];
+    }
+
+    return WorkloadIntegration.getAcademicYearOptions(workloadData)
+        .filter((year) => year && year !== 'all')
+        .sort();
+}
+
+function getIntegratedYearData(year) {
+    if (!workloadData || !year || typeof WorkloadIntegration === 'undefined' || typeof WorkloadIntegration.buildIntegratedWorkloadYearData !== 'function') {
+        return null;
+    }
+
+    return WorkloadIntegration.buildIntegratedWorkloadYearData(workloadData, year);
+}
+
+function createEmptyCourseSummary(courses) {
+    const byCode = {};
+    courses.forEach((course) => {
+        byCode[course.code] = {
+            ...course,
+            students: 0,
+            credits: 0,
+            workload: 0,
+            sections: 0,
+            supervisors: {}
+        };
+    });
+
+    return {
+        byCode,
+        totals: {
+            students: 0,
+            credits: 0,
+            workload: 0,
+            sections: 0
+        }
+    };
+}
+
+function buildYearSummary(year) {
+    const courses = getAppliedLearningCourses();
+    const summary = createEmptyCourseSummary(courses);
+    const yearData = getIntegratedYearData(year);
+    const facultyData = yearData && yearData.all ? yearData.all : {};
+
+    Object.entries(facultyData).forEach(([facultyName, facultyRecord]) => {
+        Object.entries(facultyRecord?.appliedLearning || {}).forEach(([code, details]) => {
+            const bucket = summary.byCode[code];
+            if (!bucket) return;
+
+            const students = Number(details?.students) || 0;
+            const credits = Number(details?.credits) || 0;
+            const workload = Number(details?.workload) || 0;
+            const sections = Number(details?.sections) || 0;
+            if ((students + credits + workload + sections) <= 0) return;
+
+            bucket.students += students;
+            bucket.credits += credits;
+            bucket.workload += workload;
+            bucket.sections += sections;
+
+            if (!bucket.supervisors[facultyName]) {
+                bucket.supervisors[facultyName] = { students: 0, credits: 0, workload: 0, sections: 0 };
+            }
+            bucket.supervisors[facultyName].students += students;
+            bucket.supervisors[facultyName].credits += credits;
+            bucket.supervisors[facultyName].workload += workload;
+            bucket.supervisors[facultyName].sections += sections;
+
+            summary.totals.students += students;
+            summary.totals.credits += credits;
+            summary.totals.workload += workload;
+            summary.totals.sections += sections;
+        });
+    });
+
+    return summary;
+}
+
+function buildSummaryForScope() {
+    const years = getAvailableYears();
+    if (currentYear !== 'all') {
+        return buildYearSummary(currentYear);
+    }
+
+    const combined = createEmptyCourseSummary(getAppliedLearningCourses());
+    years.forEach((year) => {
+        const yearSummary = buildYearSummary(year);
+        Object.entries(yearSummary.byCode).forEach(([code, details]) => {
+            const bucket = combined.byCode[code];
+            if (!bucket) return;
+
+            bucket.students += details.students;
+            bucket.credits += details.credits;
+            bucket.workload += details.workload;
+            bucket.sections += details.sections;
+
+            Object.entries(details.supervisors || {}).forEach(([facultyName, supervisor]) => {
+                if (!bucket.supervisors[facultyName]) {
+                    bucket.supervisors[facultyName] = { students: 0, credits: 0, workload: 0, sections: 0 };
+                }
+                bucket.supervisors[facultyName].students += supervisor.students;
+                bucket.supervisors[facultyName].credits += supervisor.credits;
+                bucket.supervisors[facultyName].workload += supervisor.workload;
+                bucket.supervisors[facultyName].sections += supervisor.sections;
+            });
+        });
+
+        combined.totals.students += yearSummary.totals.students;
+        combined.totals.credits += yearSummary.totals.credits;
+        combined.totals.workload += yearSummary.totals.workload;
+        combined.totals.sections += yearSummary.totals.sections;
+    });
+
+    return combined;
+}
+
+function hideLoadingShowContent() {
+    const loading = document.getElementById('loadingMessage');
+    const content = document.getElementById('dashboardContent');
+    if (loading) loading.style.display = 'none';
+    if (content) content.style.display = 'block';
+}
+
+function showError(message) {
+    const loading = document.getElementById('loadingMessage');
+    if (loading) {
+        loading.textContent = message;
+        loading.classList.add('error');
+    }
+}
+
+function applyDepartmentProfileCopy() {
+    const identity = getDepartmentIdentity();
+    const courses = getAppliedLearningCourses();
+    const subtitle = document.getElementById('dashboardSubtitle');
+    const note = document.getElementById('multiplierNote');
+    const yearSelect = document.getElementById('academicYearFilter');
+
+    document.title = `Applied Learning - ${identity.displayName}`;
+
+    if (subtitle) {
+        const codes = courses.map((course) => course.code).join(', ');
+        subtitle.textContent = codes
+            ? `${codes} supervision tracking and trends`
+            : `${identity.code} applied-learning supervision tracking and trends`;
+    }
+
+    if (note) {
+        const parts = courses
+            .filter((course) => course.rate > 0)
+            .map((course) => `${course.code} multiplier = ${formatNumber(course.rate, 2)}x`);
+        note.textContent = parts.length
+            ? parts.join(' | ')
+            : 'Applied-learning workload multipliers are profile-driven.';
+    }
+
+    if (yearSelect) {
+        yearSelect.setAttribute('aria-label', `${identity.displayName} academic year`);
+    }
+}
+
+function populateYearFilter() {
+    const select = document.getElementById('academicYearFilter');
+    if (!select) return;
+
+    const years = getAvailableYears();
+    const currentAcademicYear = (() => {
+        const now = new Date();
+        const startYear = now.getMonth() >= 6 ? now.getFullYear() : now.getFullYear() - 1;
+        return `${startYear}-${String(startYear + 1).slice(-2)}`;
+    })();
+
+    select.innerHTML = '';
+
+    const allOption = document.createElement('option');
+    allOption.value = 'all';
+    allOption.textContent = years.length ? `All Years (${years[0]} to ${years[years.length - 1]})` : 'All Years';
+    select.appendChild(allOption);
+
+    years.forEach((year) => {
+        const option = document.createElement('option');
+        option.value = year;
+        option.textContent = year;
+        if (year === currentAcademicYear) {
+            option.textContent = `${year} (Current)`;
+        }
+        select.appendChild(option);
+    });
+
+    if (years.includes(currentAcademicYear)) {
+        currentYear = currentAcademicYear;
+    } else if (years.length) {
+        currentYear = years[years.length - 1];
+    } else {
+        currentYear = 'all';
+    }
+
+    select.value = currentYear;
+}
+
 function onYearChange(event) {
     if (event && event.target) {
         currentYear = event.target.value;
     }
 
-    console.log(`📅 Year changed to: ${currentYear}`);
+    const badgeText = currentYear === 'all' ? 'All Years' : currentYear;
+    const yearBadge = document.getElementById('yearBadge');
+    const currentYearBadge = document.getElementById('currentYearBadge');
+    if (yearBadge) yearBadge.textContent = badgeText;
+    if (currentYearBadge) currentYearBadge.textContent = badgeText;
 
-    // Update badges
-    document.getElementById('yearBadge').textContent = currentYear === 'all'
-        ? 'All Years'
-        : currentYear;
-    document.getElementById('currentYearBadge').textContent = currentYear === 'all'
-        ? 'All Years'
-        : currentYear;
-
-    // Refresh all visualizations
     refreshDashboard();
 }
 
-/**
- * Refresh all dashboard sections
- */
-function refreshDashboard() {
-    if (!workloadData || !workloadData.appliedLearningTrends) {
-        console.warn('⚠️ No applied learning data available');
-        return;
-    }
+function renderSummaryCards() {
+    const container = document.getElementById('summaryCards');
+    if (!container) return;
 
-    updateSummaryStats();
-    renderCumulativeTrendChart();
-    renderInstructorSummaryChart();
-    renderAnnualBreakdownTable();
-    renderCurrentYearDetails();
+    const summary = buildSummaryForScope();
+    container.innerHTML = '';
+
+    Object.values(summary.byCode).forEach((course) => {
+        const card = document.createElement('div');
+        card.className = 'stat-card';
+        card.innerHTML = `
+            <div class="stat-label">${course.code} (${course.title})</div>
+            <div class="stat-value">${formatNumber(course.students, 0)} students</div>
+            <div class="stat-subtitle">
+                <span>${formatNumber(course.credits, 1)} credits</span> •
+                <span>${formatNumber(course.sections, 0)} sections</span> •
+                <span>${formatNumber(course.workload, 1)} workload</span>
+            </div>
+        `;
+        container.appendChild(card);
+    });
+
+    const totalCard = document.createElement('div');
+    totalCard.className = 'stat-card';
+    totalCard.innerHTML = `
+        <div class="stat-label">Total Students Served</div>
+        <div class="stat-value">${formatNumber(summary.totals.students, 0)}</div>
+        <div class="stat-subtitle">
+            <span>${formatNumber(summary.totals.credits, 1)} credits</span> •
+            <span>${formatNumber(summary.totals.sections, 0)} sections</span> •
+            <span>${formatNumber(summary.totals.workload, 1)} workload equivalent</span>
+        </div>
+    `;
+    container.appendChild(totalCard);
 }
 
-/**
- * Update summary statistics
- */
-function updateSummaryStats() {
-    const trends = workloadData.appliedLearningTrends.trends;
-
-    if (currentYear === 'all') {
-        // Calculate cumulative totals
-        let total499 = 0, total495 = 0, total491 = 0;
-        let totalStudents = 0, totalWorkload = 0;
-        let sections499 = 0, sections495 = 0, sections491 = 0;
-
-        Object.values(trends).forEach(yearData => {
-            total499 += yearData['DESN 499'].totalCredits || 0;
-            total495 += yearData['DESN 495'].totalCredits || 0;
-            // Note: DESN 491 might not be in the data yet
-            total491 += (yearData['DESN 491']?.totalCredits || 0);
-
-            totalStudents += yearData.total.students || 0;
-            totalWorkload += yearData.total.workloadEquivalent || 0;
-
-            sections499 += yearData['DESN 499'].sections || 0;
-            sections495 += yearData['DESN 495'].sections || 0;
-            sections491 += (yearData['DESN 491']?.sections || 0);
-        });
-
-        document.getElementById('desn499Total').textContent = `${totalStudents} students`;
-        document.getElementById('desn499Credits').textContent = `${total499} total credits`;
-        document.getElementById('desn499Sections').textContent = `${sections499} sections`;
-        document.getElementById('desn499Workload').textContent = `${(total499 * 0.2).toFixed(1)} workload`;
-
-        document.getElementById('desn495Total').textContent = `${totalStudents} students`;
-        document.getElementById('desn495Credits').textContent = `${total495} total credits`;
-        document.getElementById('desn495Sections').textContent = `${sections495} sections`;
-        document.getElementById('desn495Workload').textContent = `${(total495 * 0.1).toFixed(1)} workload`;
-
-        document.getElementById('desn491Total').textContent = `${total491} credits`;
-        document.getElementById('desn491Credits').textContent = `${total491} total credits`;
-        document.getElementById('desn491Sections').textContent = `${sections491} sections`;
-
-        document.getElementById('totalStudents').textContent = totalStudents;
-        document.getElementById('totalWorkload').textContent = `${totalWorkload.toFixed(1)} credits`;
-
-    } else {
-        // Show specific year
-        const yearData = trends[currentYear];
-
-        if (yearData) {
-            const desn499 = yearData['DESN 499'];
-            const desn495 = yearData['DESN 495'];
-            const desn491 = yearData['DESN 491'] || { totalCredits: 0, students: 0, sections: 0 };
-
-            document.getElementById('desn499Total').textContent = `${desn499.students} students`;
-            document.getElementById('desn499Credits').textContent = `${desn499.totalCredits} credits`;
-            document.getElementById('desn499Sections').textContent = `${desn499.sections} sections`;
-            document.getElementById('desn499Workload').textContent = `${desn499.workloadCredits.toFixed(1)} workload`;
-
-            document.getElementById('desn495Total').textContent = `${desn495.students} students`;
-            document.getElementById('desn495Credits').textContent = `${desn495.totalCredits} credits`;
-            document.getElementById('desn495Sections').textContent = `${desn495.sections} sections`;
-            document.getElementById('desn495Workload').textContent = `${desn495.workloadCredits.toFixed(1)} workload`;
-
-            document.getElementById('desn491Total').textContent = `${desn491.totalCredits} credits`;
-            document.getElementById('desn491Credits').textContent = `${desn491.totalCredits} credits`;
-            document.getElementById('desn491Sections').textContent = `${desn491.sections} sections`;
-
-            document.getElementById('totalStudents').textContent = yearData.total.students;
-            document.getElementById('totalWorkload').textContent = `${yearData.total.workloadEquivalent.toFixed(1)} credits`;
-        }
-    }
-}
-
-/**
- * Render cumulative trend chart
- */
 function renderCumulativeTrendChart() {
     if (charts.cumulative) {
         destroyChart(charts.cumulative);
     }
 
-    const trends = workloadData.appliedLearningTrends.trends;
-    const years = workloadData.appliedLearningTrends.years;
-
-    const data499 = years.map(year => trends[year]['DESN 499'].totalCredits);
-    const data495 = years.map(year => trends[year]['DESN 495'].totalCredits);
-    const data491 = years.map(year => trends[year]['DESN 491']?.totalCredits || 0);
-
     const canvas = document.getElementById('cumulativeTrendChart');
+    const years = getAvailableYears();
+    const courses = getAppliedLearningCourses();
+    if (!canvas || !years.length || !courses.length) return;
 
     charts.cumulative = createLineChart(canvas, {
         data: {
             labels: years,
-            datasets: [
-                {
-                    label: 'DESN 499 (Independent Study)',
-                    data: data499,
-                    borderColor: '#667eea',
-                    backgroundColor: 'rgba(102, 126, 234, 0.1)',
+            datasets: courses.map((course, index) => {
+                const color = getColor(index);
+                return {
+                    label: `${course.code} (${course.title})`,
+                    data: years.map((year) => buildYearSummary(year).byCode[course.code]?.credits || 0),
+                    borderColor: color.border,
+                    backgroundColor: color.fill,
                     borderWidth: 3,
                     fill: true
-                },
-                {
-                    label: 'DESN 495 (Internship)',
-                    data: data495,
-                    borderColor: '#51cf66',
-                    backgroundColor: 'rgba(81, 207, 102, 0.1)',
-                    borderWidth: 3,
-                    fill: true
-                },
-                {
-                    label: 'DESN 491 (Senior Project)',
-                    data: data491,
-                    borderColor: '#ffa726',
-                    backgroundColor: 'rgba(255, 167, 38, 0.1)',
-                    borderWidth: 3,
-                    fill: true
-                }
-            ]
+                };
+            })
         },
         options: {
             plugins: {
                 title: {
                     display: true,
-                    text: 'Growth in Applied Learning Credits (2022-2026)'
+                    text: 'Applied Learning Credits by Year'
                 }
             },
             scales: {
@@ -210,91 +352,57 @@ function renderCumulativeTrendChart() {
     });
 }
 
-/**
- * Render instructor summary chart
- */
 function renderInstructorSummaryChart() {
     if (charts.instructorSummary) {
         destroyChart(charts.instructorSummary);
     }
 
-    // Aggregate by instructor across all years
-    const instructorData = {};
-    const trends = workloadData.appliedLearningTrends.trends;
+    const canvas = document.getElementById('instructorSummaryChart');
+    const courses = getAppliedLearningCourses();
+    const years = currentYear === 'all' ? getAvailableYears() : [currentYear];
+    if (!canvas || !courses.length || !years.length) return;
 
-    Object.values(trends).forEach(yearData => {
-        // DESN 499
-        Object.entries(yearData['DESN 499'].supervisors || {}).forEach(([instructor, data]) => {
-            if (!instructorData[instructor]) {
-                instructorData[instructor] = { desn499: 0, desn495: 0, desn491: 0 };
-            }
-            instructorData[instructor].desn499 += data.credits || 0;
-        });
-
-        // DESN 495
-        Object.entries(yearData['DESN 495'].supervisors || {}).forEach(([instructor, data]) => {
-            if (!instructorData[instructor]) {
-                instructorData[instructor] = { desn499: 0, desn495: 0, desn491: 0 };
-            }
-            instructorData[instructor].desn495 += data.credits || 0;
-        });
-
-        // DESN 491 (if exists)
-        if (yearData['DESN 491'] && yearData['DESN 491'].supervisors) {
-            Object.entries(yearData['DESN 491'].supervisors).forEach(([instructor, data]) => {
-                if (!instructorData[instructor]) {
-                    instructorData[instructor] = { desn499: 0, desn495: 0, desn491: 0 };
+    const byInstructor = {};
+    years.forEach((year) => {
+        const summary = buildYearSummary(year);
+        Object.values(summary.byCode).forEach((course) => {
+            Object.entries(course.supervisors || {}).forEach(([facultyName, details]) => {
+                if (!byInstructor[facultyName]) {
+                    byInstructor[facultyName] = { total: 0, byCode: {} };
                 }
-                instructorData[instructor].desn491 += data.credits || 0;
+                byInstructor[facultyName].byCode[course.code] = (byInstructor[facultyName].byCode[course.code] || 0) + details.credits;
+                byInstructor[facultyName].total += details.credits;
             });
-        }
+        });
     });
 
-    // Sort by total credits
-    const sorted = Object.entries(instructorData)
-        .map(([name, data]) => ({
-            name,
-            ...data,
-            total: data.desn499 + data.desn495 + data.desn491
-        }))
+    const rows = Object.entries(byInstructor)
+        .map(([name, details]) => ({ name, ...details }))
         .sort((a, b) => b.total - a.total)
         .slice(0, 15);
 
-    const canvas = document.getElementById('instructorSummaryChart');
-
     charts.instructorSummary = createStackedBarChart(canvas, {
         data: {
-            labels: sorted.map(d => d.name),
-            datasets: [
-                {
-                    label: 'DESN 499',
-                    data: sorted.map(d => d.desn499),
-                    backgroundColor: 'rgba(102, 126, 234, 0.8)',
-                    borderColor: '#667eea',
+            labels: rows.map((row) => row.name),
+            datasets: courses.map((course, index) => {
+                const color = getColor(index);
+                return {
+                    label: course.code,
+                    data: rows.map((row) => row.byCode[course.code] || 0),
+                    backgroundColor: color.fill.replace('0.14', '0.8').replace('0.16', '0.8'),
+                    borderColor: color.border,
                     borderWidth: 2
-                },
-                {
-                    label: 'DESN 495',
-                    data: sorted.map(d => d.desn495),
-                    backgroundColor: 'rgba(81, 207, 102, 0.8)',
-                    borderColor: '#51cf66',
-                    borderWidth: 2
-                },
-                {
-                    label: 'DESN 491',
-                    data: sorted.map(d => d.desn491),
-                    backgroundColor: 'rgba(255, 167, 38, 0.8)',
-                    borderColor: '#ffa726',
-                    borderWidth: 2
-                }
-            ]
+                };
+            })
         },
         options: {
             indexAxis: 'y',
             plugins: {
                 title: {
                     display: true,
-                    text: 'Total Applied Learning Credits by Faculty (2022-2026)'
+                    text: currentYear === 'all'
+                        ? 'Applied Learning Credits by Faculty'
+                        : `Applied Learning Credits by Faculty (${currentYear})`
                 }
             },
             scales: {
@@ -309,202 +417,199 @@ function renderInstructorSummaryChart() {
     });
 }
 
-/**
- * Render annual breakdown table using safe DOM methods
- */
 function renderAnnualBreakdownTable() {
-    const tbody = document.querySelector('#annualBreakdownTable tbody');
-    if (!tbody) return;
+    const table = document.getElementById('annualBreakdownTable');
+    if (!table) return;
 
-    // Clear existing rows
-    while (tbody.firstChild) {
-        tbody.removeChild(tbody.firstChild);
-    }
+    const thead = table.querySelector('thead');
+    const tbody = table.querySelector('tbody');
+    if (!thead || !tbody) return;
 
-    // Get all instructors across all years
-    const instructors = new Set();
-    const trends = workloadData.appliedLearningTrends.trends;
+    thead.innerHTML = '';
+    tbody.innerHTML = '';
 
-    Object.values(trends).forEach(yearData => {
-        Object.keys(yearData['DESN 499'].supervisors || {}).forEach(name => instructors.add(name));
-        Object.keys(yearData['DESN 495'].supervisors || {}).forEach(name => instructors.add(name));
-        if (yearData['DESN 491']) {
-            Object.keys(yearData['DESN 491'].supervisors || {}).forEach(name => instructors.add(name));
-        }
+    const years = getAvailableYears();
+    const courses = getAppliedLearningCourses();
+    if (!years.length || !courses.length) return;
+
+    const headerRow = document.createElement('tr');
+    const headerName = document.createElement('th');
+    headerName.rowSpan = 2;
+    headerName.textContent = 'Instructor';
+    headerRow.appendChild(headerName);
+
+    years.forEach((year) => {
+        const th = document.createElement('th');
+        th.colSpan = courses.length;
+        th.textContent = year;
+        headerRow.appendChild(th);
     });
 
-    const sortedInstructors = Array.from(instructors).sort();
+    const totalHeader = document.createElement('th');
+    totalHeader.rowSpan = 2;
+    totalHeader.textContent = 'Total';
+    headerRow.appendChild(totalHeader);
+    thead.appendChild(headerRow);
 
-    sortedInstructors.forEach(instructor => {
+    const courseRow = document.createElement('tr');
+    years.forEach(() => {
+        courses.forEach((course) => {
+            const th = document.createElement('th');
+            th.textContent = course.code;
+            courseRow.appendChild(th);
+        });
+    });
+    thead.appendChild(courseRow);
+
+    const instructors = new Set();
+    years.forEach((year) => {
+        const summary = buildYearSummary(year);
+        Object.values(summary.byCode).forEach((course) => {
+            Object.keys(course.supervisors || {}).forEach((name) => instructors.add(name));
+        });
+    });
+
+    Array.from(instructors).sort().forEach((instructor) => {
         const row = document.createElement('tr');
-
-        let totalCredits = 0;
-
-        // Name cell
-        const tdName = document.createElement('td');
+        const nameCell = document.createElement('td');
         const strong = document.createElement('strong');
         strong.textContent = instructor;
-        tdName.appendChild(strong);
-        row.appendChild(tdName);
+        nameCell.appendChild(strong);
+        row.appendChild(nameCell);
 
-        // For each year
-        ['2022-23', '2023-24', '2024-25', '2025-26'].forEach(year => {
-            const yearData = trends[year];
-
-            if (yearData) {
-                const credits499 = yearData['DESN 499'].supervisors?.[instructor]?.credits || 0;
-                const credits495 = yearData['DESN 495'].supervisors?.[instructor]?.credits || 0;
-                const credits491 = yearData['DESN 491']?.supervisors?.[instructor]?.credits || 0;
-
-                totalCredits += credits499 + credits495 + credits491;
-
-                [credits499, credits495, credits491].forEach(val => {
-                    const td = document.createElement('td');
-                    td.textContent = val || '-';
-                    row.appendChild(td);
-                });
-            } else {
-                for (let i = 0; i < 3; i++) {
-                    const td = document.createElement('td');
-                    td.textContent = '-';
-                    row.appendChild(td);
-                }
-            }
+        let totalCredits = 0;
+        years.forEach((year) => {
+            const summary = buildYearSummary(year);
+            courses.forEach((course) => {
+                const credits = summary.byCode[course.code]?.supervisors?.[instructor]?.credits || 0;
+                totalCredits += credits;
+                const td = document.createElement('td');
+                td.textContent = credits ? formatNumber(credits, 1) : '-';
+                row.appendChild(td);
+            });
         });
 
-        // Total cell
-        const tdTotal = document.createElement('td');
+        const totalCell = document.createElement('td');
         const totalStrong = document.createElement('strong');
-        totalStrong.textContent = totalCredits;
-        tdTotal.appendChild(totalStrong);
-        row.appendChild(tdTotal);
-
+        totalStrong.textContent = formatNumber(totalCredits, 1);
+        totalCell.appendChild(totalStrong);
+        row.appendChild(totalCell);
         tbody.appendChild(row);
     });
 }
 
-/**
- * Render current year details using safe DOM methods
- */
 function renderCurrentYearDetails() {
-    const details499 = document.getElementById('desn499Details');
-    const details495 = document.getElementById('desn495Details');
-    const details491 = document.getElementById('desn491Details');
+    const container = document.getElementById('currentYearCards');
+    if (!container) return;
 
-    // Helper to clear and set message
-    function setMessage(element, message) {
-        if (!element) return;
-        while (element.firstChild) {
-            element.removeChild(element.firstChild);
-        }
-        const p = document.createElement('p');
-        p.textContent = message;
-        element.appendChild(p);
-    }
-
-    // Helper to create metric div
-    function createMetric(label, value) {
-        const div = document.createElement('div');
-        div.className = 'card-metric';
-
-        const labelSpan = document.createElement('span');
-        labelSpan.className = 'card-metric-label';
-        labelSpan.textContent = label;
-        div.appendChild(labelSpan);
-
-        const valueSpan = document.createElement('span');
-        valueSpan.className = 'card-metric-value';
-        valueSpan.textContent = value;
-        div.appendChild(valueSpan);
-
-        return div;
-    }
-
-    // Helper to render course details
-    function renderCourseDetails(element, courseData, multiplierText) {
-        if (!element) return;
-
-        while (element.firstChild) {
-            element.removeChild(element.firstChild);
-        }
-
-        element.appendChild(createMetric('Total Students:', courseData.students));
-        element.appendChild(createMetric('Total Credits:', courseData.totalCredits));
-        element.appendChild(createMetric('Sections:', courseData.sections));
-
-        if (courseData.workloadCredits !== undefined) {
-            element.appendChild(createMetric('Workload Equivalent:',
-                courseData.workloadCredits.toFixed(1) + ' (' + multiplierText + ')'));
-        }
-
-        if (courseData.supervisors && Object.keys(courseData.supervisors).length > 0) {
-            const h4 = document.createElement('h4');
-            h4.style.marginTop = '15px';
-            h4.style.marginBottom = '10px';
-            h4.textContent = 'Supervisors:';
-            element.appendChild(h4);
-
-            Object.entries(courseData.supervisors).forEach(([name, data]) => {
-                element.appendChild(createMetric(name + ':',
-                    data.credits + ' credits (' + data.sections + ' sections)'));
-            });
-        }
-    }
+    container.innerHTML = '';
 
     if (currentYear === 'all') {
-        setMessage(details499, 'Select a specific year to view details.');
-        setMessage(details495, 'Select a specific year to view details.');
-        setMessage(details491, 'Select a specific year to view details.');
+        const message = document.createElement('p');
+        message.textContent = 'Select a specific year to view course-level detail.';
+        container.appendChild(message);
         return;
     }
 
-    const yearData = workloadData.appliedLearningTrends.trends[currentYear];
+    const summary = buildYearSummary(currentYear);
+    Object.values(summary.byCode).forEach((course) => {
+        const card = document.createElement('div');
+        card.className = 'card';
 
-    if (!yearData) {
-        setMessage(details499, 'No data available for this year.');
-        setMessage(details495, 'No data available for this year.');
-        setMessage(details491, 'No data available for this year.');
-        return;
-    }
+        const header = document.createElement('div');
+        header.className = 'card-header';
+        header.innerHTML = `
+            <h3 class="card-title">${course.code}</h3>
+            <span class="health-score good">${course.title}</span>
+        `;
+        card.appendChild(header);
 
-    // DESN 499 Details
-    renderCourseDetails(details499, yearData['DESN 499'], '0.2× multiplier');
+        const content = document.createElement('div');
+        content.className = 'card-content';
+        content.appendChild(createMetric('Total Students:', formatNumber(course.students, 0)));
+        content.appendChild(createMetric('Total Credits:', formatNumber(course.credits, 1)));
+        content.appendChild(createMetric('Sections:', formatNumber(course.sections, 0)));
+        content.appendChild(createMetric('Workload Equivalent:', `${formatNumber(course.workload, 1)} (${formatNumber(course.rate, 2)}x multiplier)`));
 
-    // DESN 495 Details
-    renderCourseDetails(details495, yearData['DESN 495'], '0.1× multiplier');
+        const supervisorEntries = Object.entries(course.supervisors || {}).sort((a, b) => b[1].credits - a[1].credits);
+        if (supervisorEntries.length) {
+            const heading = document.createElement('h4');
+            heading.style.marginTop = '15px';
+            heading.style.marginBottom = '10px';
+            heading.textContent = 'Supervisors:';
+            content.appendChild(heading);
 
-    // DESN 491 Details
-    const desn491 = yearData['DESN 491'] || { students: 0, totalCredits: 0, sections: 0, supervisors: {} };
-
-    if (details491) {
-        while (details491.firstChild) {
-            details491.removeChild(details491.firstChild);
-        }
-
-        details491.appendChild(createMetric('Total Students:', desn491.students || 0));
-        details491.appendChild(createMetric('Total Credits:', desn491.totalCredits || 0));
-        details491.appendChild(createMetric('Sections:', desn491.sections || 0));
-
-        if (desn491.supervisors && Object.keys(desn491.supervisors).length > 0) {
-            const h4 = document.createElement('h4');
-            h4.style.marginTop = '15px';
-            h4.style.marginBottom = '10px';
-            h4.textContent = 'Supervisors:';
-            details491.appendChild(h4);
-
-            Object.entries(desn491.supervisors).forEach(([name, data]) => {
-                details491.appendChild(createMetric(name + ':',
-                    data.credits + ' credits (' + data.sections + ' sections)'));
+            supervisorEntries.forEach(([name, details]) => {
+                content.appendChild(createMetric(
+                    `${name}:`,
+                    `${formatNumber(details.credits, 1)} credits (${formatNumber(details.sections, 0)} sections)`
+                ));
             });
         } else {
-            const p = document.createElement('p');
-            p.style.marginTop = '15px';
-            p.style.color = '#6c757d';
-            p.textContent = 'No DESN 491 data available for this year.';
-            details491.appendChild(p);
+            const empty = document.createElement('p');
+            empty.style.marginTop = '15px';
+            empty.style.color = '#6c757d';
+            empty.textContent = `No ${course.code} data available for this year.`;
+            content.appendChild(empty);
         }
+
+        card.appendChild(content);
+        container.appendChild(card);
+    });
+}
+
+function createMetric(label, value) {
+    const div = document.createElement('div');
+    div.className = 'card-metric';
+
+    const labelSpan = document.createElement('span');
+    labelSpan.className = 'card-metric-label';
+    labelSpan.textContent = label;
+    div.appendChild(labelSpan);
+
+    const valueSpan = document.createElement('span');
+    valueSpan.className = 'card-metric-value';
+    valueSpan.textContent = value;
+    div.appendChild(valueSpan);
+
+    return div;
+}
+
+function refreshDashboard() {
+    renderSummaryCards();
+    renderCumulativeTrendChart();
+    renderInstructorSummaryChart();
+    renderAnnualBreakdownTable();
+    renderCurrentYearDetails();
+}
+
+async function initializeDepartmentProfileContext() {
+    const manager = window.DepartmentProfileManager;
+    if (!manager || typeof manager.initialize !== 'function') return;
+
+    const snapshot = await manager.initialize();
+    activeDepartmentProfile = snapshot && snapshot.profile ? snapshot.profile : null;
+}
+
+async function initDashboard() {
+    try {
+        await initializeDepartmentProfileContext();
+        workloadData = await loadWorkloadData('../');
+
+        if (!workloadData) {
+            showError('Failed to load applied learning data.');
+            return;
+        }
+
+        applyDepartmentProfileCopy();
+        populateYearFilter();
+        document.getElementById('academicYearFilter')?.addEventListener('change', onYearChange);
+        onYearChange({ target: { value: currentYear } });
+        hideLoadingShowContent();
+    } catch (error) {
+        console.error('Failed to initialize applied learning dashboard:', error);
+        showError(error?.message || 'Could not initialize applied learning dashboard.');
     }
 }
 
-// Initialize on page load
 window.addEventListener('load', initDashboard);


### PR DESCRIPTION
## Unit 10 rescue group G3

Port of develop's `d9d96e0` ("feat: make applied learning dashboard profile-aware", refs #98).

## What it does

- Courses, multipliers, year list, aggregation, and identity all sourced from the active profile via `WorkloadIntegration` (`getAppliedLearningCourses`, `getAcademicYearOptions`, `buildIntegratedWorkloadYearData`) — no hardcoded DESN 499/495/491 anywhere
- Summary cards, table headers, current-year cards, and charts render dynamically for any N applied-learning courses (rotating palette)
- Year dropdown built at runtime with July-boundary current-AY default; hardcoded 2022–2026 option list removed
- Page loads `department-profile.js` + `workload-integration.js`

## Adaptations (per the inventory artifact)

1. **Back-link**: main's `../program-command.html` survived the merge (develop still pointed at the old entry point) ✔
2. **Auth block restored**: the develop commit deleted main's supabase-js / supabase-config / auth-service / auth-guard script tags — the cherry-pick carried that deletion, so the block was manually restored. No page loses Phase 0/1 auth (inventory invariant).

All `WorkloadIntegration` / `DepartmentProfileManager` APIs the new JS calls verified present on main. Suite green: 154/154.

Ref: docs/phase2-unit10-inventory.html (G3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)