### PR TITLE
feat: add Supabase keep-alive workflow

### DIFF
--- a/.github/workflows/keep-supabase-awake.yml
+++ b/.github/workflows/keep-supabase-awake.yml
@@ -1,0 +1,48 @@
+name: Keep Supabase Awake
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  ping-database:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+
+    steps:
+      - name: Query Supabase database
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
+        run: |
+          set -euo pipefail
+          : "${SUPABASE_URL:?SUPABASE_URL secret is not configured}"
+          : "${SUPABASE_PUBLISHABLE_KEY:?SUPABASE_PUBLISHABLE_KEY secret is not configured}"
+
+          http_status="$(
+            curl --fail-with-body --silent \
+              --proto '=https' \
+              --connect-timeout 10 \
+              --max-time 60 \
+              --request POST \
+              --url "$SUPABASE_URL/rest/v1/rpc/keep_alive" \
+              --header "apikey: $SUPABASE_PUBLISHABLE_KEY" \
+              --header "Content-Type: application/json" \
+              --data '{}' \
+              --output /dev/null \
+              --write-out '%{http_code}'
+          )" || {
+            curl_exit=$?
+            echo "::error::Supabase keep-alive RPC failed (curl exit $curl_exit, HTTP ${http_status:-000})."
+            exit "$curl_exit"
+          }
+
+          if [[ ! "$http_status" =~ ^2[0-9]{2}$ ]]; then
+            echo "::error::Supabase keep-alive RPC returned HTTP ${http_status:-000}."
+            exit 1
+          fi
+
+          echo "Supabase keep-alive RPC succeeded (HTTP $http_status)."

--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ npm install
 npm run serve
 ```
 
+## 🩺 Supabase Keep-Alive
+
+The production Supabase project is on a free plan and may be paused after prolonged inactivity. `/.github/workflows/keep-supabase-awake.yml` makes a read-only database RPC request every six hours from GitHub Actions. This request does not deploy the application.
+
+Before enabling the workflow, run `scripts/supabase-keep-alive.sql` in the production project's Supabase SQL Editor. Then configure these **repository secrets** under **Settings → Secrets and variables → Actions**:
+
+- `SUPABASE_URL` — the production project URL.
+- `SUPABASE_PUBLISHABLE_KEY` — the production `sb_publishable_...` key.
+
+Use only the publishable key. Do **not** use a legacy `service_role` key or a new `sb_secret_...` key. The workflow sends the publishable key only in the `apikey` header; it does not replace the application's existing Supabase client configuration.
+
+To test it manually, open **Actions → Keep Supabase Awake → Run workflow**, select `main`, and run it. A successful run shows a green **Query Supabase database** step and the message `Supabase keep-alive RPC succeeded.` Missing secrets, timeouts, and non-successful HTTP responses fail the step without printing secret values.
+
+This best-effort request reduces the risk of Supabase inactivity pausing; it is not a formal uptime guarantee. GitHub may delay scheduled jobs, and [automatically disables scheduled workflows in public repositories after 60 days without repository activity](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/disable-and-enable-workflows), at which point this workflow must be re-enabled manually.
+
 ## 📊 Dashboards
 
 ### Public Schedule

--- a/scripts/supabase-keep-alive.sql
+++ b/scripts/supabase-keep-alive.sql
@@ -1,0 +1,19 @@
+-- Read-only RPC used by the external GitHub Actions keep-alive request.
+-- Idempotent: safe to run multiple times in the Supabase SQL Editor.
+
+begin;
+
+create or replace function public.keep_alive()
+returns timestamptz
+language sql
+stable
+security invoker
+set search_path = ''
+as $$
+  select now();
+$$;
+
+revoke all on function public.keep_alive() from public;
+grant execute on function public.keep_alive() to anon;
+
+commit;


### PR DESCRIPTION
## Summary

The production Supabase project can now receive an external, read-only database request every six hours, with a manual GitHub Actions trigger for immediate verification. The request uses an `sb_publishable_...` key in the `apikey` header and invokes a zero-argument, invoker-security RPC; the existing application configuration and deployment path are unchanged.

Failures are bounded and secret-safe: missing configuration, insecure URLs, redirects, timeouts, and non-2xx responses fail the job without logging the project URL or key. This is a best-effort inactivity signal, not an uptime guarantee.

## Validation

- `actionlint` and Ruby YAML parsing passed.
- The embedded shell passed `bash -n`.
- Mocked HTTP 204 succeeded; HTTP 302 and 401 failed with status-only diagnostics.
- An insecure `http://` URL was rejected.
- The SQL parsed as five PostgreSQL statements with `pglast`.
- The staged diff passed whitespace and credential/project-URL scans.
- Existing tests passed: 38 Jest suites / 154 tests; onboarding: 5 suites / 15 tests.
- A live GitHub Actions → production Supabase run remains intentionally pending until the workflow is merged.

## Required maintainer steps

1. Review these protected workflow and SQL changes and apply the human-only `allow-forbidden-paths` label; the required guard is expected to fail until then.
2. Confirm `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY` are repository secrets on **sicxz/program-command** and both belong to the intended production project. Never use a service-role or `sb_secret_...` key.
3. Confirm `scripts/supabase-keep-alive.sql` has been applied to that same project. The operator reported completing the SQL step, but this PR does not independently mutate or inspect production.

## Post-deploy monitoring

Immediately after merge, a maintainer should run **Actions → Keep Supabase Awake → Run workflow** on `main`. Success is a green **Query Supabase database** step with `Supabase keep-alive RPC succeeded (HTTP 2xx).` Then confirm the next scheduled run appears within six hours.

Missing-secret errors, HTTP 3xx/4xx/5xx responses, curl timeouts, or a disabled schedule are failure signals. Correct the repository secrets or RPC installation and re-run manually; re-enable the workflow if GitHub disables schedules after prolonged repository inactivity.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)